### PR TITLE
fix(Dialog): prop `footerAppearance` typo and open/close animations improvement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20124,6 +20124,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/el-transition": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/el-transition/-/el-transition-0.0.7.tgz",
+      "integrity": "sha512-a23pEa7ahqLmBIEqtxi8CdL6CRLF52ZoAwawDFTD1IDkegrL4iValQAj6IMEgIEXPSrXZtx/Nr/ej6ebov4uoA=="
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.628",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.628.tgz",
@@ -41883,7 +41888,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/core": "^1.5.3",
-        "@floating-ui/dom": "^1.5.4"
+        "@floating-ui/dom": "^1.5.4",
+        "el-transition": "^0.0.7"
       }
     },
     "packages/beeq-angular": {

--- a/packages/beeq/package.json
+++ b/packages/beeq/package.json
@@ -16,7 +16,8 @@
   ],
   "dependencies": {
     "@floating-ui/core": "^1.5.3",
-    "@floating-ui/dom": "^1.5.4"
+    "@floating-ui/dom": "^1.5.4",
+    "el-transition": "^0.0.7"
   },
   "browserslist": [
     "> 1%",

--- a/packages/beeq/src/components.d.ts
+++ b/packages/beeq/src/components.d.ts
@@ -311,7 +311,7 @@ export namespace Components {
         /**
           * The appearance of footer
          */
-        "footerApperance": TDialogFooterAppearance;
+        "footerAppearance": TDialogFooterAppearance;
         /**
           * Closes the dialog
          */
@@ -2214,7 +2214,7 @@ declare namespace LocalJSX {
         /**
           * The appearance of footer
          */
-        "footerApperance"?: TDialogFooterAppearance;
+        "footerAppearance"?: TDialogFooterAppearance;
         /**
           * If true, it hides the close button
          */

--- a/packages/beeq/src/components/dialog/bq-dialog.tsx
+++ b/packages/beeq/src/components/dialog/bq-dialog.tsx
@@ -1,4 +1,5 @@
 import { Component, Element, Event, EventEmitter, h, Listen, Method, Prop, State, Watch } from '@stencil/core';
+import { enter, leave } from 'el-transition';
 
 import { DIALOG_FOOTER_APPEARANCE, DIALOG_SIZE, TDialogFooterAppearance, TDialogSize } from './bq-dialog.types';
 import { hasSlotContent, validatePropValue } from '../../shared/utils';
@@ -72,15 +73,13 @@ export class BqDialog {
   }
 
   @Watch('open')
-  handleOpenChange() {
+  async handleOpenChange() {
     if (this.open) {
-      this.el.classList.add(this.OPEN_CSS_CLASS);
-      this.removeInertAttribute();
-      !this.disableBackdrop ? this.dialogElem.showModal() : this.dialogElem.show();
-    } else {
-      this.dialogElem.close();
-      this.setInertAttribute();
+      await this.handleOpen();
+      return;
     }
+
+    await this.handleClose();
   }
 
   // Events section
@@ -112,20 +111,13 @@ export class BqDialog {
 
   componentDidLoad() {
     this.handleOpenChange();
-    this.dialogElem.addEventListener('cancel', this.handleEscDown);
-    this.dialogElem.addEventListener('transitionend', this.handleTransitionEnd);
-  }
-
-  disconnectedCallback() {
-    this.dialogElem?.removeEventListener('cancel', this.handleEscDown);
-    this.dialogElem?.removeEventListener('transitionend', this.handleTransitionEnd);
   }
 
   // Listeners
   // ==============
 
   @Listen('mousedown', { target: 'window', capture: true })
-  handleMouseClick(event: MouseEvent) {
+  async handleMouseClick(event: MouseEvent) {
     if (!this.open) return;
     if (!this.dialogElem || this.disableCloseClickOutside) return;
     // Skip if the mouse button is not the main button
@@ -138,8 +130,15 @@ export class BqDialog {
       event.clientX < rect.left ||
       event.clientX > rect.right
     ) {
-      this.handleCancel();
+      await this.cancel();
     }
+  }
+
+  @Listen('keydown', { target: 'window', capture: true })
+  async handleKeyDown(event: KeyboardEvent) {
+    if (!this.open || !this.dialogElem || !(event.key === 'Escape' || event.key === 'Esc')) return;
+
+    await this.cancel();
   }
 
   // Public methods API
@@ -152,19 +151,32 @@ export class BqDialog {
   /** Open the dialog */
   @Method()
   async show() {
-    this.handleOpen();
+    if (!this.dialogElem) return;
+
+    const ev = this.bqOpen.emit();
+    if (ev.defaultPrevented) return;
+
+    this.open = true;
   }
 
   /** Closes the dialog */
   @Method()
   async hide() {
-    this.handleClose();
+    if (!this.dialogElem) return;
+
+    const ev = this.bqClose.emit();
+    if (ev.defaultPrevented) return;
+
+    this.open = false;
   }
 
   /** Dismiss or cancel the dialog */
   @Method()
   async cancel() {
-    this.handleCancel();
+    const ev = this.bqCancel.emit();
+    if (ev.defaultPrevented) return;
+
+    this.open = false;
   }
 
   // Local methods
@@ -182,28 +194,24 @@ export class BqDialog {
     this.dialogElem.removeAttribute('inert');
   }
 
-  private handleClose = () => {
-    if (!this.dialogElem) return;
-
-    const ev = this.bqClose.emit();
-    if (ev.defaultPrevented) return;
-    this.open = false;
+  private handleClose = async () => {
+    this.dialogElem.close();
+    await leave(this.dialogElem);
+    // Emit bqAfterClose event after the dialog is closed
+    this.handleTransitionEnd();
+    // Set the inert attribute to the dialog element
+    this.setInertAttribute();
   };
 
-  private handleOpen = () => {
-    if (!this.dialogElem) return;
-
-    const ev = this.bqOpen.emit();
-    if (ev.defaultPrevented) return;
-
-    this.open = true;
-  };
-
-  private handleCancel = () => {
-    const ev = this.bqCancel.emit();
-    if (ev.defaultPrevented) return;
-
-    this.open = false;
+  private handleOpen = async () => {
+    this.el.classList.add(this.OPEN_CSS_CLASS);
+    // Remove the inert attribute from the dialog element
+    this.removeInertAttribute();
+    // Show the dialog
+    this.disableBackdrop ? this.dialogElem.show() : this.dialogElem.showModal();
+    await enter(this.dialogElem);
+    // Emit bqAfterOpen event after the dialog is opened
+    this.handleTransitionEnd();
   };
 
   private handleTransitionEnd = () => {
@@ -214,15 +222,6 @@ export class BqDialog {
 
     this.bqAfterClose.emit();
     this.el.classList.remove(this.OPEN_CSS_CLASS);
-  };
-
-  private handleEscDown = (event: KeyboardEvent) => {
-    if (this.disableCloseEscKeydown) {
-      event.preventDefault();
-      return;
-    }
-
-    this.handleCancel();
   };
 
   private handleContentSlotChange = () => {
@@ -239,13 +238,24 @@ export class BqDialog {
 
   render() {
     return (
-      <dialog class={`bq-dialog ${this.size}`} ref={(dialogElem) => (this.dialogElem = dialogElem)} part="dialog">
+      <dialog
+        part="dialog"
+        inert={this.open ? undefined : true}
+        class={{ [`bq-dialog ${this.size}`]: true }}
+        ref={(dialogElem) => (this.dialogElem = dialogElem)}
+        data-transition-enter="transition ease-out duration-200"
+        data-transition-enter-start="transform opacity-0 scale-75"
+        data-transition-enter-end="transform opacity-100 scale-100"
+        data-transition-leave="transition ease-in duration-100"
+        data-transition-leave-start="transform opacity-100 scale-100"
+        data-transition-leave-end="transform opacity-0 scale-75"
+      >
         <main class="flex flex-col gap-[var(--bq-dialog--title-body-gap)] overflow-hidden" part="content">
           <header class="bq-dialog--header" part="header">
             <div class="bq-dialog--title flex flex-1 items-center justify-between" part="title">
               <slot name="title" />
             </div>
-            <div class="flex" onClick={this.handleCancel} part="button-close">
+            <div class="flex" onClick={() => this.hide()} role="button" part="button-close">
               <slot name="button-close">
                 {!this.hideCloseButton && (
                   <bq-button class="bq-dialog--close" appearance="text" size="small" slot="button-close">

--- a/packages/beeq/src/components/dialog/bq-dialog.tsx
+++ b/packages/beeq/src/components/dialog/bq-dialog.tsx
@@ -51,7 +51,7 @@ export class BqDialog {
   @Prop({ reflect: true }) disableCloseClickOutside = false;
 
   /** The appearance of footer */
-  @Prop({ reflect: true }) footerApperance: TDialogFooterAppearance = 'standard';
+  @Prop({ reflect: true }) footerAppearance: TDialogFooterAppearance = 'standard';
 
   /** If true, it hides the close button */
   @Prop({ reflect: true }) hideCloseButton = false;
@@ -64,11 +64,11 @@ export class BqDialog {
 
   // Prop lifecycle events
   // =======================
-  @Watch('footerApperance')
+  @Watch('footerAppearance')
   @Watch('size')
   checkPropValues() {
     validatePropValue(DIALOG_SIZE, 'large', this.el, 'size');
-    validatePropValue(DIALOG_FOOTER_APPEARANCE, 'standard', this.el, 'footerApperance');
+    validatePropValue(DIALOG_FOOTER_APPEARANCE, 'standard', this.el, 'footerAppearance');
   }
 
   @Watch('open')
@@ -271,7 +271,7 @@ export class BqDialog {
           class={{
             '!hidden': !this.hasFooter,
             'bq-dialog--footer': this.hasFooter,
-            'bg-ui-primary-alt !py-s': this.footerApperance === 'highlight',
+            'bg-ui-primary-alt !py-s': this.footerAppearance === 'highlight',
           }}
           ref={(footerElem) => (this.footerElem = footerElem)}
           part="footer"

--- a/packages/beeq/src/components/dialog/bq-dialog.tsx
+++ b/packages/beeq/src/components/dialog/bq-dialog.tsx
@@ -151,8 +151,6 @@ export class BqDialog {
   /** Open the dialog */
   @Method()
   async show() {
-    if (!this.dialogElem) return;
-
     const ev = this.bqOpen.emit();
     if (ev.defaultPrevented) return;
 
@@ -162,8 +160,6 @@ export class BqDialog {
   /** Closes the dialog */
   @Method()
   async hide() {
-    if (!this.dialogElem) return;
-
     const ev = this.bqClose.emit();
     if (ev.defaultPrevented) return;
 
@@ -195,6 +191,8 @@ export class BqDialog {
   }
 
   private handleClose = async () => {
+    if (!this.dialogElem) return;
+
     this.dialogElem.close();
     await leave(this.dialogElem);
     // Emit bqAfterClose event after the dialog is closed
@@ -204,6 +202,8 @@ export class BqDialog {
   };
 
   private handleOpen = async () => {
+    if (!this.dialogElem) return;
+
     this.el.classList.add(this.OPEN_CSS_CLASS);
     // Remove the inert attribute from the dialog element
     this.removeInertAttribute();

--- a/packages/beeq/src/components/dialog/readme.md
+++ b/packages/beeq/src/components/dialog/readme.md
@@ -12,7 +12,7 @@
 | `disableBackdrop`          | `disable-backdrop`            | If true, the backdrop overlay won't be shown when the dialog opens       | `boolean`                        | `false`      |
 | `disableCloseClickOutside` | `disable-close-click-outside` | If true, the dialog will not close when clicking on the backdrop overlay | `boolean`                        | `false`      |
 | `disableCloseEscKeydown`   | `disable-close-esc-keydown`   | If true, the dialog will not close when the [Esc] key is press           | `boolean`                        | `false`      |
-| `footerApperance`          | `footer-apperance`            | The appearance of footer                                                 | `"highlight" \| "standard"`      | `'standard'` |
+| `footerAppearance`         | `footer-appearance`           | The appearance of footer                                                 | `"highlight" \| "standard"`      | `'standard'` |
 | `hideCloseButton`          | `hide-close-button`           | If true, it hides the close button                                       | `boolean`                        | `false`      |
 | `open`                     | `open`                        | If true, the dialog will be shown as open                                | `boolean`                        | `false`      |
 | `size`                     | `size`                        | The size of the dialog                                                   | `"large" \| "medium" \| "small"` | `'medium'`   |

--- a/packages/beeq/src/components/dialog/scss/bq-dialog.scss
+++ b/packages/beeq/src/components/dialog/scss/bq-dialog.scss
@@ -18,7 +18,6 @@
   @apply absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 transform flex-col gap-[var(--bq-dialog--content-footer-gap)] p-0;
   @apply bg-[--bq-dialog--background] text-[--bq-dialog--text-color] shadow-[shadow:--bq-dialog--box-shadow];
   @apply rounded-[var(--bq-dialog--border-radius)] border-[length:--bq-dialog--border-width] border-[color:--bq-dialog--border-color];
-  @apply opacity-0 transition-opacity duration-300 ease-in-out;
   // If mobile resolution, dialog will be full width
   @apply w-[90vw];
 
@@ -35,10 +34,6 @@
   &.large {
     @apply sm:w-[--bq-dialog--width-large];
   }
-}
-
-.bq-dialog[open] {
-  @apply opacity-100;
 }
 
 /* ----------------------------- Dialog backdrop ---------------------------- */

--- a/packages/beeq/src/shared/utils/props.ts
+++ b/packages/beeq/src/shared/utils/props.ts
@@ -23,8 +23,8 @@ export const validatePropValue = <T extends E[keyof E], E extends Element>(
   element[propertyName as string] = fallbackValue;
   // Notify developer in the browser console
   console.warn(
-    `[${element.tagName.toUpperCase()}] Please notice that "${propertyName}" should be one of ${ACCEPTED_VALUES.join(
-      '|',
-    )}`,
+    `[${element.tagName.toUpperCase()}] Please notice that "${String(
+      propertyName,
+    )}" should be one of ${ACCEPTED_VALUES.join('|')}`,
   );
 };


### PR DESCRIPTION
This PR fixes a typo in the `footerAppearance` property name and improves the enter/leave animations when the dialog gets open/closed.


https://github.com/Endava/BEEQ/assets/328492/e9007b2b-3f16-463c-8df0-8c19c148b65c

