### PR TITLE
feat(Select): add `clear()` method to remove selected value programmatically

### DIFF
--- a/packages/beeq/src/components.d.ts
+++ b/packages/beeq/src/components.d.ts
@@ -699,6 +699,12 @@ export namespace Components {
          */
         "autofocus": boolean;
         /**
+          * Clears the selected value.
+          * @return 
+          * @memberof BqSelect
+         */
+        "clear": () => Promise<void>;
+        /**
           * The clear button aria label
          */
         "clearButtonLabel"?: string;

--- a/packages/beeq/src/components/select/_storybook/bq-select.stories.tsx
+++ b/packages/beeq/src/components/select/_storybook/bq-select.stories.tsx
@@ -55,12 +55,12 @@ const meta: Meta = {
     bqFocus: { action: 'bqFocus' },
     bqSelect: { action: 'bqSelect' },
     // Not part of the public API, so we don't want to expose it in the docs
-    noLabel: { control: 'bolean', table: { disable: true } },
-    hasLabelTooltip: { control: 'bolean', table: { disable: true } },
-    noHelperText: { control: 'bolean', table: { disable: true } },
-    optionalLabel: { control: 'bolean', table: { disable: true } },
-    prefix: { control: 'bolean', table: { disable: true } },
-    suffix: { control: 'bolean', table: { disable: true } },
+    noLabel: { control: 'boolean', table: { disable: true } },
+    hasLabelTooltip: { control: 'boolean', table: { disable: true } },
+    noHelperText: { control: 'boolean', table: { disable: true } },
+    optionalLabel: { control: 'boolean', table: { disable: true } },
+    prefix: { control: 'boolean', table: { disable: true } },
+    suffix: { control: 'boolean', table: { disable: true } },
     options: { control: 'text', table: { disable: true } },
   },
   args: {

--- a/packages/beeq/src/components/select/bq-select.tsx
+++ b/packages/beeq/src/components/select/bq-select.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, h, Listen, Prop, State, Watch } from '@stencil/core';
+import { Component, Element, Event, EventEmitter, h, Listen, Method, Prop, State, Watch } from '@stencil/core';
 
 import { FloatingUIPlacement } from '../../services/interfaces';
 import { getTextContent, hasSlotContent, isDefined, isHTMLElement } from '../../shared/utils';
@@ -188,6 +188,22 @@ export class BqSelect {
   // Requires JSDocs for public API documentation.
   // ===============================================
 
+  /**
+   * Clears the selected value.
+   *
+   * @return {Promise<void>}
+   * @memberof BqSelect
+   */
+  @Method()
+  async clear(): Promise<void> {
+    if (this.disabled) return;
+
+    this.value = undefined;
+    this.displayValue = undefined;
+
+    this.bqClear.emit(this.el);
+  }
+
   // Local methods
   // Internal business logic.
   // These methods cannot be called from the host element.
@@ -213,12 +229,9 @@ export class BqSelect {
   };
 
   private handleClearClick = (ev: CustomEvent) => {
-    if (this.disabled) return;
-
-    this.value = '';
-    this.displayValue = '';
-
-    this.bqClear.emit(this.el);
+    (async () => {
+      await this.clear();
+    })();
     this.inputElem.focus();
 
     ev.stopPropagation();

--- a/packages/beeq/src/components/select/readme.md
+++ b/packages/beeq/src/components/select/readme.md
@@ -40,6 +40,19 @@
 | `bqSelect` | Callback handler emitted when the selected value has changed      | `CustomEvent<{ value: string \| number \| string[]; item: HTMLBqOptionElement; }>` |
 
 
+## Methods
+
+### `clear() => Promise<void>`
+
+Clears the selected value.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+
 ## Shadow Parts
 
 | Part            | Description                                                     |


### PR DESCRIPTION
This will allow users to clear the selection programmatically. E.g:

```html
<bq-select name="options" placeholder="Placeholder" value="2">
  <bq-option value="1" class="hydrated">Option 1</bq-option>
  <bq-option value="2" class="hydrated">Option 2</bq-option>
  <bq-option value="3" class="hydrated">Option 3</bq-option>
  <bq-option value="4" class="hydrated">Option 4</bq-option>
  <bq-option value="5" class="hydrated">Option 5</bq-option>
</bq-select>

```

```ts
const bqSelectElem = document.querySelector('bq-select[name="options"]');
...
await bqSelectElem.clear();
```