### PR TITLE
fix(Accordion): fix cursor styling in accordion for disabled state

### DIFF
--- a/packages/beeq/src/components/accordion/scss/bq-accordion.scss
+++ b/packages/beeq/src/components/accordion/scss/bq-accordion.scss
@@ -10,7 +10,11 @@
 
 .bq-accordion {
   &.disabled {
-    @apply pointer-events-none cursor-not-allowed opacity-60;
+    @apply cursor-not-allowed opacity-60;
+
+    .bq-accordion__header {
+      @apply pointer-events-none;
+    }
   }
 
   &.small .bq-accordion__header {


### PR DESCRIPTION
The purpose of this PR is to correct the cursor style for the off state of the accordion. The pointer-events: none rule has been moved down one level to avoid overriding this cursor: not-allowed. 

![Screenshot 2024-02-26 at 11 47 45](https://github.com/Endava/BEEQ/assets/98550729/cb6d191b-b3da-48b7-9038-c6dabd6b4be1)
