### PR TITLE
fix(Dropdown): disable the trigger element if the dropdown have `disable="true"`

### DIFF
--- a/packages/beeq/src/components/dropdown/bq-dropdown.tsx
+++ b/packages/beeq/src/components/dropdown/bq-dropdown.tsx
@@ -69,6 +69,14 @@ export class BqDropdown {
     this.bqOpen.emit({ open: this.open });
   }
 
+  @Watch('disabled')
+  handleDisabledChange(newValue: boolean) {
+    const bqButton = document.querySelector('bq-button');
+    if (!bqButton) return;
+
+    bqButton.disabled = newValue;
+  }
+
   // Events section
   // Requires JSDocs for public API documentation
   // ==============================================
@@ -82,6 +90,7 @@ export class BqDropdown {
 
   componentDidLoad() {
     this.triggerElem = this.el.querySelector('[slot="trigger"]');
+    this.handleDisabledChange(this.disabled);
   }
 
   // Listeners

--- a/packages/beeq/src/components/dropdown/bq-dropdown.tsx
+++ b/packages/beeq/src/components/dropdown/bq-dropdown.tsx
@@ -70,11 +70,11 @@ export class BqDropdown {
   }
 
   @Watch('disabled')
-  handleDisabledChange(newValue: boolean) {
-    const bqButton = document.querySelector('bq-button');
-    if (!bqButton) return;
+  handleDisabledChange() {
+    if (!this.triggerElem) return;
 
-    bqButton.disabled = newValue;
+    // set 'disabled' attribute based on 'this.disabled' value, ensuring consistent state handling
+    this.disabled ? this.triggerElem?.setAttribute('disabled', 'true') : this.triggerElem?.removeAttribute('disabled');
   }
 
   // Events section
@@ -90,7 +90,7 @@ export class BqDropdown {
 
   componentDidLoad() {
     this.triggerElem = this.el.querySelector('[slot="trigger"]');
-    this.handleDisabledChange(this.disabled);
+    this.handleDisabledChange();
   }
 
   // Listeners


### PR DESCRIPTION
The purpose of this PR is to address the issue related to the disabled state management in the dropdown component. Previously, the disabled state of the dropdown was not properly synchronized with the associated button's disabled state. This PR fixes that issue by implementing a mechanism to correctly update the button's disabled state based on the dropdown's disabled property. As a result, the dropdown component now ensures consistent behavior when managing its disabled state, enhancing overall accessibility and user experience.

Before|After
-|-
![Screenshot 2024-02-26 at 14 03 47](https://github.com/Endava/BEEQ/assets/98550729/ef816ec6-0b7a-4328-908f-4a2a126da402)|![Screenshot 2024-02-26 at 14 04 29](https://github.com/Endava/BEEQ/assets/98550729/a1a72cff-4e82-4653-a3f5-b6becf9168ad)


