### PR TITLE
perf(CSS):  remove the massive wall of empty CSS properties added by Tailwind CSS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,12 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+* @dgonzalezr @endv-bogdanb @Cata1989
+
 # Any change related to the .github workflows
 # will require approval from @dgonzalezr.
-.github/ @dgonzalezr
+.github/ @dgonzalezr @endv-bogdanb
 
 # Any change related to the NPM dependencies
 # will require approval from @dgonzalezr @endv-bogdanb.
@@ -10,4 +16,4 @@ package-lock.json @dgonzalezr @endv-bogdanb
 
 # Any change inside the `/packages` directory
 # will require approval from @dgonzalezr @endv-bogdanb.
-/packages @dgonzalezr @endv-bogdanb
+/packages @dgonzalezr @endv-bogdanb @Cata1989

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,7 +13,33 @@ export default {
       textColor: ['active', 'disabled'],
     },
   },
+  variantOrder: [
+    'first',
+    'last',
+    'odd',
+    'even',
+    'visited',
+    'checked',
+    'empty',
+    'read-only',
+    'group-hover',
+    'group-focus',
+    'focus-within',
+    'hover',
+    'focus',
+    'focus-visible',
+    'active',
+    'disabled'
+  ],
   corePlugins: {
     preflight: false,
+    // Disables usage of rgb/opacity
+    textOpacity: false,
+    backgroundOpacity: false,
+    borderOpacity: false
+  },
+  experimental: {
+    // Prevents Tailwind from generating that wall of empty custom properties
+    optimizeUniversalDefaults: true,
   },
 } satisfies Config;


### PR DESCRIPTION
## Description

The default Tailwind CSS behavior adds a lot of useless empty custom CSS properties.

![CleanShot 2024-03-06 at 13 27 25](https://github.com/Endava/BEEQ/assets/328492/e184c26f-b21e-4ac4-beff-d0462f833ea3)

with these changes, we avoid Tailwind bloating the CSS with all these custom CSS properties.

![CleanShot 2024-03-06 at 13 28 02](https://github.com/Endava/BEEQ/assets/328492/7f94248c-e66f-4a4b-9f6b-17e67f428ca0).

Here we're also disabling the usage of rgb/opacity, which also removes a massive block of empty Custom Properties that Tailwind generates.

## Related Issue

 N/A

## Documentation

https://piccalil.li/blog/a-css-project-boilerplate/
https://v2.tailwindcss.com/docs/configuration#variant-order

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.
