### PR TITLE
fix(Dialog): wrong position on entry/leave transition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beeq",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beeq",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -21540,11 +21540,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/el-transition": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/el-transition/-/el-transition-0.0.7.tgz",
-      "integrity": "sha512-a23pEa7ahqLmBIEqtxi8CdL6CRLF52ZoAwawDFTD1IDkegrL4iValQAj6IMEgIEXPSrXZtx/Nr/ej6ebov4uoA=="
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.699",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.699.tgz",
@@ -42834,17 +42829,16 @@
     },
     "packages/beeq": {
       "name": "@beeq/core",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/core": "^1.6.0",
-        "@floating-ui/dom": "^1.6.3",
-        "el-transition": "^0.0.7"
+        "@floating-ui/dom": "^1.6.3"
       }
     },
     "packages/beeq-angular": {
       "name": "@beeq/angular",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@beeq/core": "^1.0.1",
@@ -42857,7 +42851,7 @@
     },
     "packages/beeq-react": {
       "name": "@beeq/react",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@beeq/core": "^1.0.1"
@@ -42870,7 +42864,7 @@
     },
     "packages/beeq-tailwindcss": {
       "name": "@beeq/tailwindcss",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "tailwindcss": "^3.4.1",
@@ -42879,7 +42873,7 @@
     },
     "packages/beeq-vue": {
       "name": "@beeq/vue",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@beeq/core": "^1.0.1",

--- a/packages/beeq/package.json
+++ b/packages/beeq/package.json
@@ -16,8 +16,7 @@
   ],
   "dependencies": {
     "@floating-ui/core": "^1.6.0",
-    "@floating-ui/dom": "^1.6.3",
-    "el-transition": "^0.0.7"
+    "@floating-ui/dom": "^1.6.3"
   },
   "repository": {
     "type": "git",

--- a/packages/beeq/src/components/alert/bq-alert.tsx
+++ b/packages/beeq/src/components/alert/bq-alert.tsx
@@ -1,8 +1,7 @@
 import { Component, Element, Event, EventEmitter, h, Host, Method, Prop, State, Watch } from '@stencil/core';
-import { enter, leave } from 'el-transition';
 
 import { ALERT_TYPE, TAlertBorderRadius, TAlertType } from './bq-alert.types';
-import { debounce, hasSlotContent, TDebounce, validatePropValue } from '../../shared/utils';
+import { debounce, enter, hasSlotContent, leave, TDebounce, validatePropValue } from '../../shared/utils';
 
 /**
  * @part base - The `<div>` container of the predefined bq-icon component

--- a/packages/beeq/src/components/dialog/bq-dialog.tsx
+++ b/packages/beeq/src/components/dialog/bq-dialog.tsx
@@ -1,5 +1,4 @@
 import { Component, Element, Event, EventEmitter, h, Listen, Method, Prop, State, Watch } from '@stencil/core';
-import { enter, leave } from 'el-transition';
 
 import {
   DIALOG_FOOTER_APPEARANCE,
@@ -8,7 +7,7 @@ import {
   TDialogFooterAppearance,
   TDialogSize,
 } from './bq-dialog.types';
-import { hasSlotContent, validatePropValue } from '../../shared/utils';
+import { enter, hasSlotContent, leave, validatePropValue } from '../../shared/utils';
 
 /**
  * @part body - The `<main>` that holds the dialog body content
@@ -189,16 +188,6 @@ export class BqDialog {
   // These methods cannot be called from the host element.
   // =======================================================
 
-  private setInertAttribute() {
-    if (!this.dialogElem) return;
-    this.dialogElem.setAttribute('inert', 'true');
-  }
-
-  private removeInertAttribute() {
-    if (!this.dialogElem) return;
-    this.dialogElem.removeAttribute('inert');
-  }
-
   private handleClose = async () => {
     if (!this.dialogElem) return;
 
@@ -206,16 +195,12 @@ export class BqDialog {
     await leave(this.dialogElem);
     // Emit bqAfterClose event after the dialog is closed
     this.handleTransitionEnd();
-    // Set the inert attribute to the dialog element
-    this.setInertAttribute();
   };
 
   private handleOpen = async () => {
     if (!this.dialogElem) return;
 
     this.el.classList.add(this.OPEN_CSS_CLASS);
-    // Remove the inert attribute from the dialog element
-    this.removeInertAttribute();
     // Show the dialog
     this.disableBackdrop ? this.dialogElem.show() : this.dialogElem.showModal();
     await enter(this.dialogElem);
@@ -253,13 +238,13 @@ export class BqDialog {
     return (
       <dialog
         style={style}
-        class={{ [`bq-dialog ${this.size}`]: true }}
-        data-transition-enter="transition ease-out duration-200"
-        data-transition-enter-start="transform opacity-0 scale-75"
-        data-transition-enter-end="transform opacity-100 scale-100"
-        data-transition-leave="transition ease-in duration-100"
-        data-transition-leave-start="transform opacity-100 scale-100"
-        data-transition-leave-end="transform opacity-0 scale-75"
+        class={`bq-dialog hidden  ${this.size}`}
+        data-transition-enter="transition ease-in duration-300"
+        data-transition-enter-start="opacity-0 scale-75"
+        data-transition-enter-end="opacity-100 scale-100"
+        data-transition-leave="transition ease-out duration-300"
+        data-transition-leave-start="opacity-100 scale-100"
+        data-transition-leave-end="opacity-0 scale-75"
         inert={this.open ? undefined : true}
         ref={(dialogElem) => (this.dialogElem = dialogElem)}
         part="dialog"

--- a/packages/beeq/src/components/dialog/bq-dialog.tsx
+++ b/packages/beeq/src/components/dialog/bq-dialog.tsx
@@ -238,7 +238,7 @@ export class BqDialog {
     return (
       <dialog
         style={style}
-        class={`bq-dialog hidden  ${this.size}`}
+        class={`bq-dialog hidden ${this.size}`}
         data-transition-enter="transition ease-in duration-300"
         data-transition-enter-start="opacity-0 scale-75"
         data-transition-enter-end="opacity-100 scale-100"

--- a/packages/beeq/src/components/dialog/scss/bq-dialog.scss
+++ b/packages/beeq/src/components/dialog/scss/bq-dialog.scss
@@ -15,9 +15,13 @@
 /* --------------------------------- Dialog --------------------------------- */
 
 .bq-dialog {
-  @apply absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 transform flex-col gap-[var(--bq-dialog--content-footer-gap)] p-0;
+  @apply absolute left-1/2 top-1/2 flex;
+  @apply flex-col gap-[var(--bq-dialog--content-footer-gap)] p-0;
   @apply bg-[--bq-dialog--background] text-[--bq-dialog--text-color] shadow-[shadow:--bq-dialog--box-shadow];
   @apply rounded-[var(--bq-dialog--border-radius)] border-[length:--bq-dialog--border-width] border-[color:--bq-dialog--border-color];
+  // After setting `optimizeUniversalDefaults` to `true` in `tailwind.config.js`,
+  // `!important` is required to avoid default --tw-* variables to override custom transform values
+  @apply -translate-x-1/2 -translate-y-1/2 #{!important};
   // If mobile resolution, dialog will be full width
   @apply w-[90vw];
 

--- a/packages/beeq/src/components/notification/bq-notification.tsx
+++ b/packages/beeq/src/components/notification/bq-notification.tsx
@@ -1,8 +1,7 @@
 import { Component, Element, Event, EventEmitter, h, Host, Listen, Method, Prop, State, Watch } from '@stencil/core';
-import { enter, leave } from 'el-transition';
 
 import { NOTIFICATION_TYPE, TNotificationBorderRadius, TNotificationType } from './bq-notification.types';
-import { debounce, hasSlotContent, TDebounce, validatePropValue } from '../../shared/utils';
+import { debounce, enter, hasSlotContent, leave, TDebounce, validatePropValue } from '../../shared/utils';
 
 const notificationPortal = Object.assign(document.createElement('div'), { className: 'bq-notification-portal' });
 

--- a/packages/beeq/src/components/notification/scss/bq-notification.scss
+++ b/packages/beeq/src/components/notification/scss/bq-notification.scss
@@ -13,12 +13,12 @@
 }
 
 .bq-notification {
-  @apply relative flex  min-w-[var(--bq-notification--min-width)] p-[var(--bq-notification--padding)] transition-all;
+  @apply relative flex min-w-[var(--bq-notification--min-width)] p-[var(--bq-notification--padding)] transition-all;
   @apply rounded-[var(--bq-notification--border-radius)] bg-[var(--bq-notification--background)] shadow-[shadow:var(--bq-notification--box-shadow)];
 }
 
 /**
- * Set the nocitication icon color based on the type value selected
+ * Set the notification icon color based on the type value selected
  */
 .notification--icon.color {
   &-error {
@@ -43,7 +43,7 @@
 }
 
 /**
- * Tweak the close bq-buton styles so it remain small wihout extra padding
+ * Tweak the close bq-button styles so it remain small without extra padding
  */
 .notification--close::part(button) {
   @apply h-fit rounded-s border-0 p-0;

--- a/packages/beeq/src/shared/utils/index.ts
+++ b/packages/beeq/src/shared/utils/index.ts
@@ -10,3 +10,4 @@ export * from './isString';
 export * from './props';
 export * from './setRafTimeout';
 export * from './slot';
+export * from './transition';

--- a/packages/beeq/src/shared/utils/transition.ts
+++ b/packages/beeq/src/shared/utils/transition.ts
@@ -1,0 +1,61 @@
+interface HTMLElementWithAnimations extends HTMLElement {
+  getAnimations(): Animation[];
+}
+
+export const enter = async (element: HTMLElement, transitionName: string | null = null): Promise<void> => {
+  element.classList.remove('hidden');
+  await transition('enter', element, transitionName);
+};
+
+export const leave = async (element: HTMLElement, transitionName: string | null = null): Promise<void> => {
+  await transition('leave', element, transitionName);
+  element.classList.add('hidden');
+};
+
+export const toggle = async (element: HTMLElement, transitionName: string | null = null): Promise<void> => {
+  if (element.classList.contains('hidden')) {
+    await enter(element, transitionName);
+  } else {
+    await leave(element, transitionName);
+  }
+};
+
+async function transition(direction: string, element: HTMLElement, animation: string | null): Promise<void> {
+  const dataset = element.dataset;
+  const animationClass = animation ? `${animation}-${direction}` : direction;
+  const transition = `transition${direction.charAt(0).toUpperCase() + direction.slice(1)}`;
+  const genesis = dataset[transition] ? dataset[transition].split(' ') : [animationClass];
+  const start = dataset[`${transition}Start`] ? dataset[`${transition}Start`].split(' ') : [`${animationClass}-start`];
+  const end = dataset[`${transition}End`] ? dataset[`${transition}End`].split(' ') : [`${animationClass}-end`];
+
+  addClasses(element, genesis);
+  addClasses(element, start);
+  await nextFrame();
+
+  removeClasses(element, start);
+  addClasses(element, end);
+  await afterTransition(element as HTMLElementWithAnimations);
+
+  removeClasses(element, end);
+  removeClasses(element, genesis);
+}
+
+function addClasses(element: HTMLElement, classes: string[]): void {
+  element.classList.add(...classes);
+}
+
+function removeClasses(element: HTMLElement, classes: string[]): void {
+  element.classList.remove(...classes);
+}
+
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => resolve());
+    });
+  });
+}
+
+function afterTransition(element: HTMLElementWithAnimations): Promise<Animation[]> {
+  return Promise.all(element.getAnimations().map((animation) => animation.finished));
+}

--- a/packages/beeq/src/shared/utils/transition.ts
+++ b/packages/beeq/src/shared/utils/transition.ts
@@ -1,17 +1,43 @@
+/* -------------------------------------------------------------------------- */
+/*            Credits to MikeMcCall for the original implementation           */
+/*            Github: https://github.com/mmccall10/el-transition              */
+/* -------------------------------------------------------------------------- */
+
 interface HTMLElementWithAnimations extends HTMLElement {
   getAnimations(): Animation[];
 }
 
+/**
+ * Transition an element entry
+ *
+ * @param element The element to enter
+ * @param transitionName The name of the transition
+ * @returns A promise that resolves when the transition is complete
+ */
 export const enter = async (element: HTMLElement, transitionName: string | null = null): Promise<void> => {
   element.classList.remove('hidden');
   await transition('enter', element, transitionName);
 };
 
+/**
+ * Transition an element exit
+ *
+ * @param element The element to leave
+ * @param transitionName The name of the transition
+ * @returns A promise that resolves when the transition is complete
+ */
 export const leave = async (element: HTMLElement, transitionName: string | null = null): Promise<void> => {
   await transition('leave', element, transitionName);
   element.classList.add('hidden');
 };
 
+/**
+ * Toggle an element entry/exit
+ *
+ * @param element The element to toggle
+ * @param transitionName The name of the transition
+ * @returns A promise that resolves when the transition is complete
+ */
 export const toggle = async (element: HTMLElement, transitionName: string | null = null): Promise<void> => {
   if (element.classList.contains('hidden')) {
     await enter(element, transitionName);
@@ -20,7 +46,16 @@ export const toggle = async (element: HTMLElement, transitionName: string | null
   }
 };
 
-async function transition(direction: string, element: HTMLElement, animation: string | null): Promise<void> {
+/**
+ * Perform a transition on an element
+ *
+ * @param direction The direction of the transition
+ * @param element The element to transition
+ * @param animation The animation to use
+ * @returns A promise that resolves when the transition is complete
+ * @internal
+ */
+const transition = async (direction: string, element: HTMLElement, animation: string | null): Promise<void> => {
   const dataset = element.dataset;
   const animationClass = animation ? `${animation}-${direction}` : direction;
   const transition = `transition${direction.charAt(0).toUpperCase() + direction.slice(1)}`;
@@ -38,24 +73,47 @@ async function transition(direction: string, element: HTMLElement, animation: st
 
   removeClasses(element, end);
   removeClasses(element, genesis);
-}
+};
 
-function addClasses(element: HTMLElement, classes: string[]): void {
+/**
+ * Add classes to an element
+ *
+ * @param element The element to add the CSS classes to
+ * @param classes The classes to add
+ */
+const addClasses = (element: HTMLElement, classes: string[]): void => {
   element.classList.add(...classes);
-}
+};
 
-function removeClasses(element: HTMLElement, classes: string[]): void {
+/**
+ * Remove classes from an element
+ *
+ * @param element The element to remove the CSS classes from
+ * @param classes The classes to remove
+ */
+const removeClasses = (element: HTMLElement, classes: string[]): void => {
   element.classList.remove(...classes);
-}
+};
 
-function nextFrame(): Promise<void> {
+/**
+ * Wait for the next frame
+ * @returns A promise that resolves when the next frame is available
+ * @internal
+ */
+const nextFrame = (): Promise<void> => {
   return new Promise((resolve) => {
     requestAnimationFrame(() => {
       requestAnimationFrame(() => resolve());
     });
   });
-}
+};
 
-function afterTransition(element: HTMLElementWithAnimations): Promise<Animation[]> {
+/**
+ * Wait for all animations to finish
+ * @param element The element to wait for
+ * @returns A promise that resolves when all animations are finished
+ * @internal
+ */
+const afterTransition = (element: HTMLElementWithAnimations): Promise<Animation[]> => {
   return Promise.all(element.getAnimations().map((animation) => animation.finished));
-}
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -29,14 +29,14 @@ export default {
     'focus',
     'focus-visible',
     'active',
-    'disabled'
+    'disabled',
   ],
   corePlugins: {
     preflight: false,
     // Disables usage of rgb/opacity
     textOpacity: false,
     backgroundOpacity: false,
-    borderOpacity: false
+    borderOpacity: false,
   },
   experimental: {
     // Prevents Tailwind from generating that wall of empty custom properties


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
After setting `optimizeUniversalDefaults` on the Tailwind config, some transform values get overriden. This affect the Dialog position when the component is entering or leaving while transitioning.

The bug can be reproduced also in Storybook: https://storybook.beeq.design/?path=/story/components-dialog--default

## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

N/A

## Documentation

I have extracted the code from the `el-transition` dependency package and moved to the project as: `packages/beeq/src/shared/utils/transition.ts`, added the types and JSDoc, that way we have complete control in case that we need to change something.

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

![CleanShot 2024-03-15 at 16 18 52@2x](https://github.com/Endava/BEEQ/assets/328492/6f305ff2-c304-415d-ac46-3903a2788b4a)

https://github.com/Endava/BEEQ/assets/328492/fe401a3e-ee36-4a95-ba20-664e02c4c038

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
