### PR TITLE
fix(Accordion): improve open/close animations and handle `bqAfterOpen` and `bqAfterClose` events

### DIFF
--- a/packages/beeq/src/components.d.ts
+++ b/packages/beeq/src/components.d.ts
@@ -1386,9 +1386,11 @@ export interface BqToastCustomEvent<T> extends CustomEvent<T> {
 }
 declare global {
     interface HTMLBqAccordionElementEventMap {
-        "bqClick": HTMLBqAccordionElement;
-        "bqFocus": HTMLBqAccordionElement;
         "bqBlur": HTMLBqAccordionElement;
+        "bqFocus": HTMLBqAccordionElement;
+        "bqOpen": HTMLBqAccordionElement;
+        "bqClose": HTMLBqAccordionElement;
+        "bqClick": HTMLBqAccordionElement;
     }
     interface HTMLBqAccordionElement extends Components.BqAccordion, HTMLStencilElement {
         addEventListener<K extends keyof HTMLBqAccordionElementEventMap>(type: K, listener: (this: HTMLBqAccordionElement, ev: BqAccordionCustomEvent<HTMLBqAccordionElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2044,14 +2046,19 @@ declare namespace LocalJSX {
           * Handler to be called when the accordion loses focus
          */
         "onBqBlur"?: (event: BqAccordionCustomEvent<HTMLBqAccordionElement>) => void;
-        /**
-          * Handler to be called when the accordion is clicked
-         */
         "onBqClick"?: (event: BqAccordionCustomEvent<HTMLBqAccordionElement>) => void;
+        /**
+          * Handler to be called when the accordion is closed
+         */
+        "onBqClose"?: (event: BqAccordionCustomEvent<HTMLBqAccordionElement>) => void;
         /**
           * Handler to be called when the accordion gets focus
          */
         "onBqFocus"?: (event: BqAccordionCustomEvent<HTMLBqAccordionElement>) => void;
+        /**
+          * Handler to be called when the accordion is opened
+         */
+        "onBqOpen"?: (event: BqAccordionCustomEvent<HTMLBqAccordionElement>) => void;
         /**
           * If true accordion expand icon is rotate 180deg when expanded
          */

--- a/packages/beeq/src/components.d.ts
+++ b/packages/beeq/src/components.d.ts
@@ -1389,7 +1389,9 @@ declare global {
         "bqBlur": HTMLBqAccordionElement;
         "bqFocus": HTMLBqAccordionElement;
         "bqOpen": HTMLBqAccordionElement;
+        "bqAfterOpen": HTMLBqAccordionElement;
         "bqClose": HTMLBqAccordionElement;
+        "bqAfterClose": HTMLBqAccordionElement;
         "bqClick": HTMLBqAccordionElement;
     }
     interface HTMLBqAccordionElement extends Components.BqAccordion, HTMLStencilElement {
@@ -2042,6 +2044,14 @@ declare namespace LocalJSX {
           * If true accordion is expanded
          */
         "expanded"?: boolean;
+        /**
+          * Handler to be called after the accordion is closed
+         */
+        "onBqAfterClose"?: (event: BqAccordionCustomEvent<HTMLBqAccordionElement>) => void;
+        /**
+          * Handler to be called after the accordion is opened
+         */
+        "onBqAfterOpen"?: (event: BqAccordionCustomEvent<HTMLBqAccordionElement>) => void;
         /**
           * Handler to be called when the accordion loses focus
          */

--- a/packages/beeq/src/components/accordion-group/bq-accordion-group.tsx
+++ b/packages/beeq/src/components/accordion-group/bq-accordion-group.tsx
@@ -1,6 +1,6 @@
 import { Component, Element, h, Listen, Prop, Watch } from '@stencil/core';
 
-import { isNil } from '../../shared/utils';
+import { isHTMLElement, isNil } from '../../shared/utils';
 import { TAccordionAppearance, TAccordionSize } from '../accordion/bq-accordion.types';
 
 /**
@@ -62,6 +62,9 @@ export class BqAccordionGroup {
 
   @Listen('bqClick', { passive: true })
   onBqClick(event: CustomEvent<HTMLBqAccordionElement>) {
+    const { detail: bqElem } = event;
+    // Make sure the event is coming from a bq-accordion element and its a child of the bq-accordion-group
+    if (!isHTMLElement(bqElem, 'bq-accordion') || !this.el.contains(bqElem)) return;
     // We keep default behavior if multiple accordion can be expanded
     if (this.multiple) return;
 

--- a/packages/beeq/src/components/accordion/__tests__/bq-accordion.e2e.ts
+++ b/packages/beeq/src/components/accordion/__tests__/bq-accordion.e2e.ts
@@ -68,25 +68,30 @@ describe('bq-accordion', () => {
     });
 
     const details = await page.find('bq-accordion >>> [part="base"]');
+    expect(details).toHaveAttribute('open');
 
-    expect(await details.getProperty('open')).toBe(true);
+    const header = await details.find('.bq-accordion__header');
+    expect(header).toHaveAttribute('aria-expanded');
   });
 
   it('should be collapsed when disabled', async () => {
     const page = await newE2EPage({
-      html: `<bq-accordion expanded disabled><span slot="header">${HEADER_TEXT}</span></bq-accordion>`,
+      html: `<bq-accordion expanded><span slot="header">${HEADER_TEXT}</span></bq-accordion>`,
     });
 
-    const details = await page.find('bq-accordion >>> [part="base"]');
+    const accordion = await page.find('bq-accordion');
+    accordion.setProperty('disabled', true);
+    await page.waitForChanges();
 
-    expect(await details.getProperty('open')).toBe(false);
+    const summary = await page.find('bq-accordion >>> [part="base"] summary');
+    expect(summary.getAttribute('aria-expanded')).toBeFalsy();
   });
 
   it('should respect design style', async () => {
     const page = await newE2EPage({
       html: `
-      <bq-accordion size="small"><span slot="header">${HEADER_TEXT}</span></bq-accordion>
-      <bq-accordion size="medium"><span slot="header">${HEADER_TEXT}</span></bq-accordion>
+        <bq-accordion size="small"><span slot="header">${HEADER_TEXT}</span></bq-accordion>
+        <bq-accordion size="medium"><span slot="header">${HEADER_TEXT}</span></bq-accordion>
       `,
     });
 

--- a/packages/beeq/src/components/accordion/_storybook/bq-accordion.stories.tsx
+++ b/packages/beeq/src/components/accordion/_storybook/bq-accordion.stories.tsx
@@ -20,9 +20,10 @@ const meta: Meta = {
     appearance: { control: 'select', options: [...ACCORDION_APPEARANCE] },
     size: { control: 'select', options: [...ACCORDION_SIZE] },
     // Event handlers
-    bqFocus: { action: 'bqFocus' },
-    bqClick: { action: 'bqClick' },
     bqBlur: { action: 'bqBlur' },
+    bqClose: { action: 'bqClose' },
+    bqFocus: { action: 'bqFocus' },
+    bqOpen: { action: 'bqOpen' },
     // Not part of the component
     header: { control: 'text', table: { disable: true } },
   },
@@ -46,9 +47,10 @@ const Template = (args: Args) => html`
     .expanded=${args.expanded}
     .disabled=${args.disabled}
     .rotate=${args.rotate}
-    @bqFocus=${args.bqFocus}
-    @bqClick=${args.bqClick}
     @bqBlur=${args.bqBlur}
+    @bqFocus=${args.bqFocus}
+    @bqClose=${args.bqClose}
+    @bqOpen=${args.bqOpen}
   >
     ${ifDefined(args.prefix) ? args.prefix : nothing}
     <span slot="header">${args.header}</span>

--- a/packages/beeq/src/components/accordion/_storybook/bq-accordion.stories.tsx
+++ b/packages/beeq/src/components/accordion/_storybook/bq-accordion.stories.tsx
@@ -14,25 +14,28 @@ const meta: Meta = {
     },
   },
   argTypes: {
-    expanded: { control: 'boolean' },
-    disabled: { control: 'boolean' },
-    rotate: { control: 'boolean' },
     appearance: { control: 'select', options: [...ACCORDION_APPEARANCE] },
+    disabled: { control: 'boolean' },
+    expanded: { control: 'boolean' },
+    rotate: { control: 'boolean' },
     size: { control: 'select', options: [...ACCORDION_SIZE] },
     // Event handlers
     bqBlur: { action: 'bqBlur' },
-    bqClose: { action: 'bqClose' },
     bqFocus: { action: 'bqFocus' },
     bqOpen: { action: 'bqOpen' },
+    bqAfterOpen: { action: 'bqAfterOpen' },
+    bqClose: { action: 'bqClose' },
+    bqAfterClose: { action: 'bqAfterClose' },
     // Not part of the component
     header: { control: 'text', table: { disable: true } },
   },
   args: {
-    expanded: false,
-    disabled: false,
-    rotate: false,
     appearance: 'filled',
+    disabled: false,
+    expanded: false,
+    rotate: false,
     size: 'medium',
+    // Not part of the component
     header: 'Header',
   },
 };
@@ -42,15 +45,17 @@ type Story = StoryObj;
 
 const Template = (args: Args) => html`
   <bq-accordion
-    size=${args.size}
     appearance=${args.appearance}
-    .expanded=${args.expanded}
-    .disabled=${args.disabled}
-    .rotate=${args.rotate}
+    ?disabled=${args.disabled}
+    ?expanded=${args.expanded}
+    ?rotate=${args.rotate}
+    size=${args.size}
     @bqBlur=${args.bqBlur}
     @bqFocus=${args.bqFocus}
-    @bqClose=${args.bqClose}
     @bqOpen=${args.bqOpen}
+    @bqAfterOpen=${args.bqAfterOpen}
+    @bqClose=${args.bqClose}
+    @bqAfterClose=${args.bqAfterClose}
   >
     ${ifDefined(args.prefix) ? args.prefix : nothing}
     <span slot="header">${args.header}</span>

--- a/packages/beeq/src/components/accordion/bq-accordion.tsx
+++ b/packages/beeq/src/components/accordion/bq-accordion.tsx
@@ -22,7 +22,6 @@ export class BqAccordion {
   // ====================
 
   private accordion: Accordion;
-  private accordionBody: HTMLDivElement;
   private prefixElem: HTMLDivElement;
   private suffixElem: HTMLDivElement;
   private detailsElem: HTMLDetailsElement;
@@ -68,16 +67,14 @@ export class BqAccordion {
 
   @Watch('expanded')
   handleExpandedChange() {
-    // Animate the opacity of the body so it doesn't overflow while the height is being animated
-    this.accordionBody.animate(
-      {
-        opacity: this.expanded ? [0, 1] : [1, 0],
-      },
-      {
-        duration: 300,
-        easing: 'ease-in-out',
-      },
-    );
+    if (!this.accordion) return;
+
+    if (this.expanded) {
+      this.accordion.open();
+      return; // We don't want to shrink the accordion if it's already expanded
+    }
+
+    this.accordion.close();
   }
 
   // Events section
@@ -103,10 +100,7 @@ export class BqAccordion {
 
   componentDidLoad() {
     this.accordion = new Accordion(this.detailsElem);
-  }
-
-  disconnectedCallback() {
-    this.accordion.destroy();
+    this.handleExpandedChange();
   }
 
   // Listeners
@@ -125,9 +119,9 @@ export class BqAccordion {
   // =======================================================
 
   private handleClick = (event: MouseEvent) => {
-    if (this.disabled) return;
-
     event.preventDefault();
+
+    if (this.disabled) return;
 
     this.expanded = !this.expanded;
     this.bqClick.emit(this.el);
@@ -162,14 +156,13 @@ export class BqAccordion {
   render() {
     return (
       <details
-        class={{ [`bq-accordion ${this.size} ${this.appearance}`]: true, disabled: this.disabled }}
-        open={this.open}
-        onClick={this.handleClick}
+        class={{ [`bq-accordion overflow-hidden ${this.size} ${this.appearance}`]: true, disabled: this.disabled }}
         ref={(detailsElem: HTMLDetailsElement) => (this.detailsElem = detailsElem)}
         part="base"
       >
         <summary
           class="bq-accordion__header"
+          onClick={this.handleClick}
           onFocus={this.handleFocus}
           onBlur={this.handleBlur}
           aria-expanded={this.open}
@@ -213,7 +206,7 @@ export class BqAccordion {
             </slot>
           </div>
         </summary>
-        <div class="bq-accordion__body overflow-hidden" part="panel" ref={(div) => (this.accordionBody = div)}>
+        <div class="bq-accordion__body overflow-hidden" part="panel">
           <slot />
         </div>
       </details>

--- a/packages/beeq/src/components/accordion/bq-accordion.tsx
+++ b/packages/beeq/src/components/accordion/bq-accordion.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, h, Prop, State, Watch } from '@stencil/core';
+import { Component, Element, Event, EventEmitter, h, Listen, Prop, State, Watch } from '@stencil/core';
 
 import { ACCORDION_APPEARANCE, ACCORDION_SIZE, TAccordionAppearance, TAccordionSize } from './bq-accordion.types';
 import { Accordion } from './helper';
@@ -78,6 +78,13 @@ export class BqAccordion {
     this.expanded ? this.accordion.open() : this.accordion.close();
   }
 
+  @Watch('disabled')
+  handleDisabledChange() {
+    if (!this.disabled) return;
+
+    this.expanded = false;
+  }
+
   // Events section
   // Requires JSDocs for public API documentation
   // ==============================================
@@ -91,8 +98,14 @@ export class BqAccordion {
   /** Handler to be called when the accordion is opened */
   @Event() bqOpen: EventEmitter<HTMLBqAccordionElement>;
 
+  /** Handler to be called after the accordion is opened */
+  @Event() bqAfterOpen: EventEmitter<HTMLBqAccordionElement>;
+
   /** Handler to be called when the accordion is closed */
   @Event() bqClose: EventEmitter<HTMLBqAccordionElement>;
+
+  /** Handler to be called after the accordion is closed */
+  @Event() bqAfterClose: EventEmitter<HTMLBqAccordionElement>;
 
   /** @internal Handler to be called when the accordion is clicked */
   @Event() bqClick: EventEmitter<HTMLBqAccordionElement>;
@@ -113,6 +126,13 @@ export class BqAccordion {
   // Listeners
   // ==============
 
+  @Listen('accordionTransitionEnd')
+  onAccordionTransitionEnd(event: CustomEvent) {
+    if (event.target !== this.el) return;
+
+    this.expanded ? this.bqAfterOpen.emit(this.el) : this.bqAfterClose.emit(this.el);
+  }
+
   // Public methods API
   // These methods are exposed on the host element.
   // Always use two lines.
@@ -124,7 +144,6 @@ export class BqAccordion {
   // Internal business logic.
   // These methods cannot be called from the host element.
   // =======================================================
-
   private handleClick = (event: MouseEvent) => {
     event.preventDefault();
 

--- a/packages/beeq/src/components/accordion/bq-accordion.tsx
+++ b/packages/beeq/src/components/accordion/bq-accordion.tsx
@@ -69,26 +69,33 @@ export class BqAccordion {
   handleExpandedChange() {
     if (!this.accordion) return;
 
-    if (this.expanded) {
-      this.accordion.open();
-      return; // We don't want to shrink the accordion if it's already expanded
+    const event = this.expanded ? this.bqOpen.emit(this.el) : this.bqClose.emit(this.el);
+    if (event.defaultPrevented) {
+      this.expanded = !this.expanded;
+      return;
     }
 
-    this.accordion.close();
+    this.expanded ? this.accordion.open() : this.accordion.close();
   }
 
   // Events section
   // Requires JSDocs for public API documentation
   // ==============================================
 
-  /** Handler to be called when the accordion is clicked */
-  @Event() bqClick: EventEmitter<HTMLBqAccordionElement>;
+  /** Handler to be called when the accordion loses focus */
+  @Event() bqBlur: EventEmitter<HTMLBqAccordionElement>;
 
   /** Handler to be called when the accordion gets focus */
   @Event() bqFocus: EventEmitter<HTMLBqAccordionElement>;
 
-  /** Handler to be called when the accordion loses focus */
-  @Event() bqBlur: EventEmitter<HTMLBqAccordionElement>;
+  /** Handler to be called when the accordion is opened */
+  @Event() bqOpen: EventEmitter<HTMLBqAccordionElement>;
+
+  /** Handler to be called when the accordion is closed */
+  @Event() bqClose: EventEmitter<HTMLBqAccordionElement>;
+
+  /** @internal Handler to be called when the accordion is clicked */
+  @Event() bqClick: EventEmitter<HTMLBqAccordionElement>;
 
   // Component lifecycle events
   // Ordered by their natural call order

--- a/packages/beeq/src/components/accordion/helper/index.ts
+++ b/packages/beeq/src/components/accordion/helper/index.ts
@@ -99,5 +99,8 @@ export class Accordion {
     this.isExpanding = false;
     // Remove the overflow hidden and the fixed height
     this.el.removeAttribute('style');
+    // Dispatch a custom event based on the open parameter
+    const endEvent = new Event('accordionTransitionEnd', { bubbles: false, composed: true });
+    this.el.dispatchEvent(endEvent);
   }
 }

--- a/packages/beeq/src/components/accordion/helper/index.ts
+++ b/packages/beeq/src/components/accordion/helper/index.ts
@@ -1,99 +1,103 @@
-/* -------------------------------------------------------------------------- */
-/*   💡 Credits: https://css-tricks.com/how-to-animate-the-details-element/   */
-/* -------------------------------------------------------------------------- */
+/* -------------------------------------------------------------------------------------- */
+/*   💡 Credits: https://css-tricks.com/how-to-animate-the-details-element-using-waapi    */
+/* -------------------------------------------------------------------------------------- */
 
 export class Accordion {
   private el: HTMLDetailsElement;
   private header: HTMLElement;
-  private body: HTMLElement;
+  private panel: HTMLElement;
   private animation: Animation | null;
   private isClosing: boolean;
   private isExpanding: boolean;
+  private animationOptions = {
+    duration: 300,
+    easing: 'ease-in-out',
+  };
 
   constructor(el: HTMLDetailsElement) {
+    // Store the <details> element
     this.el = el;
+    // Store the <summary> header element
     this.header = el.querySelector('summary');
-    this.body = el.querySelector('.bq-accordion__body');
-
+    // Store the <div class="content"> element
+    this.panel = el.querySelector('.bq-accordion__body');
+    // Store the animation object (so we can cancel it, if needed)
     this.animation = null;
+    // Store if the element is closing
     this.isClosing = false;
+    // Store if the element is expanding
     this.isExpanding = false;
-
-    this.header.addEventListener('click', (e) => this.onClick(e));
   }
 
-  destroy(): void {
-    this.header.removeEventListener('click', (e) => this.onClick(e));
-  }
-
-  private onClick(e: MouseEvent): void {
-    e.preventDefault();
-
-    if (this.isClosing || !this.el.open) {
-      this.open();
-    } else if (this.isExpanding || this.el.open) {
-      this.collapse();
-    }
-  }
-
-  private open(): void {
+  public open() {
+    // Check if the element is being closed or is already closed
+    if (!this.isClosing && this.el.open) return;
+    // Apply a fixed height on the element
     this.el.style.height = `${this.el.offsetHeight}px`;
+    // Force the [open] attribute on the details element
     this.el.open = true;
+    // Wait for the next frame to call the expand function
     window.requestAnimationFrame(() => this.expand());
   }
 
-  private expand(): void {
-    this.isExpanding = true;
-    const startHeight = `${this.el.offsetHeight}px`;
-    const endHeight = `${this.header.offsetHeight + this.body.offsetHeight}px`;
-
-    if (this.animation) {
-      this.animation.cancel();
-    }
-
-    this.animation = this.el.animate(
-      {
-        height: [startHeight, endHeight],
-      },
-      {
-        duration: 300,
-        easing: 'ease-in-out',
-      },
-    );
-
-    this.animation.onfinish = () => this.onAnimationFinish(true);
-    this.animation.oncancel = () => (this.isExpanding = false);
-  }
-
-  private collapse(): void {
+  public close() {
+    // Check if the element is being opened or is already open
+    if (!this.isExpanding && !this.el.open) return;
+    // Set the element as "being closed"
     this.isClosing = true;
 
+    // Store the current height of the element
     const startHeight = `${this.el.offsetHeight}px`;
+    // Calculate the height of the <summary> header
     const endHeight = `${this.header.offsetHeight}px`;
 
+    // If there is already an animation running
     if (this.animation) {
+      // Cancel the current animation
       this.animation.cancel();
     }
 
-    this.animation = this.el.animate(
-      {
-        height: [startHeight, endHeight],
-      },
-      {
-        duration: 300,
-        easing: 'ease-out',
-      },
-    );
-
+    // Start a WAAPI animation
+    this.animation = this.el.animate({ height: [startHeight, endHeight] }, this.animationOptions);
+    // When the animation is complete, call onAnimationFinish()
     this.animation.onfinish = () => this.onAnimationFinish(false);
+    // If the animation is cancelled, isClosing variable is set to false
     this.animation.oncancel = () => (this.isClosing = false);
   }
 
-  private onAnimationFinish(open: boolean): void {
+  // Expands the accordion
+  private expand() {
+    // Set the element as "being expanding"
+    this.isExpanding = true;
+    // Get the current fixed height of the element
+    const startHeight = `${this.el.offsetHeight}px`;
+    // Calculate the open height of the element (summary header height + panel body height)
+    const endHeight = `${this.header.offsetHeight + this.panel.offsetHeight}px`;
+
+    // If there is already an animation running
+    if (this.animation) {
+      // Cancel the current animation
+      this.animation.cancel();
+    }
+
+    // Start a WAAPI animation
+    this.animation = this.el.animate({ height: [startHeight, endHeight] }, this.animationOptions);
+    // When the animation is complete, call onAnimationFinish()
+    this.animation.onfinish = () => this.onAnimationFinish(true);
+    // If the animation is cancelled, isExpanding variable is set to false
+    this.animation.oncancel = () => (this.isExpanding = false);
+  }
+
+  // Handles the end of the animation
+  private onAnimationFinish(open: boolean) {
+    // Set the open attribute based on the parameter
     this.el.open = open;
+    // Clear the stored animation
     this.animation = null;
+    // Reset isClosing & isExpanding
     this.isClosing = false;
     this.isExpanding = false;
-    this.el.style.height = this.el.style.overflow = '';
+    // Remove the overflow hidden and the fixed height
+    this.el.removeAttribute('style');
   }
 }

--- a/packages/beeq/src/components/accordion/readme.md
+++ b/packages/beeq/src/components/accordion/readme.md
@@ -18,12 +18,14 @@
 
 ## Events
 
-| Event     | Description                                         | Type                                  |
-| --------- | --------------------------------------------------- | ------------------------------------- |
-| `bqBlur`  | Handler to be called when the accordion loses focus | `CustomEvent<HTMLBqAccordionElement>` |
-| `bqClose` | Handler to be called when the accordion is closed   | `CustomEvent<HTMLBqAccordionElement>` |
-| `bqFocus` | Handler to be called when the accordion gets focus  | `CustomEvent<HTMLBqAccordionElement>` |
-| `bqOpen`  | Handler to be called when the accordion is opened   | `CustomEvent<HTMLBqAccordionElement>` |
+| Event          | Description                                         | Type                                  |
+| -------------- | --------------------------------------------------- | ------------------------------------- |
+| `bqAfterClose` | Handler to be called after the accordion is closed  | `CustomEvent<HTMLBqAccordionElement>` |
+| `bqAfterOpen`  | Handler to be called after the accordion is opened  | `CustomEvent<HTMLBqAccordionElement>` |
+| `bqBlur`       | Handler to be called when the accordion loses focus | `CustomEvent<HTMLBqAccordionElement>` |
+| `bqClose`      | Handler to be called when the accordion is closed   | `CustomEvent<HTMLBqAccordionElement>` |
+| `bqFocus`      | Handler to be called when the accordion gets focus  | `CustomEvent<HTMLBqAccordionElement>` |
+| `bqOpen`       | Handler to be called when the accordion is opened   | `CustomEvent<HTMLBqAccordionElement>` |
 
 
 ## Shadow Parts

--- a/packages/beeq/src/components/accordion/readme.md
+++ b/packages/beeq/src/components/accordion/readme.md
@@ -21,8 +21,9 @@
 | Event     | Description                                         | Type                                  |
 | --------- | --------------------------------------------------- | ------------------------------------- |
 | `bqBlur`  | Handler to be called when the accordion loses focus | `CustomEvent<HTMLBqAccordionElement>` |
-| `bqClick` | Handler to be called when the accordion is clicked  | `CustomEvent<HTMLBqAccordionElement>` |
+| `bqClose` | Handler to be called when the accordion is closed   | `CustomEvent<HTMLBqAccordionElement>` |
 | `bqFocus` | Handler to be called when the accordion gets focus  | `CustomEvent<HTMLBqAccordionElement>` |
+| `bqOpen`  | Handler to be called when the accordion is opened   | `CustomEvent<HTMLBqAccordionElement>` |
 
 
 ## Shadow Parts

--- a/packages/beeq/src/components/accordion/scss/bq-accordion.scss
+++ b/packages/beeq/src/components/accordion/scss/bq-accordion.scss
@@ -108,6 +108,10 @@
 }
 
 .bq-accordion__header {
+  // Since there's an overflow on the <summary> element, the focus outline is not visible,
+  // so we force it to be inset to avoid the overflow hidden.
+  --bq-ring-offset-width: -2px;
+
   @apply flex cursor-pointer select-none list-none items-center transition-colors duration-300 ease-in-out focus-visible:focus;
   @apply border-[length:--bq-accordion--collapsed-border-width] border-[color:--bq-accordion--collapsed-border-color];
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR improves the animation of the Accordion when it opens and closes. It also handles the `bqOpen` and `bqClose` events handler callback and `bqAfterOpen` | `bqAfterClose`.

## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

Fixes #919 

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

https://github.com/Endava/BEEQ/assets/328492/c0c4623a-1a93-4ecc-8ca9-769bc7dddd76

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->

Storybook preview: https://6408a8161bf55e5999ae828b-ejgiolewwn.chromatic.com/?path=/story/components-accordion--group
