### PR TITLE
refactor(Icon): flatten icon SVG files when extracted and improve assets path

### DIFF
--- a/packages/beeq/src/components/icon/bq-icon.tsx
+++ b/packages/beeq/src/components/icon/bq-icon.tsx
@@ -1,8 +1,8 @@
-import { Component, Env, Event, EventEmitter, getAssetPath, h, Host, Prop, State, Watch } from '@stencil/core';
+import { Component, Env, Event, EventEmitter, h, Host, Prop, State, Watch } from '@stencil/core';
 
 import { TIconWeight } from './bq-icon.types';
 import { getSvgContent, iconContent } from './helper/request';
-import { getColorCSSVariable } from '../../shared/utils';
+import { getBasePath, getColorCSSVariable } from '../../shared/utils';
 
 /**
  * Icons are simplified images that graphically explain the meaning of an object on the screen.
@@ -104,7 +104,8 @@ export class BqIcon {
       iconName = `${this.name}.svg`;
       path = `${svgPath}/${iconName}`;
     }
-    return getAssetPath(path);
+
+    return getBasePath(path);
   };
 
   private loadIcon = () => {

--- a/packages/beeq/src/components/icon/bq-icon.tsx
+++ b/packages/beeq/src/components/icon/bq-icon.tsx
@@ -96,16 +96,8 @@ export class BqIcon {
     // Return the src if it is set
     if (this.src) return this.src;
 
-    const svgPath = Env.ICONS_SVG_PATH;
-    let iconName = this.weight !== 'regular' ? `${this.name}-${this.weight}.svg` : `${this.name}.svg`;
-    let path = `./svg/${this.weight}/${iconName}`;
-
-    if (svgPath) {
-      iconName = `${this.name}.svg`;
-      path = `${svgPath}/${iconName}`;
-    }
-
-    return getBasePath(path);
+    const { iconPath } = this.getIconDetails();
+    return getBasePath(iconPath);
   };
 
   private loadIcon = () => {
@@ -114,6 +106,33 @@ export class BqIcon {
       this._svgContent = iconContent.get(url);
       this.svgLoaded.emit(this._svgContent);
     });
+  };
+
+  private getIconDetails = (): { iconName: string; iconPath: string } => {
+    const REGULAR = 'regular';
+    const SVG_EXTENSION = '.svg';
+    const LOCAL_SVG_PATH = './svg/';
+    const ENV_SVG_PATH = Env.ICONS_SVG_PATH;
+
+    // Check if the icon is weighted. An icon is considered weighted if its weight is not 'regular' and ENV_SVG_PATH is not set.
+    // Eg: if the weight is 'bold' and ENV_SVG_PATH is not set, isWeightedIcon will be true.
+    const isWeightedIcon = this.weight !== REGULAR && !ENV_SVG_PATH;
+
+    // If the icon is weighted, append the weight to the icon name. Otherwise, append nothing.
+    // Eg: if isWeightedIcon is true and the weight is 'bold', weightSuffix will be '-bold'.
+    const weightSuffix = isWeightedIcon ? `-${this.weight}` : '';
+
+    // Construct the icon name by appending the weight suffix (if any) and the file extension.
+    // Eg: if the name is 'my-icon' and weightSuffix is '-bold', iconName will be 'my-icon-bold.svg'.
+    const iconName = `${this.name}${weightSuffix}${SVG_EXTENSION}`;
+
+    // Construct the path to the icon file.
+    // Eg: if iconName is 'my-icon-bold.svg', iconPath will be './svg/my-icon-bold.svg'.
+    // Eg: if iconName is 'my-icon-bold.svg' and ENV_SVG_PATH is 'https://mycdn.com/icons', iconPath will be 'https://mycdn.com/icons/my-icon-bold.svg'.
+    const iconPath = !ENV_SVG_PATH ? `${LOCAL_SVG_PATH}${iconName}` : `${ENV_SVG_PATH}/${iconName}`;
+
+    // Return the icon name and path.
+    return { iconName, iconPath };
   };
 
   // render() function

--- a/packages/beeq/src/index.ts
+++ b/packages/beeq/src/index.ts
@@ -1,2 +1,5 @@
 // eslint-disable-next-line import/no-unresolved
 export * from './components';
+
+export * from './services/interfaces';
+export * from './shared/utils';

--- a/packages/beeq/src/shared/utils/assetsPath.ts
+++ b/packages/beeq/src/shared/utils/assetsPath.ts
@@ -1,0 +1,50 @@
+/**
+ * Inspired by Shoelace's `getBasePath` and `setBasePath` functions.
+ * https://github.com/shoelace-style/shoelace/blob/next/src/utilities/base-path.ts
+ */
+
+let basePath = '';
+
+const scripts = [...document.getElementsByTagName('script')] as HTMLScriptElement[];
+
+const findConfigScript = () => scripts.find((script) => script.hasAttribute('data-beeq'));
+
+const findFallbackScript = () => scripts.find((script) => /beeq(\.esm)?\.js($|\?)/.test(script.src));
+
+const getScriptPath = (script: HTMLScriptElement) => script.getAttribute('src')!.split('/').slice(0, -1).join('/');
+
+/**
+ * Returns the base path for the Assets.
+ * If the base path has not been set, it will attempt to find the base path using the following methods:
+ * 1. If a script with the attribute `data-beeq` exists, the base path will be set to the value of the `src` attribute.
+ * 2. If a script with the name `beeq.js` or `beeq.esm.js` exists, the base path will be set to the value of the `src` attribute.
+ * 3. If the base path has not been set and no scripts are found, the base path will be set to the current directory.
+ *
+ * @param subpath - An optional subpath to append to the base path.
+ * @returns The base path of the assets.
+ */
+export const getBasePath = (subpath = '') => {
+  if (!basePath) {
+    const configScript = findConfigScript();
+    const fallbackScript = configScript ? null : findFallbackScript();
+
+    const script = configScript || fallbackScript;
+    if (script) {
+      const path = configScript ? script.getAttribute('data-beeq')! : getScriptPath(script);
+      setBasePath(path);
+    }
+  }
+
+  // Return the base path without a trailing slash. If one exists, append the subpath separated by a slash.
+  const formattedSubpath = subpath ? `/${subpath.replace(/^\//, '')}` : '';
+  return basePath.replace(/\/$/, '') + formattedSubpath;
+};
+
+/**
+ * Sets the base path for the Assets.
+ *
+ * @param path - The base path to set.
+ */
+export const setBasePath = (path: string) => {
+  basePath = path;
+};

--- a/packages/beeq/src/shared/utils/index.ts
+++ b/packages/beeq/src/shared/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './assetsPath';
 export * from './cssVariables';
 export * from './debounce';
 export * from './getNextElement';

--- a/tools/src/executors/icons/helpers/extract.ts
+++ b/tools/src/executors/icons/helpers/extract.ts
@@ -1,6 +1,6 @@
-import * as fs from 'fs-extra';
-import * as path from 'path';
 import * as decompress from 'decompress';
+import { copy, remove } from 'fs-extra';
+import { join, basename } from 'node:path';
 
 interface IExtractIcons {
   assetsFolder: string;
@@ -18,15 +18,17 @@ export const extractIcons = async ({
   svgFolder,
 }: IExtractIcons) => {
   try {
-    const files = await decompress(path.join(downloadPath, fileName), downloadPath);
+    const files = await decompress(join(downloadPath, fileName), downloadPath);
     // Remove all existing files under the `/svg/` folder (if there's any) to create a clean copy
-    await fs.remove(extractToPath);
-    // Move the SVG assets to the icon component `/svg/` folder in a flat structure
+    await remove(extractToPath);
+    // Copy the SVG assets to the extractToPath (eg: `packages/beeq/src/components/icon/svg/`) folder.
+    // We copy the icons in a flat structure, the Phosphor icons are under the `/assets/` folder,
+    // and subfolders (bold, duotone, fill, light, regular) are not needed.
     for (const file of files) {
-      if (file.type === 'file' && (file.path as string).includes(path.join(svgFolder, assetsFolder))) {
-        const oldPath = path.join(downloadPath, file.path);
-        const newPath = path.join(extractToPath, path.basename(file.path));
-        await fs.copy(oldPath, newPath, { overwrite: true });
+      if (file.type === 'file' && (file.path as string).includes(join(svgFolder, assetsFolder))) {
+        const oldPath = join(downloadPath, file.path);
+        const newPath = join(extractToPath, basename(file.path));
+        await copy(oldPath, newPath, { overwrite: true });
       }
     }
     Promise.resolve();

--- a/tools/src/executors/icons/helpers/extract.ts
+++ b/tools/src/executors/icons/helpers/extract.ts
@@ -1,6 +1,6 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
 import * as decompress from 'decompress';
-import { copy, remove } from 'fs-extra';
-import { join } from 'node:path';
 
 interface IExtractIcons {
   assetsFolder: string;
@@ -18,13 +18,17 @@ export const extractIcons = async ({
   svgFolder,
 }: IExtractIcons) => {
   try {
-    await decompress(join(downloadPath, fileName), downloadPath);
+    const files = await decompress(path.join(downloadPath, fileName), downloadPath);
     // Remove all existing files under the `/svg/` folder (if there's any) to create a clean copy
-    await remove(extractToPath);
-    // Move the SVG assets to the icon component `/svg/` folder
-    await copy(join(downloadPath, svgFolder, assetsFolder), extractToPath, {
-      overwrite: true,
-    });
+    await fs.remove(extractToPath);
+    // Move the SVG assets to the icon component `/svg/` folder in a flat structure
+    for (const file of files) {
+      if (file.type === 'file' && (file.path as string).includes(path.join(svgFolder, assetsFolder))) {
+        const oldPath = path.join(downloadPath, file.path);
+        const newPath = path.join(extractToPath, path.basename(file.path));
+        await fs.copy(oldPath, newPath, { overwrite: true });
+      }
+    }
     Promise.resolve();
   } catch (error) {
     Promise.reject(error);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR flattens the SVG files once extracted and copied into the `./src/components/icon/svg` folder, making it easy to get the path to the files. Now for weighted icons (e.g. bold, fill, duotone, thing) instead of having `./svg/bold/icon-name-bold.svg` we will have `./svg/icon-name-bold.svg`.

Also, we are replacing `getAssetPath()` from `@stencil/core`, which breaks on Vue projects, with a custom set/get base path method.

## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

N/A

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
