### PR TITLE
fix(Dialog): dialog closes on Esc down if `disable-close-esc-keydown` is enabled

### DIFF
--- a/packages/beeq/src/components/dialog/bq-dialog.tsx
+++ b/packages/beeq/src/components/dialog/bq-dialog.tsx
@@ -143,8 +143,14 @@ export class BqDialog {
   }
 
   @Listen('keydown', { target: 'window', capture: true })
-  async handleKeyDown(event: KeyboardEvent) {
-    if (!this.open || !this.dialogElem || !(event.key === 'Escape' || event.key === 'Esc')) return;
+  async handleKeyDown(ev: KeyboardEvent) {
+    const isEscapeKey = ev.key === 'Escape' || ev.key === 'Esc';
+    if (!this.open || !this.dialogElem || !isEscapeKey) return;
+
+    if (this.disableCloseEscKeydown) {
+      ev.preventDefault();
+      return;
+    }
 
     await this.cancel();
   }
@@ -238,7 +244,7 @@ export class BqDialog {
     return (
       <dialog
         style={style}
-        class={`bq-dialog hidden ${this.size}`}
+        class={`bq-dialog hidden ${this.size} focus-visible:outline-none`}
         data-transition-enter="transition ease-in duration-300"
         data-transition-enter-start="opacity-0 scale-75"
         data-transition-enter-end="opacity-100 scale-100"


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

Avoid the dialog to close when pressing the Esc key down if `disable-close-esc-keydown` is enabled.

## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

Fixes #978 

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

https://github.com/Endava/BEEQ/assets/328492/82069cbb-3535-4a6d-a701-9d1fa68b1a49

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
