### PR TITLE
chore(Renovate): configure renovate to group all NPM dependencies

### DIFF
--- a/.commitlintrc.ts
+++ b/.commitlintrc.ts
@@ -6,5 +6,6 @@ export default {
       'always',
       ['feat', 'fix', 'test', 'docs', 'style', 'chore', 'perf', 'refactor', 'revert', 'ci', 'build', 'wip', 'release'],
     ],
+    'body-max-line-length': [2, 'always', 300],
   },
 };

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,6 +20,17 @@
    */
   dependencyDashboard: true,
   /**
+   * Configuration presets to use or extend from.
+   */
+  extends: ['group:all'],
+  /**
+   * Slug to use for group (e.g. in branch name).
+   * By default, Renovate will "slugify" the groupName to determine the branch name.
+   * For example if you named your group "devDependencies (non-major)"
+   * then the branchName would be renovate/devdependencies-non-major
+   */
+  groupSlug: 'npm',
+  /**
    * The ignoreDeps configuration field allows you to define a list of dependency names to be ignored by Renovate.
    * Currently it supports only "exact match" dependency names
    */
@@ -42,9 +53,10 @@
    */
   packageRules: [
     {
-      groupName: 'all dependencies',
-      matchPackagePrefixes: ['*'],
-      excludePackagePrefixes: [
+      groupName: 'all NPM dependencies',
+      groupSlug: 'npmDependencies',
+      matchDepPatterns: ['*'],
+      excludeDepPatterns: [
         '@angular',
         '@schematics',
         'ng-packagr',
@@ -60,27 +72,27 @@
     },
     {
       groupName: 'Angular',
-      matchPackagePrefixes: ['@angular', '@schematics', 'ng-packagr'],
+      matchDepPatterns: ['@angular', '@schematics', 'ng-packagr'],
     },
     {
       groupName: 'Nx',
-      matchPackagePrefixes: ['@nx', 'nx'],
+      matchDepPatterns: ['@nx', 'nx'],
     },
     {
       groupName: 'Stencil',
-      matchPackagePrefixes: ['@stencil'],
+      matchDepPatterns: ['@stencil'],
     },
     {
       groupName: 'Storybook',
-      matchPackagePrefixes: ['@storybook', 'storybook'],
+      matchDepPatterns: ['@storybook', 'storybook'],
     },
     {
       groupName: 'Floating-UI',
-      matchPackagePrefixes: ['@floating-ui'],
+      matchDepPatterns: ['@floating-ui'],
     },
     {
       groupName: 'Typescript',
-      matchPackagePrefixes: ['typescript'],
+      matchPackageNames: ['typescript'],
       allowedVersions: '<5.4.0',
     },
     {

--- a/packages/beeq/project.json
+++ b/packages/beeq/project.json
@@ -43,6 +43,7 @@
         "configPath": "packages/beeq/stencil.config.ts",
         "outputPath": "dist/beeq",
         "watch": true,
+        "docs": true,
         "dev": true
       }
     },


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

Renovate should group all NPM dependencies in a single PR, except those packages that matter most like `@angular/*`, `@stencil/*`, `@storybook/*`, etc.

## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

N/A

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
