### PR TITLE
feat(Slider): allow to enable/show a Tooltip over the Slider thumb(s)

### DIFF
--- a/packages/beeq/src/components.d.ts
+++ b/packages/beeq/src/components.d.ts
@@ -920,6 +920,10 @@ export namespace Components {
          */
         "disabled"?: boolean;
         /**
+          * If `true`, a tooltip will be shown displaying the progress value
+         */
+        "enableTooltip": boolean;
+        /**
           * If `true` it will show the value label on a side of the slider track area
          */
         "enableValueIndicator"?: boolean;
@@ -939,6 +943,10 @@ export namespace Components {
           * A number representing the step of the slider. ⚠️ Please notice that the value (or list of values if the slider type is `range`) will be rounded to the nearest multiple of `step`.
          */
         "step": number;
+        /**
+          * If `true`, a tooltip will always display the progress value. It relies on enableTooltip and if enableTooltip is false, tooltipAlwaysVisible cannot be true.
+         */
+        "tooltipAlwaysVisible": boolean;
         /**
           * It defines the type of slider to display
          */
@@ -3105,6 +3113,10 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
+          * If `true`, a tooltip will be shown displaying the progress value
+         */
+        "enableTooltip"?: boolean;
+        /**
           * If `true` it will show the value label on a side of the slider track area
          */
         "enableValueIndicator"?: boolean;
@@ -3136,6 +3148,10 @@ declare namespace LocalJSX {
           * A number representing the step of the slider. ⚠️ Please notice that the value (or list of values if the slider type is `range`) will be rounded to the nearest multiple of `step`.
          */
         "step"?: number;
+        /**
+          * If `true`, a tooltip will always display the progress value. It relies on enableTooltip and if enableTooltip is false, tooltipAlwaysVisible cannot be true.
+         */
+        "tooltipAlwaysVisible"?: boolean;
         /**
           * It defines the type of slider to display
          */

--- a/packages/beeq/src/components/slider/__tests__/bq-slider.e2e.ts
+++ b/packages/beeq/src/components/slider/__tests__/bq-slider.e2e.ts
@@ -4,8 +4,9 @@ import { computedStyle, setProperties, sleep } from '../../../shared/test-utils'
 
 describe('bq-slider', () => {
   it('should render', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<bq-slider value="30"></bq-slider>');
+    const page = await newE2EPage({
+      html: '<bq-slider value="30"></bq-slider>',
+    });
 
     const element = await page.find('bq-slider');
 
@@ -13,8 +14,9 @@ describe('bq-slider', () => {
   });
 
   it('should have shadow root', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<bq-slider value="30"></bq-slider>');
+    const page = await newE2EPage({
+      html: '<bq-slider value="30"></bq-slider>',
+    });
 
     const element = await page.find('bq-slider');
 
@@ -22,8 +24,9 @@ describe('bq-slider', () => {
   });
 
   it('should handle `disabled` property', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<bq-slider type="range" value="[30,70]" disabled></bq-slider>');
+    const page = await newE2EPage({
+      html: '<bq-slider type="range" value="[30,70]" disabled></bq-slider>',
+    });
 
     const bqFocus = await page.spyOnEvent('bqFocus');
     const bqBlur = await page.spyOnEvent('bqBlur');
@@ -46,8 +49,9 @@ describe('bq-slider', () => {
   });
 
   it('should handle `value-indicator` property', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<bq-slider type="range" value="[30,70]"></bq-slider>');
+    const page = await newE2EPage({
+      html: '<bq-slider type="range" value="[30,70]"></bq-slider>',
+    });
 
     await page.$eval('bq-slider', (elem: HTMLBqSliderElement) => {
       elem.enableValueIndicator = true;
@@ -62,12 +66,12 @@ describe('bq-slider', () => {
   });
 
   it('should handle `gap` property', async () => {
-    const gap = 4;
+    const gap = 10;
     const page = await newE2EPage({
-      html: `<bq-slider type="range" min="0" max="10" value="[2, 8]" gap="${gap}"></bq-slider>`,
+      html: `<bq-slider type="range" min="0" max="100" value="[30, 70]" gap="${gap}"></bq-slider>`,
     });
 
-    await setProperties(page, 'bq-slider', { value: [5, 7] });
+    await setProperties(page, 'bq-slider', { value: [55, 60] });
 
     const minRangeInput = await page.find('bq-slider >>> input[part="input-min"]');
     const maxRangeInput = await page.find('bq-slider >>> input[part="input-max"]');
@@ -80,8 +84,9 @@ describe('bq-slider', () => {
   });
 
   it('should handle `type` property', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<bq-slider type="single" value="30"></bq-slider>');
+    const page = await newE2EPage({
+      html: '<bq-slider type="single" value="30"></bq-slider>',
+    });
 
     const element = await page.find('bq-slider');
     expect(element.shadowRoot.querySelectorAll('input').length).toBe(1);

--- a/packages/beeq/src/components/slider/_storybook/bq-slider.stories.tsx
+++ b/packages/beeq/src/components/slider/_storybook/bq-slider.stories.tsx
@@ -111,6 +111,7 @@ export const MinMaxStep: Story = {
     'enable-value-indicator': true,
     max: 10,
     min: 0,
+    step: 1.25,
     value: 3,
   },
 };
@@ -119,11 +120,12 @@ export const Gap: Story = {
   render: Template,
   args: {
     'enable-value-indicator': true,
-    gap: 4,
-    max: 10,
+    gap: 10,
+    max: 100,
     min: 0,
+    step: 5,
     type: 'range',
-    value: [2, 8],
+    value: [30, 70],
   },
 };
 

--- a/packages/beeq/src/components/slider/_storybook/bq-slider.stories.tsx
+++ b/packages/beeq/src/components/slider/_storybook/bq-slider.stories.tsx
@@ -17,6 +17,8 @@ const meta: Meta = {
     'debounce-time': { control: 'number' },
     disabled: { control: 'boolean' },
     'enable-value-indicator': { control: 'boolean' },
+    'enable-tooltip': { control: 'boolean' },
+    'tooltip-always-visible': { control: 'boolean' },
     gap: { control: 'number' },
     max: { control: 'number' },
     min: { control: 'number' },
@@ -32,6 +34,8 @@ const meta: Meta = {
     'debounce-time': 0,
     disabled: false,
     'enable-value-indicator': false,
+    'enable-tooltip': false,
+    'tooltip-always-visible': false,
     gap: 0,
     max: 100,
     min: 0,
@@ -50,6 +54,8 @@ const Template = (args: Args) => html`
       debounce-time=${ifDefined(args['debounce-time'])}
       ?disabled=${args.disabled}
       ?enable-value-indicator=${args['enable-value-indicator']}
+      ?enable-tooltip=${args['enable-tooltip']}
+      ?tooltip-always-visible=${args['tooltip-always-visible']}
       gap=${ifDefined(args.gap)}
       max=${ifDefined(args.max)}
       min=${ifDefined(args.min)}

--- a/packages/beeq/src/components/slider/_storybook/bq-slider.stories.tsx
+++ b/packages/beeq/src/components/slider/_storybook/bq-slider.stories.tsx
@@ -78,30 +78,11 @@ export const Default: Story = {
   },
 };
 
-export const DefaultWithTooltip: Story = {
-  render: Template,
-  args: {
-    value: 65,
-    'enable-tooltip': true,
-    'tooltip-always-visible': true,
-  },
-};
-
 export const Range: Story = {
   render: Template,
   args: {
     value: [30, 70],
     type: 'range',
-  },
-};
-
-export const RangeWithTooltip: Story = {
-  render: Template,
-  args: {
-    value: [25, 75],
-    type: 'range',
-    'enable-tooltip': true,
-    'tooltip-always-visible': true,
   },
 };
 
@@ -157,5 +138,18 @@ export const DecimalValues: Story = {
     type: 'range',
     step: 0.05,
     value: [0.3, 0.7],
+  },
+};
+
+export const WithTooltip: Story = {
+  render: Template,
+  args: {
+    'enable-tooltip': true,
+    gap: 10,
+    max: 100,
+    min: 0,
+    step: 1,
+    type: 'range',
+    value: [30, 70],
   },
 };

--- a/packages/beeq/src/components/slider/_storybook/bq-slider.stories.tsx
+++ b/packages/beeq/src/components/slider/_storybook/bq-slider.stories.tsx
@@ -78,11 +78,30 @@ export const Default: Story = {
   },
 };
 
+export const DefaultWithTooltip: Story = {
+  render: Template,
+  args: {
+    value: 65,
+    'enable-tooltip': true,
+    'tooltip-always-visible': true,
+  },
+};
+
 export const Range: Story = {
   render: Template,
   args: {
     value: [30, 70],
     type: 'range',
+  },
+};
+
+export const RangeWithTooltip: Story = {
+  render: Template,
+  args: {
+    value: [25, 75],
+    type: 'range',
+    'enable-tooltip': true,
+    'tooltip-always-visible': true,
   },
 };
 

--- a/packages/beeq/src/components/slider/bq-slider.tsx
+++ b/packages/beeq/src/components/slider/bq-slider.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, Event, EventEmitter, h, Prop, State, Watch } from '@stencil/core';
 
 import { TSliderType, TSliderValue } from './bq-slider.types';
-import { debounce, isString, TDebounce } from '../../shared/utils';
+import { debounce, isNil, isString, TDebounce } from '../../shared/utils';
 
 /**
  * @part base - The component's base wrapper.
@@ -43,9 +43,9 @@ export class BqSlider {
    * The `minValue` state is the only value when the slider type is `single`
    * and the minimum value when the slider type is `range`.
    */
-  @State() minValue: number = 0;
+  @State() minValue: number;
   /** The `maxValue` state is only used when the slider type is `range`. */
-  @State() maxValue: number = 100;
+  @State() maxValue: number;
   @State() calculatedLeftThumbPosition: number;
   @State() calculatedRightThumbPosition: number;
 
@@ -115,7 +115,7 @@ export class BqSlider {
     if (!this.isRangeType) return;
     // Use the this.value prop value when the component is initialized
     // Otherwise, use the current this.min and this.max state values
-    const value = this.min && this.max ? [this.min, this.max] : this.stringToObject(this.value);
+    const value = !isNil(this.min) && !isNil(this.max) ? [this.min, this.max] : this.stringToObject(this.value);
     // If the gap is less than the min or greater than the max, set it to 0
     this.gap = newValue < value[0] || newValue > value[1] ? 0 : newValue;
   }

--- a/packages/beeq/src/components/slider/bq-slider.tsx
+++ b/packages/beeq/src/components/slider/bq-slider.tsx
@@ -337,7 +337,7 @@ export class BqSlider {
       distance={16}
       style={{ left: `${thumbPosition}px`, fontVariant: 'tabular-nums' }}
     >
-      <div class={{ 'absolute h-1 w-1': true, 'z-50': this.tooltipAlwaysVisible }} slot="trigger" />
+      <div class={{ 'absolute h-1 w-1': true, '-z-[1]': this.tooltipAlwaysVisible }} slot="trigger" />
       {value}
     </bq-tooltip>
   );

--- a/packages/beeq/src/components/slider/bq-slider.tsx
+++ b/packages/beeq/src/components/slider/bq-slider.tsx
@@ -334,7 +334,7 @@ export class BqSlider {
       exportparts="base,trigger,panel"
       alwaysVisible={this.isTooltipAlwaysVisible}
       visible
-      distance={16}
+      distance={this.enableValueIndicator ? 6 : 16}
       style={{ left: `${thumbPosition}px`, fontVariant: 'tabular-nums' }}
     >
       <div class={{ 'absolute h-1 w-1': true, '-z-[1]': this.tooltipAlwaysVisible }} slot="trigger" />

--- a/packages/beeq/src/components/slider/bq-slider.tsx
+++ b/packages/beeq/src/components/slider/bq-slider.tsx
@@ -46,6 +46,8 @@ export class BqSlider {
   @State() minValue: number = 0;
   /** The `maxValue` state is only used when the slider type is `range`. */
   @State() maxValue: number = 100;
+  @State() calculatedLeftThumbPosition: number;
+  @State() calculatedRightThumbPosition: number;
 
   // Public Property API
   // ========================
@@ -144,11 +146,20 @@ export class BqSlider {
   componentDidLoad() {
     this.updateProgressTrack();
     this.syncInputsValue();
+    if (this.enableTooltip) {
+      this.calculatedLeftThumbPosition = this.calculateThumbPosition()?.leftThumbPosition;
+      this.calculatedRightThumbPosition = this.calculateThumbPosition()?.rightThumbPosition;
+    }
   }
 
   componentDidUpdate() {
     this.updateProgressTrack();
     this.syncInputsValue();
+    this.calculateThumbPosition();
+    if (this.enableTooltip) {
+      this.calculatedLeftThumbPosition = this.calculateThumbPosition()?.leftThumbPosition;
+      this.calculatedRightThumbPosition = this.calculateThumbPosition()?.rightThumbPosition;
+    }
   }
 
   // Listeners
@@ -361,12 +372,12 @@ export class BqSlider {
           </div>
           {/* INPUT (Min), used on single type */}
           {this.renderInput('min', this.minValue, (input) => (this.inputMinElem = input))}
-          {this.enableTooltip && this.renderTooltip(this.minValue, this.calculateThumbPosition()?.leftThumbPosition)}
+          {this.enableTooltip && this.renderTooltip(this.minValue, this.calculatedLeftThumbPosition)}
           {/* INPUT (Max) */}
           {this.isRangeType && this.renderInput('max', this.maxValue, (input) => (this.inputMaxElem = input))}
           {this.enableTooltip &&
             this.isRangeType &&
-            this.renderTooltip(this.maxValue, this.calculateThumbPosition()?.rightThumbPosition)}
+            this.renderTooltip(this.maxValue, this.calculatedRightThumbPosition)}
         </div>
         {/* LABEL (end) */}
         {this.renderLabel(this.maxValue, 'end', 'ms-xs text-start')}

--- a/packages/beeq/src/components/slider/bq-slider.tsx
+++ b/packages/beeq/src/components/slider/bq-slider.tsx
@@ -247,12 +247,14 @@ export class BqSlider {
   private calculateThumbPosition = (value: number): number => {
     if (!this.progressElem) return;
 
-    // Get the width of the input container and the size of the slider thumb
-    const inputWidth = this.trackElem.getBoundingClientRect().width;
-    const thumbSize = parseInt(getComputedStyle(this.el).getPropertyValue('--bq-slider--thumb-size'), 10);
-    const totalInputWidth = inputWidth - thumbSize;
+    // Get the width of the track area and the size of the input range thumb
+    const trackAreaWidth = this.trackElem.getBoundingClientRect().width;
+    // We need to also add 4px to the thumb size,
+    // this is because the thumb is 2px border (`border-2`)
+    const inputThumbSize = parseInt(getComputedStyle(this.el).getPropertyValue('--bq-slider--thumb-size'), 10) + 4;
+    const totalWidth = trackAreaWidth - inputThumbSize;
 
-    return ((value - this.min) / (this.max - this.min)) * totalInputWidth + thumbSize / 2;
+    return ((value - this.min) / (this.max - this.min)) * totalWidth + inputThumbSize / 2;
   };
 
   private thumbPosition = (): { minThumbPosition: number; maxThumbPosition?: number } => {

--- a/packages/beeq/src/components/slider/readme.md
+++ b/packages/beeq/src/components/slider/readme.md
@@ -11,11 +11,13 @@
 | ---------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ----------- |
 | `debounceTime`         | `debounce-time`          | The amount of time, in milliseconds, to wait to trigger the `bqChange` event after each value change.                                                                                                                                                   | `number`                               | `0`         |
 | `disabled`             | `disabled`               | If `true` the slider is disabled.                                                                                                                                                                                                                       | `boolean`                              | `false`     |
+| `enableTooltip`        | `enable-tooltip`         | If `true`, a tooltip will be shown displaying the progress value                                                                                                                                                                                        | `boolean`                              | `false`     |
 | `enableValueIndicator` | `enable-value-indicator` | If `true` it will show the value label on a side of the slider track area                                                                                                                                                                               | `boolean`                              | `false`     |
 | `gap`                  | `gap`                    | A number representing the amount to remain between the minimum and maximum values (only for range type).                                                                                                                                                | `number`                               | `0`         |
 | `max`                  | `max`                    | A number representing the max value of the slider.                                                                                                                                                                                                      | `number`                               | `100`       |
 | `min`                  | `min`                    | A number representing the min value of the slider.                                                                                                                                                                                                      | `number`                               | `0`         |
 | `step`                 | `step`                   | A number representing the step of the slider. ⚠️ Please notice that the value (or list of values if the slider type is `range`) will be rounded to the nearest multiple of `step`.                                                                      | `number`                               | `1`         |
+| `tooltipAlwaysVisible` | `tooltip-always-visible` | If `true`, a tooltip will always display the progress value. It relies on enableTooltip and if enableTooltip is false, tooltipAlwaysVisible cannot be true.                                                                                             | `boolean`                              | `false`     |
 | `type`                 | `type`                   | It defines the type of slider to display                                                                                                                                                                                                                | `"range" \| "single"`                  | `'single'`  |
 | `value`                | `value`                  | The value of the slider. - If the slider type is `single`, the value is a number. - If the slider type is `range`, the value is an array of two numbers (the first number represents the `min` value and the second number represents the `max` value). | `[number, number] \| number \| string` | `undefined` |
 
@@ -42,6 +44,19 @@
 | `"progress-area"` | The progress area of the slider.                                                                                       |
 | `"track-area"`    | The track area of the slider.                                                                                          |
 
+
+## Dependencies
+
+### Depends on
+
+- [bq-tooltip](../tooltip)
+
+### Graph
+```mermaid
+graph TD;
+  bq-slider --> bq-tooltip
+  style bq-slider fill:#f9f,stroke:#333,stroke-width:4px
+```
 
 ----------------------------------------------
 

--- a/packages/beeq/src/components/tooltip/bq-tooltip.tsx
+++ b/packages/beeq/src/components/tooltip/bq-tooltip.tsx
@@ -76,6 +76,8 @@ export class BqTooltip {
   handleFloatingUIOptionsChange() {
     this.floatingUI.init({
       placement: this.placement,
+      distance: this.distance,
+      sameWidth: this.sameWidth,
       strategy: 'fixed',
     });
   }

--- a/packages/beeq/src/components/tooltip/readme.md
+++ b/packages/beeq/src/components/tooltip/readme.md
@@ -56,12 +56,14 @@ Type: `Promise<void>`
 
  - [bq-progress](../progress)
  - [bq-side-menu-item](../side-menu-item)
+ - [bq-slider](../slider)
 
 ### Graph
 ```mermaid
 graph TD;
   bq-progress --> bq-tooltip
   bq-side-menu-item --> bq-tooltip
+  bq-slider --> bq-tooltip
   style bq-tooltip fill:#f9f,stroke:#333,stroke-width:4px
 ```
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

The purpose of this PR is to enable the tooltip for slider (single and range).

## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

Fixes #ISSUE_NUMBER

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
