### PR TITLE
fix(Slider): range type not rendering correctly when max value is greater than 10

### DIFF
--- a/packages/beeq/src/components/slider/__tests__/bq-slider.e2e.ts
+++ b/packages/beeq/src/components/slider/__tests__/bq-slider.e2e.ts
@@ -4,8 +4,9 @@ import { computedStyle, setProperties, sleep } from '../../../shared/test-utils'
 
 describe('bq-slider', () => {
   it('should render', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<bq-slider value="30"></bq-slider>');
+    const page = await newE2EPage({
+      html: '<bq-slider value="30"></bq-slider>',
+    });
 
     const element = await page.find('bq-slider');
 
@@ -13,8 +14,9 @@ describe('bq-slider', () => {
   });
 
   it('should have shadow root', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<bq-slider value="30"></bq-slider>');
+    const page = await newE2EPage({
+      html: '<bq-slider value="30"></bq-slider>',
+    });
 
     const element = await page.find('bq-slider');
 
@@ -22,8 +24,9 @@ describe('bq-slider', () => {
   });
 
   it('should handle `disabled` property', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<bq-slider type="range" value="[30,70]" disabled></bq-slider>');
+    const page = await newE2EPage({
+      html: '<bq-slider type="range" value="[30,70]" disabled></bq-slider>',
+    });
 
     const bqFocus = await page.spyOnEvent('bqFocus');
     const bqBlur = await page.spyOnEvent('bqBlur');
@@ -46,8 +49,9 @@ describe('bq-slider', () => {
   });
 
   it('should handle `value-indicator` property', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<bq-slider type="range" value="[30,70]"></bq-slider>');
+    const page = await newE2EPage({
+      html: '<bq-slider type="range" value="[30,70]"></bq-slider>',
+    });
 
     await page.$eval('bq-slider', (elem: HTMLBqSliderElement) => {
       elem.enableValueIndicator = true;
@@ -62,12 +66,12 @@ describe('bq-slider', () => {
   });
 
   it('should handle `gap` property', async () => {
-    const gap = 4;
+    const gap = 10;
     const page = await newE2EPage({
-      html: `<bq-slider type="range" min="0" max="10" value="[2, 8]" gap="${gap}"></bq-slider>`,
+      html: `<bq-slider type="range" min="0" max="100" value="[30, 70]" gap="${gap}"></bq-slider>`,
     });
 
-    await setProperties(page, 'bq-slider', { value: [5, 7] });
+    await setProperties(page, 'bq-slider', { value: [55, 60] });
 
     const minRangeInput = await page.find('bq-slider >>> input[part="input-min"]');
     const maxRangeInput = await page.find('bq-slider >>> input[part="input-max"]');
@@ -80,8 +84,9 @@ describe('bq-slider', () => {
   });
 
   it('should handle `type` property', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<bq-slider type="single" value="30"></bq-slider>');
+    const page = await newE2EPage({
+      html: '<bq-slider type="single" value="30"></bq-slider>',
+    });
 
     const element = await page.find('bq-slider');
     expect(element.shadowRoot.querySelectorAll('input').length).toBe(1);

--- a/packages/beeq/src/components/slider/_storybook/bq-slider.stories.tsx
+++ b/packages/beeq/src/components/slider/_storybook/bq-slider.stories.tsx
@@ -105,6 +105,7 @@ export const MinMaxStep: Story = {
     'enable-value-indicator': true,
     max: 10,
     min: 0,
+    step: 1.25,
     value: 3,
   },
 };
@@ -113,11 +114,12 @@ export const Gap: Story = {
   render: Template,
   args: {
     'enable-value-indicator': true,
-    gap: 4,
-    max: 10,
+    gap: 10,
+    max: 100,
     min: 0,
+    step: 5,
     type: 'range',
-    value: [2, 8],
+    value: [30, 70],
   },
 };
 

--- a/packages/beeq/src/components/slider/bq-slider.tsx
+++ b/packages/beeq/src/components/slider/bq-slider.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, Event, EventEmitter, h, Prop, State, Watch } from '@stencil/core';
 
 import { TSliderType, TSliderValue } from './bq-slider.types';
-import { debounce, isString, TDebounce } from '../../shared/utils';
+import { debounce, isNil, isString, TDebounce } from '../../shared/utils';
 
 /**
  * @part base - The component's base wrapper.
@@ -42,9 +42,9 @@ export class BqSlider {
    * The `minValue` state is the only value when the slider type is `single`
    * and the minimum value when the slider type is `range`.
    */
-  @State() minValue: number = 0;
+  @State() minValue: number;
   /** The `maxValue` state is only used when the slider type is `range`. */
-  @State() maxValue: number = 100;
+  @State() maxValue: number;
 
   // Public Property API
   // ========================
@@ -103,7 +103,7 @@ export class BqSlider {
     if (!this.isRangeType) return;
     // Use the this.value prop value when the component is initialized
     // Otherwise, use the current this.min and this.max state values
-    const value = this.min && this.max ? [this.min, this.max] : this.stringToObject(this.value);
+    const value = !isNil(this.min) && !isNil(this.max) ? [this.min, this.max] : this.stringToObject(this.value);
     // If the gap is less than the min or greater than the max, set it to 0
     this.gap = newValue < value[0] || newValue > value[1] ? 0 : newValue;
   }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

After the latest refactoring on the Slider component, the range type is not rendering correctly when the max value is set to a value greater than 10.

## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

N/A

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

The issue can be reproduced here in the latest Chromatic published from the `main` branch:
https://6408a8161bf55e5999ae828b-xajapvwgrr.chromatic.com/?path=/story/components-slider--range

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
