### PR TITLE
refactor(Side menu): set background color to UI primary for the default variant

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -22,7 +22,8 @@
           }
         ],
         "scss/double-slash-comment-empty-line-before": null,
-        "scss/operator-no-unspaced": null
+        "scss/operator-no-unspaced": null,
+        "value-keyword-case": null
       }
     }
   ],

--- a/packages/beeq-tailwindcss/src/theme/colors/declarative.ts
+++ b/packages/beeq-tailwindcss/src/theme/colors/declarative.ts
@@ -48,6 +48,7 @@ export const DECLARATIVE_COLORS = {
     tertiary: 'var(--bq-stroke--tertiary)',
     inverse: 'var(--bq-stroke--inverse)',
     brand: 'var(--bq-stroke--brand)',
+    alt: 'var(--bq-stroke--alt)',
     success: 'var(--bq-stroke--success)',
     warning: 'var(--bq-stroke--warning)',
     danger: 'var(--bq-stroke--danger)',

--- a/packages/beeq-tailwindcss/src/theme/default/dark.ts
+++ b/packages/beeq-tailwindcss/src/theme/default/dark.ts
@@ -14,13 +14,14 @@ export const DefaultDarkTheme = {
   /* -------------------------------------------------------------------------- */
   /** Primary */
   'bq-icon--primary': 'var(--bq-neutral-100)',
-  'bq-icon--alt': 'var(--bq-white)',
   /** Secondary */
   'bq-icon--secondary': 'var(--bq-neutral-400)',
   /** Inverse */
   'bq-icon--inverse': 'var(--bq-neutral-800)',
   /** Brand */
   'bq-icon--brand': 'var(--bq-brand)',
+  /** Alternative */
+  'bq-icon--alt': 'var(--bq-white)',
   /** Feedback */
   'bq-icon--info': 'var(--bq-brand)',
   'bq-icon--success': 'var(--bq-success)',
@@ -31,7 +32,6 @@ export const DefaultDarkTheme = {
   /* -------------------------------------------------------------------------- */
   /** Primary */
   'bq-stroke--primary': 'var(--bq-neutral-900)',
-  'bq-stroke--alt': 'var(--bq-neutral-1000)',
   /** Secondary */
   'bq-stroke--secondary': 'var(--bq-neutral-700)',
   /** Tertiary */
@@ -40,6 +40,8 @@ export const DefaultDarkTheme = {
   'bq-stroke--inverse': 'var(--bq-neutral-950)',
   /** Brand */
   'bq-stroke--brand': 'var(--bq-brand)',
+  /** Alternative */
+  'bq-stroke--alt': 'var(--bq-neutral-1000)',
   /** Success */
   'bq-stroke--success': 'var(--bq-success)',
   /** Warning */
@@ -53,13 +55,14 @@ export const DefaultDarkTheme = {
   /* -------------------------------------------------------------------------- */
   /** Primary */
   'bq-text--primary': 'var(--bq-neutral-100)',
-  'bq-text--alt': 'var(--bq-white)',
   /** Secondary */
   'bq-text--secondary': 'var(--bq-neutral-400)',
   /** Inverse */
   'bq-text--inverse': 'var(--bq-neutral-800)',
   /** Brand */
   'bq-text--brand': 'var(--bq-brand)',
+  /** Alternative */
+  'bq-text--alt': 'var(--bq-white)',
   /** Feedback */
   'bq-text--info': 'var(--bq-brand)',
   'bq-text--success': 'var(--bq-success)',
@@ -70,7 +73,6 @@ export const DefaultDarkTheme = {
   /* -------------------------------------------------------------------------- */
   /** Primary */
   'bq-ui--primary': 'var(--bq-neutral-900)',
-  'bq-ui--alt': 'var(--bq-neutral-950)',
   /** Secondary */
   'bq-ui--secondary': 'var(--bq-neutral-800)',
   /** Tertiary */
@@ -80,6 +82,8 @@ export const DefaultDarkTheme = {
   /** Brand */
   'bq-ui--brand': 'var(--bq-brand)',
   'bq-ui--brand-alt': 'var(--bq-brand-dark)',
+  /** Alternative */
+  'bq-ui--alt': 'var(--bq-neutral-950)',
   /** Success */
   'bq-ui--success': 'var(--bq-success)',
   'bq-ui--success-alt': 'var(--bq-success-dark)',

--- a/packages/beeq-tailwindcss/src/theme/default/light.ts
+++ b/packages/beeq-tailwindcss/src/theme/default/light.ts
@@ -31,7 +31,6 @@ export const DefaultLightTheme = {
   /* -------------------------------------------------------------------------- */
   /** Primary */
   'bq-stroke--primary': 'var(--bq-neutral-200)',
-  'bq-stroke--alt': 'var(--bq-neutral-50)',
   /** Secondary */
   'bq-stroke--secondary': 'var(--bq-neutral-600)',
   /** Tertiary */
@@ -40,6 +39,8 @@ export const DefaultLightTheme = {
   'bq-stroke--inverse': 'var(--bq-white)',
   /** Brand */
   'bq-stroke--brand': 'var(--bq-brand)',
+  /** Alternative */
+  'bq-stroke--alt': 'var(--bq-neutral-50)',
   /** Success */
   'bq-stroke--success': 'var(--bq-success)',
   /** Warning */
@@ -53,13 +54,14 @@ export const DefaultLightTheme = {
   /* -------------------------------------------------------------------------- */
   /** Primary */
   'bq-text--primary': 'var(--bq-neutral-800)',
-  'bq-text--alt': 'var(--bq-white)',
   /** Secondary */
   'bq-text--secondary': 'var(--bq-neutral-600)',
   /** Inverse */
   'bq-text--inverse': 'var(--bq-neutral-50)',
   /** Brand */
   'bq-text--brand': 'var(--bq-brand)',
+  /** Alternative */
+  'bq-text--alt': 'var(--bq-white)',
   /** Feedback */
   'bq-text--info': 'var(--bq-brand)',
   'bq-text--success': 'var(--bq-success)',
@@ -70,7 +72,6 @@ export const DefaultLightTheme = {
   /* -------------------------------------------------------------------------- */
   /** Primary */
   'bq-ui--primary': 'var(--bq-white)',
-  'bq-ui--alt': 'var(--bq-neutral-50)',
   /** Secondary */
   'bq-ui--secondary': 'var(--bq-neutral-200)',
   /** Tertiary */
@@ -80,6 +81,8 @@ export const DefaultLightTheme = {
   /** Brand */
   'bq-ui--brand': 'var(--bq-brand)',
   'bq-ui--brand-alt': 'var(--bq-brand-light)',
+  /** Alternative */
+  'bq-ui--alt': 'var(--bq-neutral-50)',
   /** Success */
   'bq-ui--success': 'var(--bq-success)',
   'bq-ui--success-alt': 'var(--bq-success-light)',

--- a/packages/beeq-tailwindcss/src/theme/endava/dark.ts
+++ b/packages/beeq-tailwindcss/src/theme/endava/dark.ts
@@ -14,13 +14,14 @@ export const EndavaDarkTheme = {
   /* -------------------------------------------------------------------------- */
   /** Primary */
   'bq-icon--primary': 'var(--bq-neutral-100)',
-  'bq-icon--alt': 'var(--bq-white)',
   /** Secondary */
   'bq-icon--secondary': 'var(--bq-neutral-400)',
   /** Inverse */
   'bq-icon--inverse': 'var(--bq-neutral-800)',
   /** Brand */
   'bq-icon--brand': 'var(--bq-brand)',
+  /** Alternative */
+  'bq-icon--alt': 'var(--bq-white)',
   /** Feedback */
   'bq-icon--info': 'var(--bq-info)',
   'bq-icon--success': 'var(--bq-success)',
@@ -31,7 +32,6 @@ export const EndavaDarkTheme = {
   /* -------------------------------------------------------------------------- */
   /** Primary */
   'bq-stroke--primary': 'var(--bq-neutral-900)',
-  'bq-stroke--alt': 'var(--bq-neutral-1000)',
   /** Secondary */
   'bq-stroke--secondary': 'var(--bq-neutral-700)',
   /** Tertiary */
@@ -41,6 +41,8 @@ export const EndavaDarkTheme = {
   /** Brand */
   'bq-stroke--brand': 'var(--bq-brand)',
   'bq-stroke--brand-alt': 'var(--bq-brand-dark)',
+  /** Alternative */
+  'bq-stroke--alt': 'var(--bq-neutral-1000)',
   /** Success */
   'bq-stroke--success': 'var(--bq-success)',
   /** Warning */
@@ -54,13 +56,14 @@ export const EndavaDarkTheme = {
   /* -------------------------------------------------------------------------- */
   /** Primary */
   'bq-text--primary': 'var(--bq-neutral-100)',
-  'bq-text--alt': 'var(--bq-neutral-white)',
   /** Secondary */
   'bq-text--secondary': 'var(--bq-neutral-400)',
   /** Inverse */
   'bq-text--inverse': 'var(--bq-neutral-800)',
   /** Brand */
   'bq-text--brand': 'var(--bq-brand)',
+  /** Alternative */
+  'bq-text--alt': 'var(--bq-neutral-white)',
   /** Feedback */
   'bq-text--info': 'var(--bq-info)',
   'bq-text--success': 'var(--bq-success)',
@@ -71,7 +74,6 @@ export const EndavaDarkTheme = {
   /* -------------------------------------------------------------------------- */
   /** Primary */
   'bq-ui--primary': 'var(--bq-neutral-900)',
-  'bq-ui--alt': 'var(--bq-neutral-950)',
   /** Secondary */
   'bq-ui--secondary': 'var(--bq-neutral-800)',
   /** Tertiary */
@@ -81,6 +83,8 @@ export const EndavaDarkTheme = {
   /** Brand */
   'bq-ui--brand': 'var(--bq-brand)',
   'bq-ui--brand-alt': 'var(--bq-brand-dark)',
+  /** Alternative */
+  'bq-ui--alt': 'var(--bq-neutral-950)',
   /** Success */
   'bq-ui--success': 'var(--bq-success)',
   'bq-ui--success-alt': 'var(--bq-success-dark)',

--- a/packages/beeq-tailwindcss/src/theme/endava/light.ts
+++ b/packages/beeq-tailwindcss/src/theme/endava/light.ts
@@ -14,13 +14,14 @@ export const EndavaLightTheme = {
   /* -------------------------------------------------------------------------- */
   /** Primary */
   'bq-icon--primary': 'var(--bq-neutral-800)',
-  'bq-icon--alt': 'var(--bq-white)',
   /** Secondary */
   'bq-icon--secondary': 'var(--bq-neutral-600)',
   /** Inverse */
   'bq-icon--inverse': 'var(--bq-neutral-50)',
   /** Brand */
   'bq-icon--brand': 'var(--bq-brand)',
+  /** Alternative */
+  'bq-icon--alt': 'var(--bq-white)',
   /** Feedback */
   'bq-icon--info': 'var(--bq-info)',
   'bq-icon--success': 'var(--bq-success)',
@@ -31,7 +32,6 @@ export const EndavaLightTheme = {
   /* -------------------------------------------------------------------------- */
   /** Primary */
   'bq-stroke--primary': 'var(--bq-neutral-200)',
-  'bq-stroke--alt': 'var(--bq-neutral-50)',
   /** Secondary */
   'bq-stroke--secondary': 'var(--bq-neutral-600)',
   /** Tertiary */
@@ -40,6 +40,8 @@ export const EndavaLightTheme = {
   'bq-stroke--inverse': 'var(--bq-white)',
   /** Brand */
   'bq-stroke--brand': 'var(--bq-brand)',
+  /** Alternative */
+  'bq-stroke--alt': 'var(--bq-neutral-50)',
   'bq-stroke--brand-alt': 'var(--bq-brand-light)',
   /** Success */
   'bq-stroke--success': 'var(--bq-success)',
@@ -54,13 +56,14 @@ export const EndavaLightTheme = {
   /* -------------------------------------------------------------------------- */
   /** Primary */
   'bq-text--primary': 'var(--bq-neutral-800)',
-  'bq-text--alt': 'var(--bq-white)',
   /** Secondary */
   'bq-text--secondary': 'var(--bq-neutral-600)',
   /** Inverse */
   'bq-text--inverse': 'var(--bq-neutral-50)',
   /** Brand */
   'bq-text--brand': 'var(--bq-brand)',
+  /** Alternative */
+  'bq-text--alt': 'var(--bq-white)',
   /** Feedback */
   'bq-text--info': 'var(--bq-info)',
   'bq-text--success': 'var(--bq-success)',
@@ -71,7 +74,6 @@ export const EndavaLightTheme = {
   /* -------------------------------------------------------------------------- */
   /** Primary */
   'bq-ui--primary': 'var(--bq-white)',
-  'bq-ui--alt': 'var(--bq-neutral-50)',
   /** Secondary */
   'bq-ui--secondary': 'var(--bq-neutral-200)',
   /** Tertiary */
@@ -79,8 +81,10 @@ export const EndavaLightTheme = {
   /** Inverse */
   'bq-ui--inverse': 'var(--bq-neutral-900)',
   /** Brand */
-  'bq-ui--brand': 'var(--bq-brand)',
+  'bq-ui--alt': 'var(--bq-neutral-50)',
   'bq-ui--brand-alt': 'var(--bq-brand-light)',
+  /** Alternative */
+  'bq-ui--brand': 'var(--bq-brand)',
   /** Success */
   'bq-ui--success': 'var(--bq-success)',
   'bq-ui--success-alt': 'var(--bq-success-light)',

--- a/packages/beeq/src/components/side-menu-item/scss/bq-side-menu-item.variables.scss
+++ b/packages/beeq/src/components/side-menu-item/scss/bq-side-menu-item.variables.scss
@@ -17,7 +17,7 @@
    * @prop --bq-side-menu-item--paddingY: Side menu item horizontal padding
    */
   --bq-side-menu-item--bg-default: theme('backgroundColor.transparent');
-  --bq-side-menu-item--bg-hover: color-mix(in srgb, var(--bq-ui--secondary), var(--bq-hover) 20%);
+  --bq-side-menu-item--bg-hover: color-mix(in srgb, var(--bq-ui--alt), var(--bq-hover) 20%);
   --bq-side-menu-item--bg-active: theme('backgroundColor.ui.brand-alt');
 
   --bq-side-menu-item--text-default: theme('textColor.text.primary');

--- a/packages/beeq/src/components/side-menu/scss/bq-side-menu.scss
+++ b/packages/beeq/src/components/side-menu/scss/bq-side-menu.scss
@@ -13,13 +13,14 @@
 /* -------------------------------------------------------------------------- */
 
 .bq-side-menu {
-  @apply fixed left-0 top-0 flex h-dynamic-vh w-[var(--bq-side-menu--width)] grow flex-col bg-[var(--bq-side-menu--bg-color)];
+  @apply fixed left-0 top-0 flex h-dynamic-vh w-[--bq-side-menu--width] grow flex-col bg-[--bq-side-menu--bg-color];
+  @apply border-0 border-e border-solid border-[color:--bq-side-menu--border-color];
   @apply transition-[background-color,width] duration-150;
   @include hide-scrollbar;
 }
 
 .bq-side-menu.is-collapsed {
-  @apply w-[var(--bq-side-menu--width-collapse)];
+  @apply w-[--bq-side-menu--width-collapse];
 }
 
 /* -------------------------------------------------------------------------- */
@@ -28,7 +29,7 @@
 
 .bq-side-menu--logo {
   @apply sticky top-0 z-[1] p-xs;
-  @apply box-content flex items-center bg-[var(--bq-side-menu--bg-color)] text-[color:var(--bq-side-menu--brand-color)];
+  @apply box-content flex items-center bg-[--bq-side-menu--bg-color] text-[color:--bq-side-menu--brand-color];
 }
 
 /* -------------------------------------------------------------------------- */
@@ -47,38 +48,40 @@
 }
 
 :host([appearance='brand']) {
-  --bq-focus: #f6f6f8;
-  --bq-side-menu--bg-color: theme('colors.ui.brand');
-  --bq-side-menu--brand-color: theme('colors.stroke.inverse');
+  --bq-focus: theme(colors.stroke.alt);
+  --bq-side-menu--bg-color: theme(colors.ui.brand);
+  --bq-side-menu--brand-color: theme(colors.stroke.inverse);
+  --bq-side-menu--border-color: theme(colors.ui.brand);
 
   ::slotted(bq-side-menu-item) {
     --bq-side-menu-item--bg-hover: color-mix(in srgb, var(--bq-ui--brand), var(--bq-hover) 20%);
 
-    --bq-side-menu-item--text-default: theme('textColor.text.alt');
-    --bq-side-menu-item--text-hover: theme('textColor.text.alt');
+    --bq-side-menu-item--text-default: theme(textColor.text.alt);
+    --bq-side-menu-item--text-hover: theme(textColor.text.alt);
   }
 
   .bq-side-menu--footer ::slotted([slot='footer']) {
-    --bq-ui--secondary: theme('colors.transparent');
-    --bq-text--primary: theme('textColor.text.inverse');
+    --bq-ui--secondary: theme(colors.transparent);
+    --bq-text--primary: theme(textColor.text.inverse);
   }
 }
 
 :host([appearance='inverse']) {
-  --bq-side-menu--bg-color: theme('colors.ui.inverse');
-  --bq-side-menu--brand-color: theme('colors.stroke.inverse');
+  --bq-side-menu--bg-color: theme(colors.ui.inverse);
+  --bq-side-menu--brand-color: theme(colors.stroke.inverse);
+  --bq-side-menu--border-color: theme(colors.ui.inverse);
 
   ::slotted(bq-side-menu-item) {
     --bq-side-menu-item--bg-hover: color-mix(in srgb, var(--bq-ui--inverse), var(--bq-hover) 20%);
     --bq-side-menu-item--bg-active: color-mix(in srgb, var(--bq-ui--alt), var(--bq-active) 20%);
 
-    --bq-side-menu-item--text-default: theme('textColor.text.inverse');
-    --bq-side-menu-item--text-hover: theme('textColor.text.inverse');
-    --bq-side-menu-item--text-active: theme('textColor.text.primary');
+    --bq-side-menu-item--text-default: theme(textColor.text.inverse);
+    --bq-side-menu-item--text-hover: theme(textColor.text.inverse);
+    --bq-side-menu-item--text-active: theme(textColor.text.primary);
   }
 
   .bq-side-menu--footer ::slotted([slot='footer']) {
-    --bq-ui--secondary: theme('colors.transparent');
-    --bq-text--primary: theme('textColor.text.inverse');
+    --bq-ui--secondary: theme(colors.transparent);
+    --bq-text--primary: theme(textColor.text.inverse);
   }
 }

--- a/packages/beeq/src/components/side-menu/scss/bq-side-menu.variables.scss
+++ b/packages/beeq/src/components/side-menu/scss/bq-side-menu.variables.scss
@@ -6,9 +6,12 @@
   /**
    * @prop --bq-side-menu--bg-color: Side menu background color
    * @prop --bq-side-menu--brand-color: Side menu logo color
+   * @prop --bq-side-menu--border-color: Side menu border color
    */
   --bq-side-menu--bg-color: theme(colors.ui.primary);
   --bq-side-menu--brand-color: theme(colors.ui.brand);
+  /* stylelint-disable-next-line custom-property-pattern */
+  --bq-side-menu--border-color: var(--bq-neutral-100);
   /**
    * ⚠️ There are two CSS properties been added to the global (:root) scope
    * `--bq-side-menu--width` and `--bq-side-menu--width--collapse`

--- a/packages/beeq/src/components/side-menu/scss/bq-side-menu.variables.scss
+++ b/packages/beeq/src/components/side-menu/scss/bq-side-menu.variables.scss
@@ -7,8 +7,8 @@
    * @prop --bq-side-menu--bg-color: Side menu background color
    * @prop --bq-side-menu--brand-color: Side menu logo color
    */
-  --bq-side-menu--bg-color: theme('colors.ui.alt');
-  --bq-side-menu--brand-color: theme('colors.stroke.brand');
+  --bq-side-menu--bg-color: theme(colors.ui.primary);
+  --bq-side-menu--brand-color: theme(colors.ui.brand);
   /**
    * ⚠️ There are two CSS properties been added to the global (:root) scope
    * `--bq-side-menu--width` and `--bq-side-menu--width--collapse`


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

The side menu background has been changed in Figma. The default variant should now use the `ui--primary` token color. This PR also adds a border style to delimitate the Side Menu with the rest of the page.

## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

N/A

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

https://www.figma.com/file/2VS47PTSkQWJkr7H6DpAdR/BEEQ-Design-System-(v1.0)?type=design&node-id=3991%3A117554&mode=design&t=EQ2925S5dDYCvMpZ-1

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

![CleanShot 2024-04-15 at 12 07 22@2x](https://github.com/Endava/BEEQ/assets/328492/148da325-2cdf-47c5-b37f-d1189de7caf5)


## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
