### PR TITLE
perf(Slider): avoid excessive re-renders on thumb position update

### DIFF
--- a/packages/beeq/src/components/slider/bq-slider.tsx
+++ b/packages/beeq/src/components/slider/bq-slider.tsx
@@ -171,9 +171,9 @@ export class BqSlider {
   // =======================================================
 
   private runUpdates = () => {
+    this.updateProgressTrack();
+    this.syncInputsValue();
     requestAnimationFrame(() => {
-      this.updateProgressTrack();
-      this.syncInputsValue();
       this.setThumbPosition();
     });
   };

--- a/packages/beeq/src/components/slider/bq-slider.tsx
+++ b/packages/beeq/src/components/slider/bq-slider.tsx
@@ -173,6 +173,7 @@ export class BqSlider {
   private runUpdates = () => {
     this.updateProgressTrack();
     this.syncInputsValue();
+
     requestAnimationFrame(() => {
       this.setThumbPosition();
     });

--- a/packages/beeq/src/components/slider/bq-slider.tsx
+++ b/packages/beeq/src/components/slider/bq-slider.tsx
@@ -171,9 +171,11 @@ export class BqSlider {
   // =======================================================
 
   private runUpdates = () => {
-    this.updateProgressTrack();
-    this.syncInputsValue();
-    this.setThumbPosition();
+    requestAnimationFrame(() => {
+      this.updateProgressTrack();
+      this.syncInputsValue();
+      this.setThumbPosition();
+    });
   };
 
   private calculateMinValue = (value: TSliderValue) => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

The purpose of this PR is to enhances the performance of slider component by optimizing the state update logic. Previously, the minThumbPosition and maxThumbPosition properties were being updated during the componentDidLoad() lifecycle hook, which could trigger unnecessary re-renders and impact performance. 

To address this case, the state update logic has been improved to utilize requestAnimationFrame(). This ensures that updates to minThumbPosition and maxThumbPosition are deferred until the next frame render, reducing the potential for excessive re-renders and enhancing overall performance.

## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

Fixes #ISSUE_NUMBER

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
