### PR TITLE
fix(Select): initial value is not displayed when the component load

### DIFF
--- a/packages/beeq/src/components/select/bq-select.tsx
+++ b/packages/beeq/src/components/select/bq-select.tsx
@@ -162,6 +162,10 @@ export class BqSelect {
     this.handleValueChange();
   }
 
+  componentDidRender() {
+    this.syncItemsFromValue();
+  }
+
   // Listeners
   // ==============
 
@@ -262,6 +266,7 @@ export class BqSelect {
     // Sync display label
     const checkedItem = items.filter((item) => item.value === this.value)[0];
     this.displayValue = checkedItem ? this.getOptionLabel(checkedItem) : '';
+    this.inputElem.value = this.displayValue;
   };
 
   private getOptionLabel = (item: HTMLBqOptionElement) => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR fixes an issue on the BqSelect component where the initial value defined is not displayed/reflected in the select input. 

[Code Reproduction URL](https://codesandbox.io/p/sandbox/beeq-select-xhf5c4?layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clv56p48300063p6fm33e1hdy%2522%252C%2522sizes%2522%253A%255B100%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clv56p48300023p6fp7vjfvjc%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clv56p48300033p6f30n1m2v7%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clv56p48300053p6fwtkvbxkq%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B50%252C50%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clv56p48300023p6fp7vjfvjc%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clv56p48300013p6f9pm4sa62%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252Fsrc%252Findex.tsx%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%252C%257B%2522id%2522%253A%2522clv572zz500023p6fvsrdv5s0%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A14%252C%2522startColumn%2522%253A10%252C%2522endLineNumber%2522%253A14%252C%2522endColumn%2522%253A10%257D%255D%252C%2522filepath%2522%253A%2522%252Fcraco.config.ts%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%252C%257B%2522id%2522%253A%2522clv57a4nf00023p6frnqddojr%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A12%252C%2522startColumn%2522%253A24%252C%2522endLineNumber%2522%253A12%252C%2522endColumn%2522%253A24%257D%255D%252C%2522filepath%2522%253A%2522%252Ftsconfig.json%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%255D%252C%2522id%2522%253A%2522clv56p48300023p6fp7vjfvjc%2522%252C%2522activeTabId%2522%253A%2522clv57a4nf00023p6frnqddojr%2522%257D%252C%2522clv56p48300053p6fwtkvbxkq%2522%253A%257B%2522id%2522%253A%2522clv56p48300053p6fwtkvbxkq%2522%252C%2522activeTabId%2522%253A%2522clv57abyi001a3p6fecn9jqaz%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clv56p48300043p6fqweybprk%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522UNASSIGNED_PORT%2522%252C%2522port%2522%253A0%252C%2522path%2522%253A%2522%252F%2522%257D%252C%257B%2522type%2522%253A%2522UNASSIGNED_PORT%2522%252C%2522port%2522%253A0%252C%2522id%2522%253A%2522clv57abyi001a3p6fecn9jqaz%2522%252C%2522mode%2522%253A%2522permanent%2522%257D%255D%257D%252C%2522clv56p48300033p6f30n1m2v7%2522%253A%257B%2522tabs%2522%253A%255B%255D%252C%2522id%2522%253A%2522clv56p48300033p6f30n1m2v7%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Afalse%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D)

## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

Fixes #1016 

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

https://github.com/Endava/BEEQ/assets/328492/654ff54e-650b-4bfd-a5c4-fed3ce3d377b

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
