### PR TITLE
fix(Select): prevent bqClose to propagate further

### DIFF
--- a/packages/beeq/src/components/select/bq-select.tsx
+++ b/packages/beeq/src/components/select/bq-select.tsx
@@ -404,7 +404,11 @@ export class BqSelect {
             removable
             size="xsmall"
             variant="filled"
-            onBqClose={() => this.handleTagRemove(item)}
+            onBqClose={(event) => {
+              // NOTE: prevents triggering bqClose on parent
+              event.stopPropagation();
+              this.handleTagRemove(item);
+            }}
             // Prevent the tag from closing the panel when clicked
             onClick={(ev: MouseEvent) => ev.stopPropagation()}
             exportparts="wrapper:tag__base,prefix:tag__prefix,text:tag__text,btn-close:tag__btn-close"


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->
Stop `bqClose` event from `bq-select` to propagate to parent. This prevents issues when the parent is emitting same event eg _Drawer_.
## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

Fixes #1032

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

https://github.com/Endava/BEEQ/assets/109202804/cda58bcc-4245-4485-a7d3-8debcc42f1d7


## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
