### PR TITLE
fix(select): re-render tags when value change externally

### DIFF
--- a/packages/beeq/src/components/select/__tests__/bq-select.e2e.ts
+++ b/packages/beeq/src/components/select/__tests__/bq-select.e2e.ts
@@ -1,4 +1,5 @@
 import { newE2EPage } from '@stencil/core/testing';
+import { setProperties } from '../../../shared/test-utils';
 
 describe('bq-select', () => {
   it('should render', async () => {
@@ -144,5 +145,51 @@ describe('bq-select', () => {
     // Check that the option is selected
     expect(await page.find(optionSelector)).toHaveAttribute('selected');
     expect(eventEmitter).toHaveReceivedEventTimes(1);
+  });
+
+  it('should render with selected options', async () => {
+    const page = await newE2EPage({
+      html: `
+        <bq-select multiple>
+          <bq-option value="1">Option 1</bq-option>
+          <bq-option value="2">Option 2</bq-option>
+          <bq-option value="3">Option 3</bq-option>
+        </bq-select>
+      `,
+    });
+
+    await setProperties(page, 'bq-select', { value: JSON.stringify(['1', '2']) });
+
+    const selectedValueElements = await page.findAll(`bq-select bq-option[selected]`);
+    const displayTags = await page.findAll('bq-select >>> bq-tag');
+
+    expect(selectedValueElements).toHaveLength(2);
+    expect(displayTags).toHaveLength(2);
+    expect(displayTags[0]).toEqualText('Option 1');
+    expect(displayTags[1]).toEqualText('Option 2');
+  });
+
+  it('should rerender when value is change externally', async () => {
+    const page = await newE2EPage({
+      html: `
+        <bq-select multiple>
+          <bq-option value="1">Option 1</bq-option>
+          <bq-option value="2">Option 2</bq-option>
+          <bq-option value="3">Option 3</bq-option>
+        </bq-select>
+      `,
+    });
+
+    await setProperties(page, 'bq-select', { value: JSON.stringify(['1', '2']) });
+
+    expect(await page.findAll(`bq-select bq-option[selected]`)).toHaveLength(2);
+
+    await setProperties(page, 'bq-select', { value: JSON.stringify(['3']) });
+
+    const displayTags = await page.findAll('bq-select >>> bq-tag');
+
+    expect(await page.findAll(`bq-select bq-option[selected]`)).toHaveLength(1);
+    expect(displayTags).toHaveLength(1);
+    expect(displayTags[0]).toEqualText('Option 3');
   });
 });

--- a/packages/beeq/src/components/select/bq-select.tsx
+++ b/packages/beeq/src/components/select/bq-select.tsx
@@ -1,7 +1,15 @@
 import { Component, Element, Event, EventEmitter, h, Listen, Method, Prop, State, Watch } from '@stencil/core';
 
 import { FloatingUIPlacement } from '../../services/interfaces';
-import { debounce, getTextContent, hasSlotContent, isDefined, isHTMLElement, TDebounce } from '../../shared/utils';
+import {
+  debounce,
+  getTextContent,
+  hasSlotContent,
+  isDefined,
+  isHTMLElement,
+  isString,
+  TDebounce,
+} from '../../shared/utils';
 import { TInputValidation } from '../input/bq-input.types';
 
 export type TSelectValue = string | string[];
@@ -154,6 +162,12 @@ export class BqSelect {
 
   @Watch('value')
   handleValueChange() {
+    if (this.multiple && isString(this.value)) {
+      // NOTE: we ensure that value is an array, changing the value will trigger Watch to execute thus the return
+      this.value = Array.from(JSON.parse(String(this.value)));
+      return;
+    }
+
     this.syncItemsFromValue();
   }
 
@@ -189,10 +203,6 @@ export class BqSelect {
     }
 
     this.handleValueChange();
-  }
-
-  componentDidRender() {
-    this.syncItemsFromValue();
   }
 
   // Listeners
@@ -376,6 +386,8 @@ export class BqSelect {
       const checkedItem = items.filter((item) => item.value === this.value)[0];
       this.displayValue = checkedItem ? this.getOptionLabel(checkedItem) : '';
       this.inputElem.value = this.displayValue ?? '';
+    } else {
+      this.selectedOptions = this.options.filter((item) => this.value?.includes(item.value));
     }
   };
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->
This PR fixes the issue when for bq-select changing value externally does not update display value.
## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

Fixes #1033

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

https://github.com/Endava/BEEQ/assets/109202804/f88c37d1-eb81-48fb-b16d-57851b962efb


## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
