### PR TITLE
fix(Beeq Vue): remove `applyPolyfills()` function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
           command: npx nx affected -t e2e --exclude='*,!tag:core' --parallel=3 --base=$NX_BASE --head=$NX_HEAD --ci --code-coverage --runInBand
       - run:
           name: 📚 Build Storybook
-          command: npx nx affected -t storybook-build --exclude='*,!tag:core' --parallel=3 --base=$NX_BASE --head=$NX_HEAD
+          command: npx nx run beeq:storybook-build --output-style=stream-without-prefixes
       - run:
           name: ⏹️ Stop Nx Cloud Agents
           command: npx nx-cloud stop-all-agents

--- a/packages/beeq-angular/package.json
+++ b/packages/beeq-angular/package.json
@@ -7,7 +7,7 @@
   "module": "dist/esm2015/index.js",
   "types": "index.d.ts",
   "dependencies": {
-    "@beeq/core": "^1.1.0",
+    "@beeq/core": "^1.3.2",
     "tslib": "^2.6.2"
   },
   "peerDependencies": {

--- a/packages/beeq-react/package.json
+++ b/packages/beeq-react/package.json
@@ -7,7 +7,7 @@
   "module": "./src/index.js",
   "types": "./src/index.d.ts",
   "dependencies": {
-    "@beeq/core": "^1.1.0"
+    "@beeq/core": "^1.3.2"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/beeq-vue/package.json
+++ b/packages/beeq-vue/package.json
@@ -6,8 +6,8 @@
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
   "dependencies": {
-    "@beeq/core": "^1.1.0",
-    "tslib": "^2.3.0"
+    "@beeq/core": "^1.3.2",
+    "tslib": "^2.6.2"
   },
   "peerDependencies": {
     "vue": ">=3.3.0"

--- a/packages/beeq-vue/src/plugin.ts
+++ b/packages/beeq-vue/src/plugin.ts
@@ -1,24 +1,22 @@
 import { Plugin } from 'vue';
-import { applyPolyfills, defineCustomElements } from '@beeq/core/dist/loader';
+import { defineCustomElements } from '@beeq/core/dist/loader';
 
 export const BeeqVue: Plugin = {
   async install() {
-    applyPolyfills().then(() => {
-      // @stencil/vue-output-target does not support camelCase event names
-      // so we are attaching a custom event listener to map camelCase to kebab-case event names
-      const camelCaseToKebab = (str: string) => {
-        return str
-          .split(/(?=[A-Z])/)
-          .join('-')
-          .toLowerCase();
-      };
-      defineCustomElements(window, {
-        ael: (el: any, eventName: string, cb: any, opts: any) =>
-          el.addEventListener(camelCaseToKebab(eventName), cb, opts),
-        rel: (el: any, eventName: string, cb: any, opts: any) =>
-          el.removeEventListener(camelCaseToKebab(eventName), cb, opts),
-        ce: (eventName: string, opts: any) => new CustomEvent(camelCaseToKebab(eventName), opts),
-      } as any);
-    });
+    // @stencil/vue-output-target does not support camelCase event names
+    // so we are attaching a custom event listener to map camelCase to kebab-case event names
+    const camelCaseToKebab = (str: string) => {
+      return str
+        .split(/(?=[A-Z])/)
+        .join('-')
+        .toLowerCase();
+    };
+    defineCustomElements(window, {
+      ael: (el: any, eventName: string, cb: any, opts: any) =>
+        el.addEventListener(camelCaseToKebab(eventName), cb, opts),
+      rel: (el: any, eventName: string, cb: any, opts: any) =>
+        el.removeEventListener(camelCaseToKebab(eventName), cb, opts),
+      ce: (eventName: string, opts: any) => new CustomEvent(camelCaseToKebab(eventName), opts),
+    } as any);
   },
 };


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

BEEQ integration with Vue.js is broken, because the latest Stencil version [no longer copies polyfills to the dist OT unless building es5](https://github.com/ionic-team/stencil/pull/5725), this PR aims to fix that.

## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

N/A

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
