### PR TITLE
feat(Drawer): add support for custom footer divider

### DIFF
--- a/packages/beeq/src/components/drawer/_storybook/bq-drawer.stories.tsx
+++ b/packages/beeq/src/components/drawer/_storybook/bq-drawer.stories.tsx
@@ -41,8 +41,8 @@ type Story = StoryObj;
 
 const Template = (args: Args) => {
   const handleOpenDrawer = async () => {
-    const dialogElem = document.querySelector('bq-drawer');
-    await dialogElem.show();
+    const drawerElem = document.querySelector('bq-drawer');
+    await drawerElem.show();
   };
 
   return html`

--- a/packages/beeq/src/components/drawer/_storybook/bq-drawer.stories.tsx
+++ b/packages/beeq/src/components/drawer/_storybook/bq-drawer.stories.tsx
@@ -45,6 +45,10 @@ const Template = (args: Args) => {
     await drawerElem.show();
   };
 
+  const customFooterDivider = args.customFooterDivider
+    ? html`<bq-divider slot="footer-divider" class="mb-m block" stroke-color="stroke--primary" stroke-thickness="1" />`
+    : nothing;
+
   return html`
     <bq-button @bqClick=${handleOpenDrawer}>Open Drawer</bq-button>
     <bq-drawer
@@ -69,7 +73,7 @@ const Template = (args: Args) => {
       </div>
       ${!args.noFooter
         ? html`
-            ${args.customFooterDivider ? html`<bq-divider slot="footer-divider" class="mb-m block" />` : nothing}
+            ${customFooterDivider}
             <div class="flex flex-1 justify-center gap-xs" slot="footer">
               <bq-button appearance="primary" block size="small"> Button </bq-button>
               <bq-button appearance="link" block size="small"> Button </bq-button>
@@ -114,7 +118,7 @@ export const WithBackdrop: Story = {
   },
 };
 
-export const WithCustomDivider: Story = {
+export const WithCustomFooterDivider: Story = {
   render: Template,
   args: {
     open: false,

--- a/packages/beeq/src/components/drawer/_storybook/bq-drawer.stories.tsx
+++ b/packages/beeq/src/components/drawer/_storybook/bq-drawer.stories.tsx
@@ -25,6 +25,7 @@ const meta: Meta = {
     bqAfterClose: { action: 'bqAfterClose' },
     // Not part of the component API
     noFooter: { control: 'boolean', table: { disable: true } },
+    customFooterDivider: { control: 'boolean', table: { disable: true } },
   },
   args: {
     open: false,
@@ -68,6 +69,7 @@ const Template = (args: Args) => {
       </div>
       ${!args.noFooter
         ? html`
+            ${args.customFooterDivider ? html`<bq-divider slot="footer-divider" class="mb-m block" />` : nothing}
             <div class="flex flex-1 justify-center gap-xs" slot="footer">
               <bq-button appearance="primary" block size="small"> Button </bq-button>
               <bq-button appearance="link" block size="small"> Button </bq-button>
@@ -109,5 +111,15 @@ export const WithBackdrop: Story = {
     open: false,
     placement: 'right',
     'enable-backdrop': true,
+  },
+};
+
+export const WithCustomDivider: Story = {
+  render: Template,
+  args: {
+    open: false,
+    placement: 'right',
+    'enable-backdrop': true,
+    customFooterDivider: true,
   },
 };

--- a/packages/beeq/src/components/drawer/bq-drawer.tsx
+++ b/packages/beeq/src/components/drawer/bq-drawer.tsx
@@ -268,7 +268,9 @@ export class BqDrawer {
             ref={(footerElem) => (this.footerElem = footerElem)}
             part="footer"
           >
-            <bq-divider class="mb-m block" stroke-color="ui--secondary" dashed />
+            <slot name="footer-divider">
+              <bq-divider class="mb-m block" stroke-color="ui--secondary" dashed />
+            </slot>
             <slot name="footer" onSlotchange={this.handleFooterSlotChange} />
           </footer>
         </div>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->
Adds possibility to override footer divider. If override is not provided will use the default figma design.
## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->


## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
