### PR TITLE
fix(Date picker): missing value accessor and model config

### DIFF
--- a/packages/beeq/src/tools/angular-value-accessor-config.ts
+++ b/packages/beeq/src/tools/angular-value-accessor-config.ts
@@ -35,7 +35,7 @@ export const angularValueAccessorBindings: ValueAccessorConfig[] = [
   },
   {
     // Text
-    elementSelectors: ['bq-input:not[type="number"]', 'bq-textarea', 'bq-slider[type="range"'],
+    elementSelectors: ['bq-date-picker', 'bq-input:not[type="number"]', 'bq-slider[type="range"', 'bq-textarea'],
     event: 'bqChange',
     targetAttr: 'value',
     type: 'text',

--- a/packages/beeq/src/tools/vue-model-config.ts
+++ b/packages/beeq/src/tools/vue-model-config.ts
@@ -7,7 +7,7 @@ export const vueComponentModels: ComponentModelConfig[] = [
     targetAttr: 'checked',
   },
   {
-    elements: ['bq-input', 'bq-radio-group', 'bq-select', 'bq-slider', 'bq-textarea'],
+    elements: ['bq-date-picker', 'bq-input', 'bq-radio-group', 'bq-select', 'bq-slider', 'bq-textarea'],
     event: 'bqChange',
     targetAttr: 'value',
   },


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

Since the `bq-date-picker` is a form component,  we need to add it to the value accessor (Angular) and model config (Vue), but we missed that when the feature was implemented on #1029.

## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

N/A

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
