### PR TITLE
fix(Slider): range thumbs being stuck when min/max values overlap

### DIFF
--- a/packages/beeq/src/components/slider/bq-slider.tsx
+++ b/packages/beeq/src/components/slider/bq-slider.tsx
@@ -328,6 +328,17 @@ export class BqSlider {
   };
 
   private renderInput = (type: 'max' | 'min', value: number, refCallback: (input: HTMLInputElement) => void) => {
+    // Determine the zIndex value based on the type and the current min and max values.
+    const zIndexValue = (type: 'min' | 'max'): string => {
+      const zIndex = {
+        min: this.minValue === this.min && this.maxValue === this.minValue,
+        max: this.maxValue === this.max && this.minValue === this.maxValue,
+      };
+
+      // If the value of both thumbs is the same as the min or max value, set the zIndex to -1
+      return zIndex[type] ? '-1' : '0';
+    };
+
     return (
       <input
         type="range"
@@ -336,6 +347,7 @@ export class BqSlider {
             true,
           'pointer-events-none': this.isRangeType,
         }}
+        style={{ zIndex: zIndexValue(type) }}
         disabled={this.disabled}
         min={this.min}
         max={this.max}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR fixes the issue on the Slider range, where the thumbs get stuck if the values (min/max) are both the maximum value or the minimum value allowed. As a workaround, we change the zIndex of the min or the max input value used under the hood.

## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

Fixes #1073 

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

https://github.com/Endava/BEEQ/assets/328492/aac856d4-470b-438e-b3de-2ae46830c3ed

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
