### PR TITLE
fix(Input): typo in CSS variables for padding start/end

### DIFF
--- a/packages/beeq/src/components/input/scss/bq-input.variables.scss
+++ b/packages/beeq/src/components/input/scss/bq-input.variables.scss
@@ -45,8 +45,8 @@
   --bq-input--label-text-size: theme(fontSize.s);
   --bq-input--label-text-color: theme(colors.text.primary);
 
-  --bq-input--pading-start: theme(spacing.m);
-  --bq-input--pading-end: theme(spacing.m);
+  --bq-input--padding-start: theme(spacing.m);
+  --bq-input--padding-end: theme(spacing.m);
   --bq-input--paddingY: theme(spacing.s);
 
   --bq-input--text-color: theme(colors.text.primary);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR fixes a regression bug on the Input component where the start/end paddings are missing due to a typo in the CSS custom properties defined.

![CleanShot 2024-06-04 at 10 31 32](https://github.com/Endava/BEEQ/assets/328492/5cd74c23-be43-4d32-b3fa-efb2a559f30b)

## Related Issue
<!-- If this PR is related to an existing issue, please link it here. -->

N/A

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
