### PR TITLE
feat(Select): add support for custom tag display on multiple variant

### DIFF
--- a/packages/beeq/src/components/select/_storybook/bq-select.stories.tsx
+++ b/packages/beeq/src/components/select/_storybook/bq-select.stories.tsx
@@ -1,3 +1,4 @@
+import { useArgs } from '@storybook/preview-api';
 import type { Args, Meta, StoryObj } from '@storybook/web-components';
 import { html, nothing } from 'lit-html';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
@@ -92,47 +93,16 @@ const meta: Meta = {
     customTags: false,
     value: undefined,
     // Not part of the public API, so we don't want to expose it in the docs
-    options: html`
-      <bq-option value="running">
-        <bq-icon slot="prefix" name="sneaker-move"></bq-icon>
-        Running
-      </bq-option>
-
-      <bq-option value="hiking">
-        <bq-icon slot="prefix" name="boot"></bq-icon>
-        Hiking
-      </bq-option>
-
-      <bq-option value="biking">
-        <bq-icon slot="prefix" name="person-simple-bike"></bq-icon>
-        Biking
-      </bq-option>
-
-      <bq-option value="swimming">
-        <bq-icon slot="prefix" name="swimming-pool"></bq-icon>
-        Swimming
-      </bq-option>
-
-      <bq-option value="pizza">
-        <bq-icon slot="prefix" name="pizza"></bq-icon>
-        Pizza
-      </bq-option>
-
-      <bq-option value="hamburger">
-        <bq-icon slot="prefix" name="hamburger"></bq-icon>
-        Hamburger
-      </bq-option>
-
-      <bq-option value="cookie">
-        <bq-icon slot="prefix" name="cookie"></bq-icon>
-        Cookie
-      </bq-option>
-
-      <bq-option value="ice-cream">
-        <bq-icon slot="prefix" name="ice-cream"></bq-icon>
-        Ice-cream
-      </bq-option>
-    `,
+    options: [
+      { label: 'Running', value: 'running', icon: 'sneaker-move' },
+      { label: 'Hiking', value: 'hiking', icon: 'boot' },
+      { label: 'Biking', value: 'biking', icon: 'person-simple-bike' },
+      { label: 'Swimming', value: 'swimming', icon: 'swimming-pool' },
+      { label: 'Pizza', value: 'pizza', icon: 'pizza' },
+      { label: 'Hamburger', value: 'hamburger', icon: 'hamburger' },
+      { label: 'Cookie', value: 'cookie', icon: 'cookie' },
+      { label: 'Ice-cream', value: 'ice-cream', icon: 'ice-cream' },
+    ],
   },
 };
 export default meta;
@@ -140,6 +110,13 @@ export default meta;
 type Story = StoryObj;
 
 const Template = (args: Args) => {
+  const [, updateArgs] = useArgs();
+
+  const onSelect = (event) => {
+    updateArgs({ value: event.detail.value });
+    args.bqSelect(event);
+  };
+
   const tooltipTemplate = args.hasLabelTooltip
     ? html`
         <bq-tooltip class="ms-xs">
@@ -148,11 +125,13 @@ const Template = (args: Args) => {
         </bq-tooltip>
       `
     : nothing;
+
   const labelTemplate = html`
     <label class="flex flex-grow items-center" slot=${ifDefined(!args.optionalLabel ? 'label' : null)}>
       Select label ${tooltipTemplate}
     </label>
   `;
+
   const label = !args.optionalLabel
     ? labelTemplate
     : html`
@@ -161,11 +140,12 @@ const Template = (args: Args) => {
           <span class="text-text-secondary">Optional</span>
         </div>
       `;
+
   const style = args.hasLabelTooltip
     ? html`
         <style>
           bq-select {
-            width: 75vw;
+            inline-size: 75vw;
           }
         </style>
       `
@@ -197,23 +177,40 @@ const Template = (args: Args) => {
       validation-status=${args['validation-status']}
       value=${args.multiple ? ifDefined(JSON.stringify(args.value)) : args.value}
       @bqBlur=${args.bqBlur}
-      @bqSelect=${args.bqSelect}
+      @bqSelect=${args.customTags ? onSelect : args.bqSelect}
       @bqClear=${args.bqClear}
       @bqFocus=${args.bqFocus}
     >
       ${args.customTags
-        ? html`${args.value.map(
-            (value) =>
-              html`<bq-tag
-                size="xsmall"
-                variant="filled"
-                slot="tags"
-                class="[&::part(text)]:text-nowrap [&::part(text)]:leading-small"
-              >
-                <bq-icon name=${value} slot="prefix"></bq-icon>
-                ${value}
-              </bq-tag>`,
-          )}`
+        ? html`${args.options
+            .filter((option) => args.value.includes(option.value))
+            .map((option, index) => {
+              if (index < args['max-tags-visible'] || args['max-tags-visible'] < 0) {
+                return html`<bq-tag
+                  key=${option.value}
+                  size="xsmall"
+                  variant="filled"
+                  slot="tags"
+                  class="[&::part(text)]:text-nowrap [&::part(text)]:leading-small"
+                >
+                  <bq-icon name=${option.icon} slot="prefix"></bq-icon>
+                  ${option.value}
+                </bq-tag>`;
+              } else if (index === args['max-tags-visible']) {
+                return html`
+                  <bq-tag
+                    key="more"
+                    size="xsmall"
+                    variant="filled"
+                    slot="tags"
+                    class="[&::part(text)]:text-nowrap [&::part(text)]:leading-small"
+                  >
+                    +${args.value.length - index}
+                  </bq-tag>
+                `;
+              }
+              return nothing;
+            })}`
         : nothing}
       ${!args.noLabel ? label : nothing}
       ${args.prefix ? html`<bq-icon name="user-circle" slot="prefix"></bq-icon>` : nothing}
@@ -226,7 +223,13 @@ const Template = (args: Args) => {
             </span>
           `
         : nothing}
-      ${args.options}
+      ${args.options.map(
+        (option) => html`
+          <bq-option value=${option.value}>
+            <bq-icon slot="prefix" name=${option.icon}></bq-icon> ${option.label}
+          </bq-option>
+        `,
+      )}
     </bq-select>
   `;
 };
@@ -269,7 +272,7 @@ export const Multiple: Story = {
   args: {
     'keep-open-on-select': true,
     multiple: true,
-    value: ['biking', 'ice-cream'],
+    value: ['running', 'biking', 'pizza'],
   },
 };
 
@@ -279,7 +282,7 @@ export const MultipleCustomRender: Story = {
     'keep-open-on-select': true,
     multiple: true,
     customTags: true,
-    value: ['pizza', 'ice-cream'],
+    value: ['running', 'biking', 'pizza'],
   },
 };
 

--- a/packages/beeq/src/components/select/_storybook/bq-select.stories.tsx
+++ b/packages/beeq/src/components/select/_storybook/bq-select.stories.tsx
@@ -117,6 +117,11 @@ const Template = (args: Args) => {
     args.bqSelect(event);
   };
 
+  const onClear = (event) => {
+    updateArgs({ value: [] });
+    args.bqClear(event);
+  };
+
   const tooltipTemplate = args.hasLabelTooltip
     ? html`
         <bq-tooltip class="ms-xs">
@@ -178,7 +183,7 @@ const Template = (args: Args) => {
       value=${args.multiple ? ifDefined(JSON.stringify(args.value)) : args.value}
       @bqBlur=${args.bqBlur}
       @bqSelect=${args.customTags ? onSelect : args.bqSelect}
-      @bqClear=${args.bqClear}
+      @bqClear=${args.customTags ? onClear : args.bqClear}
       @bqFocus=${args.bqFocus}
     >
       ${args.customTags

--- a/packages/beeq/src/components/select/_storybook/bq-select.stories.tsx
+++ b/packages/beeq/src/components/select/_storybook/bq-select.stories.tsx
@@ -204,7 +204,12 @@ const Template = (args: Args) => {
       ${args.customTags
         ? html`${args.value.map(
             (value) =>
-              html`<bq-tag size="xsmall" variant="filled" slot="tags">
+              html`<bq-tag
+                size="xsmall"
+                variant="filled"
+                slot="tags"
+                class="[&::part(text)]:text-nowrap [&::part(text)]:leading-small"
+              >
                 <bq-icon name=${value} slot="prefix"></bq-icon>
                 ${value}
               </bq-tag>`,
@@ -264,7 +269,7 @@ export const Multiple: Story = {
   args: {
     'keep-open-on-select': true,
     multiple: true,
-    value: ['running', 'biking', 'pizza'],
+    value: ['biking', 'ice-cream'],
   },
 };
 
@@ -274,7 +279,7 @@ export const MultipleCustomRender: Story = {
     'keep-open-on-select': true,
     multiple: true,
     customTags: true,
-    value: ['pizza', 'hamburger', 'cookie'],
+    value: ['pizza', 'ice-cream'],
   },
 };
 

--- a/packages/beeq/src/components/select/_storybook/bq-select.stories.tsx
+++ b/packages/beeq/src/components/select/_storybook/bq-select.stories.tsx
@@ -64,6 +64,7 @@ const meta: Meta = {
     optionalLabel: { control: 'boolean', table: { disable: true } },
     prefix: { control: 'boolean', table: { disable: true } },
     suffix: { control: 'boolean', table: { disable: true } },
+    customTags: { control: 'boolean', table: { disable: true } },
     options: { control: 'text', table: { disable: true } },
   },
   args: {
@@ -88,6 +89,7 @@ const meta: Meta = {
     readonly: false,
     required: false,
     'validation-status': 'none',
+    customTags: false,
     value: undefined,
     // Not part of the public API, so we don't want to expose it in the docs
     options: html`
@@ -199,6 +201,15 @@ const Template = (args: Args) => {
       @bqClear=${args.bqClear}
       @bqFocus=${args.bqFocus}
     >
+      ${args.customTags
+        ? html`${args.value.map(
+            (value) =>
+              html`<bq-tag size="xsmall" variant="filled" slot="tags">
+                <bq-icon name=${value} slot="prefix"></bq-icon>
+                ${value}
+              </bq-tag>`,
+          )}`
+        : nothing}
       ${!args.noLabel ? label : nothing}
       ${args.prefix ? html`<bq-icon name="user-circle" slot="prefix"></bq-icon>` : nothing}
       ${args.suffix ? html`<bq-icon name="arrow-down" slot="suffix"></bq-icon>` : nothing}
@@ -254,6 +265,16 @@ export const Multiple: Story = {
     'keep-open-on-select': true,
     multiple: true,
     value: ['running', 'biking', 'pizza'],
+  },
+};
+
+export const MultipleCustomRender: Story = {
+  render: Template,
+  args: {
+    'keep-open-on-select': true,
+    multiple: true,
+    customTags: true,
+    value: ['pizza', 'hamburger', 'cookie'],
   },
 };
 

--- a/packages/beeq/src/components/select/bq-select.tsx
+++ b/packages/beeq/src/components/select/bq-select.tsx
@@ -517,7 +517,7 @@ export class BqSelect {
                   class="me-xs2 flex flex-1 gap-xs2 [&>bq-tag::part(text)]:text-nowrap [&>bq-tag::part(text)]:leading-small [&>bq-tag]:inline-flex"
                   part="tags"
                 >
-                  {this.displayTags}
+                  <slot name="tags">{this.displayTags}</slot>
                 </span>
               )}
               {/* HTML Input */}

--- a/packages/beeq/src/components/select/bq-select.tsx
+++ b/packages/beeq/src/components/select/bq-select.tsx
@@ -523,7 +523,7 @@ export class BqSelect {
               {/* HTML Input */}
               <input
                 id={this.name || this.fallbackInputId}
-                class="bq-select__control--input w-full flex-grow"
+                class="bq-select__control--input flex-grow is-full"
                 autoComplete="off"
                 autoCapitalize="off"
                 autoFocus={this.autofocus}

--- a/packages/beeq/src/components/select/bq-select.tsx
+++ b/packages/beeq/src/components/select/bq-select.tsx
@@ -513,10 +513,7 @@ export class BqSelect {
             <div class="flex flex-1 overflow-x-auto" part="input-outline">
               {/* Display selected values using BqTags for multiple selection */}
               {this.multiple && (
-                <span
-                  class="me-xs2 flex flex-1 gap-xs2 [&>bq-tag::part(text)]:text-nowrap [&>bq-tag::part(text)]:leading-small [&>bq-tag]:inline-flex"
-                  part="tags"
-                >
+                <span class="bq-select__tags" part="tags">
                   <slot name="tags">{this.displayTags}</slot>
                 </span>
               )}

--- a/packages/beeq/src/components/select/scss/bq-select.scss
+++ b/packages/beeq/src/components/select/scss/bq-select.scss
@@ -13,12 +13,12 @@
 /* -------------------------------------------------------------------------- */
 
 .bq-select__label {
-  @apply mb-[--bq-select--label-margin-bottom] flex items-center;
+  @apply flex items-center [margin-block-end:--bq-select--label-margin-bottom];
   @apply text-[length:--bq-select--label-text-size] text-[color:--bq-select--label-text-color];
 }
 
 .bq-select__helper-text {
-  @apply mt-[--bq-select--helper-margin-top] text-[length:--bq-select--helper-text-size] text-[color:--bq-select--helper-text-color];
+  @apply text-[length:--bq-select--helper-text-size] text-[color:--bq-select--helper-text-color] [margin-block-start:--bq-select--helper-margin-top];
 }
 
 .bq-select__helper-text.validation-error {
@@ -50,11 +50,11 @@
 }
 
 .bq-select__control {
-  @apply flex w-full items-center transition-[border-color,box-shadow];
+  @apply flex items-center transition-[border-color,box-shadow] [inline-size:100%];
   // Border
   @apply rounded-[--bq-select--border-radius] border-[length:--bq-select--border-width] border-[color:--bq-select--border-color];
   // Padding
-  @apply py-[--bq-select--paddingY] pe-[--bq-select--padding-end] ps-[--bq-select--padding-start];
+  @apply pe-[--bq-select--padding-end] ps-[--bq-select--padding-start] [padding-block:--bq-select--paddingY];
   // Text
   @apply select-none text-[length:--bq-select--text-size] text-[color:--bq-select--text-color] placeholder:text-[color:--bq-select--text-placeholder-color];
   // Hover
@@ -113,7 +113,7 @@
 
 .bq-select__control--input {
   @apply flex-auto cursor-[inherit] select-none appearance-none bg-[inherit] font-[inherit] text-[length:inherit] text-[color:inherit];
-  @apply m-0 min-h-[--bq-select--icon-size] min-w-[0] border-none p-0 focus:outline-none focus-visible:outline-none;
+  @apply m-0 border-none p-0 [min-block-size:--bq-select--icon-size] [min-inline-size:0px] focus:outline-none focus-visible:outline-none;
 
   box-shadow: none;
   font-weight: inherit;
@@ -130,7 +130,7 @@
   --bq-ring-offset-width: initial;
   --bq-ring-color-focus: initial;
 
-  @apply h-auto rounded-xs border-none p-0;
+  @apply rounded-xs border-none p-0 [block-size:auto];
 }
 
 /* -------------------------------------------------------------------------- */

--- a/packages/beeq/src/components/select/scss/bq-select.scss
+++ b/packages/beeq/src/components/select/scss/bq-select.scss
@@ -13,12 +13,12 @@
 /* -------------------------------------------------------------------------- */
 
 .bq-select__label {
-  @apply flex items-center [margin-block-end:--bq-select--label-margin-bottom];
+  @apply flex items-center m-be-[--bq-select--label-margin-bottom];
   @apply text-[length:--bq-select--label-text-size] text-[color:--bq-select--label-text-color];
 }
 
 .bq-select__helper-text {
-  @apply text-[length:--bq-select--helper-text-size] text-[color:--bq-select--helper-text-color] [margin-block-start:--bq-select--helper-margin-top];
+  @apply text-[length:--bq-select--helper-text-size] text-[color:--bq-select--helper-text-color] m-bs-[--bq-select--helper-margin-top];
 }
 
 .bq-select__helper-text.validation-error {
@@ -50,11 +50,11 @@
 }
 
 .bq-select__control {
-  @apply flex items-center transition-[border-color,box-shadow] [inline-size:100%];
+  @apply flex items-center transition-[border-color,box-shadow] is-full;
   // Border
   @apply rounded-[--bq-select--border-radius] border-[length:--bq-select--border-width] border-[color:--bq-select--border-color];
   // Padding
-  @apply pe-[--bq-select--padding-end] ps-[--bq-select--padding-start] [padding-block:--bq-select--paddingY];
+  @apply pe-[--bq-select--padding-end] ps-[--bq-select--padding-start] p-b-[var(--bq-select--paddingY)];
   // Text
   @apply select-none text-[length:--bq-select--text-size] text-[color:--bq-select--text-color] placeholder:text-[color:--bq-select--text-placeholder-color];
   // Hover
@@ -113,7 +113,7 @@
 
 .bq-select__control--input {
   @apply flex-auto cursor-[inherit] select-none appearance-none bg-[inherit] font-[inherit] text-[length:inherit] text-[color:inherit];
-  @apply m-0 border-none p-0 [min-block-size:--bq-select--icon-size] [min-inline-size:0px] focus:outline-none focus-visible:outline-none;
+  @apply m-0 border-none p-0 min-bs-[var(--bq-select--icon-size)] min-is-0 focus:outline-none focus-visible:outline-none;
 
   box-shadow: none;
   font-weight: inherit;
@@ -130,7 +130,7 @@
   --bq-ring-offset-width: initial;
   --bq-ring-color-focus: initial;
 
-  @apply rounded-xs border-none p-0 [block-size:auto];
+  @apply rounded-xs border-none p-0 bs-auto;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/packages/beeq/src/components/select/scss/bq-select.scss
+++ b/packages/beeq/src/components/select/scss/bq-select.scss
@@ -150,6 +150,19 @@
   @apply ms-[--bq-select--gap] transition-transform duration-300 ease-in-out;
 }
 
+.bq-select__tags {
+  @apply me-xs2 flex flex-1 gap-xs2;
+
+  bq-tag,
+  ::slotted(bq-tag) {
+    @apply inline-flex;
+  }
+
+  bq-tag::part(text) {
+    @apply text-nowrap leading-small;
+  }
+}
+
 /* -------------------------------------------------------------------------- */
 /*                         Slotted and internal icons                         */
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->
Adds support for custom tag display when bq-select is multiple

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->
<img width="1178" alt="image" src="https://github.com/Endava/BEEQ/assets/109202804/2ae9d551-6f50-490e-b2b4-f01c73e6e8e7">

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
