### PR TITLE
feat(Drawer): deprecate `placement` and add `position` property

### DIFF
--- a/packages/beeq/src/components.d.ts
+++ b/packages/beeq/src/components.d.ts
@@ -16,7 +16,7 @@ import { FloatingUIPlacement } from "./services/interfaces";
 import { TInputType, TInputValidation, TInputValue } from "./components/input/bq-input.types";
 import { TDialogBorderRadius, TDialogFooterAppearance, TDialogSize } from "./components/dialog/bq-dialog.types";
 import { TDividerOrientation, TDividerStrokeLinecap, TDividerTitleAlignment } from "./components/divider/bq-divider.types";
-import { TDrawerPlacement } from "./components/drawer/bq-drawer.types";
+import { TDrawerPlacement, TDrawerPosition } from "./components/drawer/bq-drawer.types";
 import { TEmptyStateSize } from "./components/empty-state/bq-empty-state.types";
 import { TIconWeight } from "./components/icon/bq-icon.types";
 import { TNotificationBorderRadius, TNotificationType } from "./components/notification/bq-notification.types";
@@ -45,7 +45,7 @@ export { FloatingUIPlacement } from "./services/interfaces";
 export { TInputType, TInputValidation, TInputValue } from "./components/input/bq-input.types";
 export { TDialogBorderRadius, TDialogFooterAppearance, TDialogSize } from "./components/dialog/bq-dialog.types";
 export { TDividerOrientation, TDividerStrokeLinecap, TDividerTitleAlignment } from "./components/divider/bq-divider.types";
-export { TDrawerPlacement } from "./components/drawer/bq-drawer.types";
+export { TDrawerPlacement, TDrawerPosition } from "./components/drawer/bq-drawer.types";
 export { TEmptyStateSize } from "./components/empty-state/bq-empty-state.types";
 export { TIconWeight } from "./components/icon/bq-icon.types";
 export { TNotificationBorderRadius, TNotificationType } from "./components/notification/bq-notification.types";
@@ -546,9 +546,13 @@ export namespace Components {
          */
         "open": boolean;
         /**
-          * Defines the position of the drawer
+          * @deprecated Defines the position of the drawer
          */
         "placement": TDrawerPlacement;
+        /**
+          * Defines the position of the drawer
+         */
+        "position": TDrawerPosition;
         /**
           * Method to be called to show the drawer component
          */
@@ -2834,9 +2838,13 @@ declare namespace LocalJSX {
          */
         "open"?: boolean;
         /**
-          * Defines the position of the drawer
+          * @deprecated Defines the position of the drawer
          */
         "placement"?: TDrawerPlacement;
+        /**
+          * Defines the position of the drawer
+         */
+        "position"?: TDrawerPosition;
     }
     interface BqDropdown {
         /**

--- a/packages/beeq/src/components/drawer/_storybook/bq-drawer.stories.tsx
+++ b/packages/beeq/src/components/drawer/_storybook/bq-drawer.stories.tsx
@@ -2,7 +2,7 @@ import type { Args, Meta, StoryObj } from '@storybook/web-components';
 import { html, nothing } from 'lit-html';
 
 import mdx from './bq-drawer.mdx';
-import { DRAWER_PLACEMENT } from '../bq-drawer.types';
+import { DRAWER_POSITIONS } from '../bq-drawer.types';
 
 const meta: Meta = {
   title: 'Components/Drawer',
@@ -13,11 +13,11 @@ const meta: Meta = {
     },
   },
   argTypes: {
-    open: { control: 'boolean' },
-    placement: { control: 'select', options: [...DRAWER_PLACEMENT] },
+    'enable-backdrop': { control: 'boolean' },
     'close-on-click-outside': { control: 'boolean' },
     'close-on-esc': { control: 'boolean' },
-    'enable-backdrop': { control: 'boolean' },
+    open: { control: 'boolean' },
+    position: { control: 'select', options: [...DRAWER_POSITIONS] },
     // Events
     bqOpen: { action: 'bqOpen' },
     bqClose: { action: 'bqClose' },
@@ -29,7 +29,7 @@ const meta: Meta = {
   },
   args: {
     open: false,
-    placement: 'right',
+    position: 'end',
     'close-on-click-outside': false,
     'close-on-esc': false,
     'enable-backdrop': false,
@@ -59,11 +59,11 @@ const Template = (args: Args) => {
   return html`
     <bq-button @bqClick=${handleOpenDrawer}>Open Drawer</bq-button>
     <bq-drawer
-      placement=${args.placement}
-      ?open=${args.open}
       ?close-on-click-outside=${args['close-on-click-outside']}
       ?close-on-esc=${args['close-on-esc']}
       ?enable-backdrop=${args['enable-backdrop']}
+      ?open=${args.open}
+      position=${args.position}
       @bqClose=${args.bqClose}
       @bqOpen=${args.bqOpen}
       @bqAfterOpen=${args.bqAfterOpen}
@@ -102,10 +102,11 @@ export const NoFooter: Story = {
   },
 };
 
-export const Placement: Story = {
+export const Position: Story = {
   render: Template,
   args: {
-    placement: 'right',
+    open: false,
+    position: 'start',
   },
 };
 

--- a/packages/beeq/src/components/drawer/bq-drawer.types.ts
+++ b/packages/beeq/src/components/drawer/bq-drawer.types.ts
@@ -1,2 +1,5 @@
+export const DRAWER_POSITIONS = ['start', 'end'] as const;
+export type TDrawerPosition = (typeof DRAWER_POSITIONS)[number];
+// !⚠️ Note: `placement` is deprecated and it will be removed in the future
 export const DRAWER_PLACEMENT = ['left', 'right'] as const;
 export type TDrawerPlacement = (typeof DRAWER_PLACEMENT)[number];

--- a/packages/beeq/src/components/drawer/readme.md
+++ b/packages/beeq/src/components/drawer/readme.md
@@ -7,13 +7,14 @@
 
 ## Properties
 
-| Property              | Attribute                | Description                                                        | Type                | Default     |
-| --------------------- | ------------------------ | ------------------------------------------------------------------ | ------------------- | ----------- |
-| `closeOnClickOutside` | `close-on-click-outside` | If true, the drawer will not close when clicking outside the panel | `boolean`           | `false`     |
-| `closeOnEsc`          | `close-on-esc`           | If true, the dialog will not close when the [Esc] key is pressed   | `boolean`           | `false`     |
-| `enableBackdrop`      | `enable-backdrop`        | If true, the backdrop overlay will be shown when the drawer opens  | `boolean`           | `false`     |
-| `open`                | `open`                   | If true, the drawer component will be shown                        | `boolean`           | `undefined` |
-| `placement`           | `placement`              | Defines the position of the drawer                                 | `"left" \| "right"` | `'right'`   |
+| Property              | Attribute                | Description                                                                                  | Type                | Default     |
+| --------------------- | ------------------------ | -------------------------------------------------------------------------------------------- | ------------------- | ----------- |
+| `closeOnClickOutside` | `close-on-click-outside` | If true, the drawer will not close when clicking outside the panel                           | `boolean`           | `false`     |
+| `closeOnEsc`          | `close-on-esc`           | If true, the dialog will not close when the [Esc] key is pressed                             | `boolean`           | `false`     |
+| `enableBackdrop`      | `enable-backdrop`        | If true, the backdrop overlay will be shown when the drawer opens                            | `boolean`           | `false`     |
+| `open`                | `open`                   | If true, the drawer component will be shown                                                  | `boolean`           | `undefined` |
+| `placement`           | `placement`              | <span style="color:red">**[DEPRECATED]**</span> Defines the position of the drawer<br/><br/> | `"left" \| "right"` | `'right'`   |
+| `position`            | `position`               | Defines the position of the drawer                                                           | `"end" \| "start"`  | `'end'`     |
 
 
 ## Events


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

We have moved from physical CSS properties to logical properties and to align with that we are deprecating the `placement` property in favor of the position prop with `start` | `end` values.
> With `placement` we were using `right` and `left` values which are no longer applicable in the context of using CSS logical properties.

## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

Fixes #ISSUE_NUMBER

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
