### PR TITLE
refactor(Accordion): use CSS logical properties instead of physical values

### DIFF
--- a/packages/beeq/src/components.d.ts
+++ b/packages/beeq/src/components.d.ts
@@ -78,6 +78,10 @@ export namespace Components {
          */
         "expanded": boolean;
         /**
+          * Animation is set through JS when the browser does not support CSS calc-size() If true, the accordion animation, will be disabled. No animation will be applied.
+         */
+        "noAnimation": boolean;
+        /**
           * If true accordion expand icon is rotate 180deg when expanded
          */
         "rotate": boolean;
@@ -99,6 +103,10 @@ export namespace Components {
           * If true multiple accordions can be expanded at the same time
          */
         "multiple": boolean;
+        /**
+          * Animation is set through JS when the browser does not support CSS calc-size() If true, the accordion animation, will be disabled. No animation will be applied.
+         */
+        "noAnimation": boolean;
         /**
           * The size of accordion to be applied to all accordions
          */
@@ -2271,6 +2279,10 @@ declare namespace LocalJSX {
          */
         "expanded"?: boolean;
         /**
+          * Animation is set through JS when the browser does not support CSS calc-size() If true, the accordion animation, will be disabled. No animation will be applied.
+         */
+        "noAnimation"?: boolean;
+        /**
           * Handler to be called after the accordion is closed
          */
         "onBqAfterClose"?: (event: BqAccordionCustomEvent<HTMLBqAccordionElement>) => void;
@@ -2317,6 +2329,10 @@ declare namespace LocalJSX {
           * If true multiple accordions can be expanded at the same time
          */
         "multiple"?: boolean;
+        /**
+          * Animation is set through JS when the browser does not support CSS calc-size() If true, the accordion animation, will be disabled. No animation will be applied.
+         */
+        "noAnimation"?: boolean;
         /**
           * The size of accordion to be applied to all accordions
          */

--- a/packages/beeq/src/components/accordion-group/_storybook/bq-accordion-group.stories.tsx
+++ b/packages/beeq/src/components/accordion-group/_storybook/bq-accordion-group.stories.tsx
@@ -1,5 +1,6 @@
 import type { Args, Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 import mdx from '../../accordion/_storybook/bq-accordion.mdx';
 import { ACCORDION_APPEARANCE, ACCORDION_SIZE } from '../../accordion/bq-accordion.types';
@@ -15,6 +16,7 @@ const meta: Meta = {
   argTypes: {
     appearance: { control: 'select', options: [...ACCORDION_APPEARANCE] },
     'expand-all': { control: 'boolean' },
+    'no-animation': { control: 'boolean' },
     multiple: { control: 'boolean' },
     size: { control: 'select', options: [...ACCORDION_SIZE] },
     text: { control: 'text', table: { disable: true } },
@@ -22,6 +24,7 @@ const meta: Meta = {
   args: {
     appearance: 'filled',
     'expand-all': false,
+    'no-animation': false,
     multiple: false,
     size: 'medium',
     text: 'Header',
@@ -34,10 +37,11 @@ type Story = StoryObj;
 export const Group: Story = {
   render: (args: Args) => html`
     <bq-accordion-group
+      appearance=${ifDefined(args.appearance)}
       ?expand-all=${args['expand-all']}
+      ?no-animation=${args['no-animation']}
       ?multiple=${args.multiple}
-      size=${args.size}
-      appearance=${args.appearance}
+      size=${ifDefined(args.size)}
     >
       <bq-accordion size=${args.size}>
         <span slot="header">${args.text}</span>

--- a/packages/beeq/src/components/accordion-group/bq-accordion-group.tsx
+++ b/packages/beeq/src/components/accordion-group/bq-accordion-group.tsx
@@ -27,14 +27,20 @@ export class BqAccordionGroup {
   // Public Property API
   // ========================
 
+  /** The appearance style of accordion to be applied to all accordions */
+  @Prop({ reflect: true, mutable: true }) appearance: TAccordionAppearance = 'filled';
+
   /** If true all accordions are expanded */
   @Prop({ reflect: true }) expandAll: boolean;
 
+  /**
+   * Animation is set through JS when the browser does not support CSS calc-size()
+   * If true, the accordion animation, will be disabled. No animation will be applied.
+   */
+  @Prop({ reflect: true }) noAnimation: boolean = false;
+
   /** If true multiple accordions can be expanded at the same time */
   @Prop({ reflect: true }) multiple: boolean = false;
-
-  /** The appearance style of accordion to be applied to all accordions */
-  @Prop({ reflect: true, mutable: true }) appearance: TAccordionAppearance = 'filled';
 
   /** The size of accordion to be applied to all accordions */
   @Prop({ reflect: true, mutable: true }) size: TAccordionSize = 'medium';
@@ -42,8 +48,9 @@ export class BqAccordionGroup {
   // Prop lifecycle events
   // =======================
 
-  @Watch('expandAll')
   @Watch('appearance')
+  @Watch('expandAll')
+  @Watch('noAnimation')
   @Watch('size')
   checkPropValues() {
     this.bqAccordionElements.forEach((bqAccordionElement) => {
@@ -52,6 +59,7 @@ export class BqAccordionGroup {
         bqAccordionElement.expanded = this.expandAll;
       }
       bqAccordionElement.appearance = this.appearance;
+      bqAccordionElement.noAnimation = this.noAnimation;
       bqAccordionElement.size = this.size;
     });
   }

--- a/packages/beeq/src/components/accordion-group/readme.md
+++ b/packages/beeq/src/components/accordion-group/readme.md
@@ -7,12 +7,13 @@
 
 ## Properties
 
-| Property     | Attribute    | Description                                                       | Type                  | Default     |
-| ------------ | ------------ | ----------------------------------------------------------------- | --------------------- | ----------- |
-| `appearance` | `appearance` | The appearance style of accordion to be applied to all accordions | `"filled" \| "ghost"` | `'filled'`  |
-| `expandAll`  | `expand-all` | If true all accordions are expanded                               | `boolean`             | `undefined` |
-| `multiple`   | `multiple`   | If true multiple accordions can be expanded at the same time      | `boolean`             | `false`     |
-| `size`       | `size`       | The size of accordion to be applied to all accordions             | `"medium" \| "small"` | `'medium'`  |
+| Property      | Attribute      | Description                                                                                                                                                     | Type                  | Default     |
+| ------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- | ----------- |
+| `appearance`  | `appearance`   | The appearance style of accordion to be applied to all accordions                                                                                               | `"filled" \| "ghost"` | `'filled'`  |
+| `expandAll`   | `expand-all`   | If true all accordions are expanded                                                                                                                             | `boolean`             | `undefined` |
+| `multiple`    | `multiple`     | If true multiple accordions can be expanded at the same time                                                                                                    | `boolean`             | `false`     |
+| `noAnimation` | `no-animation` | Animation is set through JS when the browser does not support CSS calc-size() If true, the accordion animation, will be disabled. No animation will be applied. | `boolean`             | `false`     |
+| `size`        | `size`         | The size of accordion to be applied to all accordions                                                                                                           | `"medium" \| "small"` | `'medium'`  |
 
 
 ## Shadow Parts

--- a/packages/beeq/src/components/accordion-group/scss/bq-accordion-group.scss
+++ b/packages/beeq/src/components/accordion-group/scss/bq-accordion-group.scss
@@ -6,4 +6,7 @@
 
 :host {
   @apply block;
+
+  direction: rtl;
+  writing-mode: vertical-rl;
 }

--- a/packages/beeq/src/components/accordion-group/scss/bq-accordion-group.scss
+++ b/packages/beeq/src/components/accordion-group/scss/bq-accordion-group.scss
@@ -6,7 +6,4 @@
 
 :host {
   @apply block;
-
-  direction: rtl;
-  writing-mode: vertical-rl;
 }

--- a/packages/beeq/src/components/accordion/_storybook/bq-accordion.stories.tsx
+++ b/packages/beeq/src/components/accordion/_storybook/bq-accordion.stories.tsx
@@ -23,6 +23,7 @@ const meta: Meta = {
     // Event handlers
     bqBlur: { action: 'bqBlur' },
     bqFocus: { action: 'bqFocus' },
+    bqClick: { action: 'bqClick' },
     bqOpen: { action: 'bqOpen' },
     bqAfterOpen: { action: 'bqAfterOpen' },
     bqClose: { action: 'bqClose' },
@@ -55,6 +56,7 @@ const Template = (args: Args) => html`
     size=${args.size}
     @bqBlur=${args.bqBlur}
     @bqFocus=${args.bqFocus}
+    @bqClick=${args.bqClick}
     @bqOpen=${args.bqOpen}
     @bqAfterOpen=${args.bqAfterOpen}
     @bqClose=${args.bqClose}

--- a/packages/beeq/src/components/accordion/_storybook/bq-accordion.stories.tsx
+++ b/packages/beeq/src/components/accordion/_storybook/bq-accordion.stories.tsx
@@ -17,6 +17,7 @@ const meta: Meta = {
     appearance: { control: 'select', options: [...ACCORDION_APPEARANCE] },
     disabled: { control: 'boolean' },
     expanded: { control: 'boolean' },
+    'no-animation': { control: 'boolean' },
     rotate: { control: 'boolean' },
     size: { control: 'select', options: [...ACCORDION_SIZE] },
     // Event handlers
@@ -33,6 +34,7 @@ const meta: Meta = {
     appearance: 'filled',
     disabled: false,
     expanded: false,
+    'no-animation': false,
     rotate: false,
     size: 'medium',
     // Not part of the component
@@ -48,6 +50,7 @@ const Template = (args: Args) => html`
     appearance=${args.appearance}
     ?disabled=${args.disabled}
     ?expanded=${args.expanded}
+    ?no-animation=${args['no-animation']}
     ?rotate=${args.rotate}
     size=${args.size}
     @bqBlur=${args.bqBlur}

--- a/packages/beeq/src/components/accordion/bq-accordion.tsx
+++ b/packages/beeq/src/components/accordion/bq-accordion.tsx
@@ -50,6 +50,12 @@ export class BqAccordion {
   /** If true accordion is expanded */
   @Prop({ reflect: true, mutable: true }) expanded: boolean = false;
 
+  /**
+   * Animation is set through JS when the browser does not support CSS calc-size()
+   * If true, the accordion animation, will be disabled. No animation will be applied.
+   */
+  @Prop({ reflect: true }) noAnimation: boolean = false;
+
   /** If true accordion expand icon is rotate 180deg when expanded */
   @Prop({ reflect: true }) rotate: boolean = false;
 
@@ -83,6 +89,18 @@ export class BqAccordion {
     if (!this.disabled) return;
 
     this.expanded = false;
+  }
+
+  @Watch('noAnimation')
+  handleJsAnimation() {
+    if (window.CSS?.supports('(block-size: calc-size(auto))')) return;
+
+    console.warn(
+      `[bq-accordion] calc-size() is not supported and animation will be set through JS
+        Consider using the 'noANimation' prop ('no-js-animation' attribute) to disable it`,
+    );
+    this.accordion = !this.noAnimation ? new Accordion(this.detailsElem) : null;
+    console.log('this.accordion', this.accordion);
   }
 
   // Events section
@@ -119,7 +137,7 @@ export class BqAccordion {
   }
 
   componentDidLoad() {
-    this.accordion = new Accordion(this.detailsElem);
+    this.handleJsAnimation();
     this.handleExpandedChange();
   }
 
@@ -144,6 +162,7 @@ export class BqAccordion {
   // Internal business logic.
   // These methods cannot be called from the host element.
   // =======================================================
+
   private handleClick = (event: MouseEvent) => {
     event.preventDefault();
 
@@ -182,8 +201,13 @@ export class BqAccordion {
   render() {
     return (
       <details
-        class={{ [`bq-accordion overflow-hidden ${this.size} ${this.appearance}`]: true, disabled: this.disabled }}
+        class={{
+          [`bq-accordion overflow-hidden ${this.size} ${this.appearance}`]: true,
+          'no-animation': this.noAnimation,
+          disabled: this.disabled,
+        }}
         ref={(detailsElem: HTMLDetailsElement) => (this.detailsElem = detailsElem)}
+        open={this.open}
         part="base"
       >
         <summary

--- a/packages/beeq/src/components/accordion/bq-accordion.tsx
+++ b/packages/beeq/src/components/accordion/bq-accordion.tsx
@@ -232,7 +232,7 @@ export class BqAccordion {
             </slot>
           </div>
         </summary>
-        <div class="bq-accordion__body" part="panel">
+        <div class="bq-accordion__body overflow-hidden" part="panel">
           <slot />
         </div>
       </details>

--- a/packages/beeq/src/components/accordion/bq-accordion.tsx
+++ b/packages/beeq/src/components/accordion/bq-accordion.tsx
@@ -97,10 +97,9 @@ export class BqAccordion {
 
     console.warn(
       `[bq-accordion] calc-size() is not supported and animation will be set through JS
-        Consider using the 'noANimation' prop ('no-js-animation' attribute) to disable it`,
+        For vertical layout, consider using the 'noANimation' prop ('no-animation' attribute) to disable it`,
     );
     this.accordion = !this.noAnimation ? new Accordion(this.detailsElem) : null;
-    console.log('this.accordion', this.accordion);
   }
 
   // Events section
@@ -207,7 +206,7 @@ export class BqAccordion {
           disabled: this.disabled,
         }}
         ref={(detailsElem: HTMLDetailsElement) => (this.detailsElem = detailsElem)}
-        open={this.open}
+        open={this.expanded}
         part="base"
       >
         <summary

--- a/packages/beeq/src/components/accordion/bq-accordion.tsx
+++ b/packages/beeq/src/components/accordion/bq-accordion.tsx
@@ -232,7 +232,7 @@ export class BqAccordion {
             </slot>
           </div>
         </summary>
-        <div class="bq-accordion__body overflow-hidden" part="panel">
+        <div class="bq-accordion__body" part="panel">
           <slot />
         </div>
       </details>

--- a/packages/beeq/src/components/accordion/helper/index.ts
+++ b/packages/beeq/src/components/accordion/helper/index.ts
@@ -10,7 +10,7 @@ export class Accordion {
   private isClosing: boolean;
   private isExpanding: boolean;
   private animationOptions = {
-    duration: 300,
+    duration: 200,
     easing: 'ease-in-out',
   };
 

--- a/packages/beeq/src/components/accordion/readme.md
+++ b/packages/beeq/src/components/accordion/readme.md
@@ -7,13 +7,14 @@
 
 ## Properties
 
-| Property     | Attribute    | Description                                                  | Type                  | Default    |
-| ------------ | ------------ | ------------------------------------------------------------ | --------------------- | ---------- |
-| `appearance` | `appearance` | The appearance style of accordion                            | `"filled" \| "ghost"` | `'filled'` |
-| `disabled`   | `disabled`   | If true accordion is disabled                                | `boolean`             | `false`    |
-| `expanded`   | `expanded`   | If true accordion is expanded                                | `boolean`             | `false`    |
-| `rotate`     | `rotate`     | If true accordion expand icon is rotate 180deg when expanded | `boolean`             | `false`    |
-| `size`       | `size`       | The size of accordion                                        | `"medium" \| "small"` | `'medium'` |
+| Property      | Attribute      | Description                                                                                                                                                     | Type                  | Default    |
+| ------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- | ---------- |
+| `appearance`  | `appearance`   | The appearance style of accordion                                                                                                                               | `"filled" \| "ghost"` | `'filled'` |
+| `disabled`    | `disabled`     | If true accordion is disabled                                                                                                                                   | `boolean`             | `false`    |
+| `expanded`    | `expanded`     | If true accordion is expanded                                                                                                                                   | `boolean`             | `false`    |
+| `noAnimation` | `no-animation` | Animation is set through JS when the browser does not support CSS calc-size() If true, the accordion animation, will be disabled. No animation will be applied. | `boolean`             | `false`    |
+| `rotate`      | `rotate`       | If true accordion expand icon is rotate 180deg when expanded                                                                                                    | `boolean`             | `false`    |
+| `size`        | `size`         | The size of accordion                                                                                                                                           | `"medium" \| "small"` | `'medium'` |
 
 
 ## Events

--- a/packages/beeq/src/components/accordion/scss/bq-accordion.scss
+++ b/packages/beeq/src/components/accordion/scss/bq-accordion.scss
@@ -17,13 +17,16 @@
     }
   }
 
+  direction: rtl;
+  writing-mode: vertical-rl;
+
   &.small .bq-accordion__header {
-    @apply gap-[--bq-accordion--small-gap] py-[--bq-accordion--small-padding-y] pe-[--bq-accordion--small-padding-end] ps-[--bq-accordion--small-padding-start];
+    @apply gap-[--bq-accordion--small-gap] pe-[--bq-accordion--small-padding-end] ps-[--bq-accordion--small-padding-start] p-b-[--bq-accordion--small-padding-y];
     @apply rounded-ee-[--bq-accordion--small-radius] rounded-es-[--bq-accordion--small-radius] rounded-se-[--bq-accordion--small-radius] rounded-ss-[--bq-accordion--small-radius];
   }
 
   &.medium .bq-accordion__header {
-    @apply gap-[--bq-accordion--medium-gap] py-[--bq-accordion--medium-padding-y] pe-[--bq-accordion--medium-padding-end] ps-[--bq-accordion--medium-padding-start];
+    @apply gap-[--bq-accordion--medium-gap] pe-[--bq-accordion--medium-padding-end] ps-[--bq-accordion--medium-padding-start] p-b-[--bq-accordion--medium-padding-y];
     @apply rounded-ee-[--bq-accordion--medium-radius] rounded-es-[--bq-accordion--medium-radius] rounded-se-[--bq-accordion--medium-radius] rounded-ss-[--bq-accordion--medium-radius];
   }
 
@@ -91,19 +94,19 @@
   }
 
   &.small.filled .bq-accordion__body {
-    @apply py-[--bq-accordion--panel-small-filled-padding-y] pe-[--bq-accordion--panel-small-filled-padding-end] ps-[--bq-accordion--panel-small-filled-padding-start];
+    @apply pe-[--bq-accordion--panel-small-filled-padding-end] ps-[--bq-accordion--panel-small-filled-padding-start] p-b-[--bq-accordion--panel-small-filled-padding-y];
   }
 
   &.medium.filled .bq-accordion__body {
-    @apply py-[--bq-accordion--panel-medium-filled-padding-y] pe-[--bq-accordion--panel-medium-filled-padding-end] ps-[--bq-accordion--panel-medium-filled-padding-start];
+    @apply pe-[--bq-accordion--panel-medium-filled-padding-end] ps-[--bq-accordion--panel-medium-filled-padding-start] p-b-[--bq-accordion--panel-medium-filled-padding-y];
   }
 
   &.small.ghost .bq-accordion__body {
-    @apply py-[--bq-accordion--panel-small-ghost-padding-y] pe-[--bq-accordion--panel-small-ghost-padding-end] ps-[--bq-accordion--panel-small-ghost-padding-start];
+    @apply pe-[--bq-accordion--panel-small-ghost-padding-end] ps-[--bq-accordion--panel-small-ghost-padding-start] p-b-[--bq-accordion--panel-small-ghost-padding-y];
   }
 
   &.medium.ghost .bq-accordion__body {
-    @apply py-[--bq-accordion--panel-medium-ghost-padding-y] pe-[--bq-accordion--panel-medium-ghost-padding-end] ps-[--bq-accordion--panel-medium-ghost-padding-start];
+    @apply pe-[--bq-accordion--panel-medium-ghost-padding-end] ps-[--bq-accordion--panel-medium-ghost-padding-start] p-b-[--bq-accordion--panel-medium-ghost-padding-y];
   }
 }
 

--- a/packages/beeq/src/components/accordion/scss/bq-accordion.scss
+++ b/packages/beeq/src/components/accordion/scss/bq-accordion.scss
@@ -107,6 +107,22 @@
   }
 }
 
+/* stylelint-disable-next-line selector-pseudo-element-no-unknown */
+.bq-accordion::details-content {
+  @apply block overflow-hidden transition-[block-size,content-visibility] duration-300 ease-in-out bs-0 [transition-behavior:allow-discrete];
+}
+
+/* stylelint-disable-next-line selector-pseudo-element-no-unknown */
+.bq-accordion[open]::details-content {
+  /* block-size: auto is just a fallback for browsers that don't support the calc-size() function */
+  @apply bs-auto;
+}
+
+/* stylelint-disable-next-line selector-pseudo-element-no-unknown */
+.bq-accordion[open]:not(.no-animation)::details-content {
+  @apply supports-[block-size:calc-size(auto)]:bs-[calc-size(auto)];
+}
+
 .bq-accordion__header {
   // Since there's an overflow on the <summary> element, the focus outline is not visible,
   // so we force it to be inset to avoid the overflow hidden.

--- a/packages/beeq/src/components/accordion/scss/bq-accordion.scss
+++ b/packages/beeq/src/components/accordion/scss/bq-accordion.scss
@@ -17,9 +17,6 @@
     }
   }
 
-  direction: rtl;
-  writing-mode: vertical-rl;
-
   &.small .bq-accordion__header {
     @apply gap-[--bq-accordion--small-gap] pe-[--bq-accordion--small-padding-end] ps-[--bq-accordion--small-padding-start] p-b-[--bq-accordion--small-padding-y];
     @apply rounded-ee-[--bq-accordion--small-radius] rounded-es-[--bq-accordion--small-radius] rounded-se-[--bq-accordion--small-radius] rounded-ss-[--bq-accordion--small-radius];


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR aims to modernize the CSS by incorporating logical properties for improved adaptability and support for RTL content direction and vertical layout.

We have implemented CSS [animation for the summary HTML element](https://codepen.io/ZoranJambor/pen/jOorzPv?editors=1100) using block-size and [calc-size](https://github.com/WebKit/standards-positions/issues/348) (still in draft). If calc-size is supported:

![CleanShot 2024-07-17 at 11 39 09@2x](https://github.com/user-attachments/assets/4dda070c-950c-4c35-935b-21401d5a6ad3)

the open/close animation will be handled via CSS instead of JavaScript. This enhances considerably the way the animation behaves on a vertical layout.

If calc-size() is not yet supported by the browser (feature flag is not enabled) animations will be handled via JavaScript, and, if there's a need for a vertical layout, we have added the possibility to disable all animation so the component works as expected, without shifting when opening or closing.

## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

N/A

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

https://github.com/user-attachments/assets/baa3a706-4626-4a4c-afc1-ba11c770626e

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
