### PR TITLE
fix(Drawer): open/close animation to be in sync with the content direction

### DIFF
--- a/packages/beeq/src/components/drawer/_storybook/bq-drawer.stories.tsx
+++ b/packages/beeq/src/components/drawer/_storybook/bq-drawer.stories.tsx
@@ -17,7 +17,7 @@ const meta: Meta = {
     'close-on-click-outside': { control: 'boolean' },
     'close-on-esc': { control: 'boolean' },
     open: { control: 'boolean' },
-    position: { control: 'select', options: [...DRAWER_POSITIONS] },
+    position: { control: 'inline-radio', options: [...DRAWER_POSITIONS] },
     // Events
     bqOpen: { action: 'bqOpen' },
     bqClose: { action: 'bqClose' },

--- a/packages/beeq/src/components/drawer/bq-drawer.tsx
+++ b/packages/beeq/src/components/drawer/bq-drawer.tsx
@@ -219,6 +219,16 @@ export class BqDrawer {
     this.el.classList.remove(this.OPEN_CSS_CLASS);
   };
 
+  private get isPositionStart() {
+    // !⚠️ `placement` is deprecated and will be removed in the future
+    return this.position === 'start' || this.placement === 'left';
+  }
+
+  private get isPositionEnd() {
+    // !⚠️ `placement` is deprecated and will be removed in the future
+    return this.position === 'end' || this.placement === 'right';
+  }
+
   // render() function
   // Always the last one in the class.
   // ===================================
@@ -242,12 +252,11 @@ export class BqDrawer {
         {/* DRAWER PANEL */}
         <div
           class={{
-            // !⚠️ `placement` is deprecated and will be removed in the future
             [`bq-drawer transition-all duration-300 ease-in-out ${this.position || this.placement}`]: true,
-            '-start-[--bq-drawer--width]': this.position === 'start' || this.placement === 'left',
-            '-end-[--bq-drawer--width]': this.position === 'end' || this.placement === 'right',
-            'start-0': this.open && (this.position === 'start' || this.placement === 'left'),
-            'end-0': this.open && (this.position === 'end' || this.placement === 'right'),
+            '-start-[--bq-drawer--width]': this.isPositionStart,
+            '-end-[--bq-drawer--width]': this.isPositionEnd,
+            'start-0': this.open && this.isPositionStart,
+            'end-0': this.open && this.isPositionEnd,
           }}
           ref={(div) => (this.drawerElem = div)}
           aria-hidden={!this.open ? 'true' : 'false'}

--- a/packages/beeq/src/components/drawer/bq-drawer.tsx
+++ b/packages/beeq/src/components/drawer/bq-drawer.tsx
@@ -57,7 +57,7 @@ export class BqDrawer {
   @Prop({ reflect: true, mutable: true }) placement: TDrawerPlacement = 'right';
 
   /** Defines the position of the drawer */
-  @Prop({ reflect: true }) position: TDrawerPosition = 'end';
+  @Prop({ reflect: true, mutable: true }) position: TDrawerPosition = 'end';
 
   // Prop lifecycle events
   // =======================
@@ -65,11 +65,11 @@ export class BqDrawer {
   @Watch('open')
   async handleOpenChange() {
     if (!this.open) {
-      await this.handleHide();
+      await this.handleAfterHide();
       return;
     }
 
-    await this.handleShow();
+    await this.handleAfterShow();
   }
 
   /**
@@ -132,10 +132,6 @@ export class BqDrawer {
     this.handlePlacementChange();
   }
 
-  componentDidLoad() {
-    this.handleOpenChange();
-  }
-
   // Listeners
   // ==============
 
@@ -170,12 +166,18 @@ export class BqDrawer {
   /** Method to be called to hide the drawer component */
   @Method()
   async hide(): Promise<void> {
+    const ev = this.bqClose.emit();
+    if (ev.defaultPrevented) return;
+
     this.open = false;
   }
 
   /** Method to be called to show the drawer component */
   @Method()
   async show(): Promise<void> {
+    const ev = this.bqOpen.emit();
+    if (ev.defaultPrevented) return;
+
     this.open = true;
   }
 
@@ -188,21 +190,15 @@ export class BqDrawer {
     this.hasFooter = hasSlotContent(this.footerElem, 'footer');
   };
 
-  private handleHide = async () => {
+  private handleAfterHide = async () => {
     if (!this.drawerElem) return;
-
-    const ev = this.bqClose.emit();
-    if (ev.defaultPrevented) return;
 
     await leave(this.drawerElem);
     this.handleTransitionEnd();
   };
 
-  private handleShow = async () => {
+  private handleAfterShow = async () => {
     if (!this.drawerElem) return;
-
-    const ev = this.bqOpen.emit();
-    if (ev.defaultPrevented) return;
 
     this.el.classList.add(this.OPEN_CSS_CLASS);
     await enter(this.drawerElem);

--- a/packages/beeq/src/components/drawer/bq-drawer.tsx
+++ b/packages/beeq/src/components/drawer/bq-drawer.tsx
@@ -219,15 +219,6 @@ export class BqDrawer {
     this.el.classList.remove(this.OPEN_CSS_CLASS);
   };
 
-  private getMoveTranslate = (): string => {
-    const positionMap = {
-      start: '-translate-x-full',
-      end: 'translate-x-full',
-    };
-
-    return positionMap[this.position] || '';
-  };
-
   // render() function
   // Always the last one in the class.
   // ===================================
@@ -252,16 +243,12 @@ export class BqDrawer {
         <div
           class={{
             // !⚠️ `placement` is deprecated and will be removed in the future
-            [`bq-drawer ${this.position || this.placement}`]: true,
-            'end-0': this.position === 'end' || this.placement === 'right',
-            'start-0': this.position === 'start' || this.placement === 'left',
+            [`bq-drawer transition-all duration-300 ease-in-out ${this.position || this.placement}`]: true,
+            '-start-[--bq-drawer--width]': this.position === 'start' || this.placement === 'left',
+            '-end-[--bq-drawer--width]': this.position === 'end' || this.placement === 'right',
+            'start-0': this.open && (this.position === 'start' || this.placement === 'left'),
+            'end-0': this.open && (this.position === 'end' || this.placement === 'right'),
           }}
-          data-transition-enter="transition-transform ease-in duration-300"
-          data-transition-enter-start={this.getMoveTranslate()}
-          data-transition-enter-end="opacity-100"
-          data-transition-leave="transition-transform ease-in duration-300"
-          data-transition-leave-start="opacity-100"
-          data-transition-leave-end={this.getMoveTranslate()}
           ref={(div) => (this.drawerElem = div)}
           aria-hidden={!this.open ? 'true' : 'false'}
           aria-labelledby="bq-drawer__title"


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR aims to solve an existing issue with the open/close animation behavior of the Drawer when the content direction switches from RTL to LTR, the animations are not working as expected since it's using `translate` which makes the drawer animates from/to the opposite side.

https://github.com/user-attachments/assets/9093d4c6-2cac-4382-8f5b-2cc27bd1e751

The fix removed the use of translation and relies on the inset-inline-start/end property, making it possible that animations work as expected regardless of the `direction="rtl | ltr"` set.

https://github.com/user-attachments/assets/d8a4a5e8-6e1a-4c9c-8deb-e2b15e2a3843

## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

N/A

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
