### PR TITLE
feat(Icon): add `--bq-icon--direction` and flip SVG automatically for `dir="rtl"`

### DIFF
--- a/packages/beeq/src/components/icon/_storybook/bq-icon.stories.tsx
+++ b/packages/beeq/src/components/icon/_storybook/bq-icon.stories.tsx
@@ -1,6 +1,7 @@
 import type { Args, Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { repeat } from 'lit-html/directives/repeat.js';
 
 import mdx from './bq-icon.mdx';
 import { ICON_WEIGHT } from '../bq-icon.types';
@@ -63,38 +64,102 @@ export const Custom: Story = {
 };
 
 export const ExploreIcons: Story = {
-  render: () => html`
-    <style>
-      bq-button::part(button) {
-        text-decoration: none;
-      }
-    </style>
-    <div class="text-text-primary m-be-xl">
-      <h1 class="text-xl font-bold">We didn't reinvent the wheel</h1>
-      <p class="m-bs-xs">
-        BEEQ icons are based on
-        <a
-          class="bq-link"
-          href="https://phosphoricons.com/"
-          target="_blank"
-          title="Phosphor icons"
-          rel="noreferrer noopener"
-        >
-          Phosphor icons library
-        </a>
-        , is a flexible icon family for interfaces, diagrams, presentations — whatever, really, is free and open-source,
-        licensed under MIT.
-      </p>
-      <span class="text-xs text-text-secondary">
-        (Below, you're seeing only a few examples of the icons that the library provides)
-      </span>
-    </div>
-    <bq-button appearance="primary" href="https://phosphoricons.com/" target="_blank">
-      <bq-icon name="binoculars" weight="fill" slot="prefix"></bq-icon>
-      Explore all the icons available
-      <bq-icon class="ms-m" name="caret-right" weight="regular" slot="suffix"></bq-icon>
-    </bq-button>
-  `,
+  render: (args) => {
+    // List of icons to show, these are just a few examples of the icons available in the library
+    const ICONS = [
+      'align-left',
+      'align-right',
+      'arrow-circle-left',
+      'arrow-circle-right',
+      'arrow-elbow-left',
+      'arrow-elbow-right',
+      'arrow-square-left',
+      'arrow-square-right',
+      'arrows-horizontal',
+      'arrows-vertical',
+      'battery-charging',
+      'book',
+      'bookmark-simple',
+      'car',
+      'clipboard-text',
+      'cloud-arrow-down',
+      'cloud-arrow-up',
+      'chart-line-up',
+      'chart-line',
+      'chart-pie-slice',
+      'chart-pie',
+      'chat',
+      'folder-open',
+      'git-commit',
+      'git-merge',
+      'git-pull-request',
+      'hard-drives',
+      'hash',
+      'hash-straight',
+      'layout',
+      'list-bullets',
+    ];
+
+    return html`
+      <style>
+        bq-button::part(button) {
+          text-decoration: none;
+        }
+      </style>
+      <div class="text-text-primary m-be-xl">
+        <h1 class="text-xl font-bold">We didn't reinvent the wheel</h1>
+        <p class="m-bs-xs">
+          BEEQ icons are based on
+          <a
+            class="bq-link"
+            href="https://phosphoricons.com/"
+            target="_blank"
+            title="Phosphor icons"
+            rel="noreferrer noopener"
+          >
+            Phosphor icons library
+          </a>
+          , is a flexible icon family for interfaces, diagrams, presentations — whatever, really, is free and
+          open-source, licensed under MIT.
+        </p>
+        <span class="text-xs text-text-secondary">
+          (Below, you're seeing only a few examples of the icons that the library provides)
+        </span>
+      </div>
+      <bq-button class="m-be-xxl" appearance="primary" href="https://phosphoricons.com/" target="_blank">
+        <bq-icon name="binoculars" weight="fill" slot="prefix"></bq-icon>
+        Explore all the icons available
+        <bq-icon class="ms-m" name="caret-right" weight="regular" slot="suffix"></bq-icon>
+      </bq-button>
+      <!-- Warning block -->
+      <bq-alert class="m-be-l" type="warning" disable-close open>
+        <bq-icon name="warning" weight="fill" slot="icon"></bq-icon>
+        Please notice
+        <span slot="body">
+          The SVG icons will be flipped horizontally when the <code>dir="rtl"</code> attribute is used.
+        </span>
+      </bq-alert>
+      <!-- Icons -->
+      <div
+        class="icon-grid grid grid-cols-[repeat(auto-fill,_minmax(75px,_1fr))] gap-l gap-x-m max-bs-auto max-is-auto"
+      >
+        ${repeat(
+          ICONS,
+          (icon) => icon,
+          (icon) => html`
+            <div class="group flex flex-col items-stretch text-center outline-0" role="button" tabindex="0">
+              <div
+                class="border flex w-full justify-center rounded-m border-solid border-stroke-primary transition-[shadow,transform] m-be-s p-b-m p-i-0 group-hover:scale-125 group-hover:shadow-l"
+              >
+                ${Template({ ...args, name: icon })}
+              </div>
+              <span class="text-s leading-regular text-text-primary">${icon}</span>
+            </div>
+          `,
+        )}
+      </div>
+    `;
+  },
   parameters: {
     chromatic: { disableSnapshot: true },
   },

--- a/packages/beeq/src/components/icon/scss/bq-icon.scss
+++ b/packages/beeq/src/components/icon/scss/bq-icon.scss
@@ -13,5 +13,5 @@
  * See lines 42 and 58 for details.
  */
 .bq-icon__svg {
-  @apply fill-current;
+  @apply scale-x-[--bq-icon--direction] fill-current;
 }

--- a/packages/beeq/src/global/styles/_components.scss
+++ b/packages/beeq/src/global/styles/_components.scss
@@ -4,7 +4,32 @@
  */
 
 :root {
+  /* ---------------------------------- Icon ---------------------------------- */
+
+  /**
+   * Used to set the icon SVG direction, this is useful for RTL languages.
+   * 1 is default (RTL), -1 is flipped (LTR).
+   *
+   * @prop --bq-icon--direction: Icon direction
+   */
+  --bq-icon--direction: 1;
+
   /* -------------------------------- Side menu ------------------------------- */
+
+  /**
+   * Used to set the side menu width when expanded.
+   *
+   * @prop --bq-side-menu--width: Side menu width
+   * @prop --bq-side-menu--width-collapse: Side menu width when collapsed
+   */
   --bq-side-menu--width: 256px;
   --bq-side-menu--width-collapse: 72px;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                Right to Left                               */
+/* -------------------------------------------------------------------------- */
+
+[dir='rtl'] {
+  --bq-icon--direction: -1;
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR adds the possibility to automatically flip the SVG icons horizontally when `dir="rtl"`. We have added a global custom property `--bq-icon--direction` that can be also used by consumers when a BqIcon needs to be flipped.

https://github.com/user-attachments/assets/987bb652-2bc0-470b-81c6-d3ec07bb912e

## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

Fixes #ISSUE_NUMBER

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
