### PR TITLE
perf(Divider): improve code readability and performance

### DIFF
--- a/packages/beeq/src/components/divider/_storybook/bq-divider.stories.tsx
+++ b/packages/beeq/src/components/divider/_storybook/bq-divider.stories.tsx
@@ -1,5 +1,6 @@
 import type { Args, Meta, StoryObj } from '@storybook/web-components';
-import { html } from 'lit-html';
+import { html, nothing } from 'lit-html';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 import mdx from './bq-divider.mdx';
 import { DIVIDER_ORIENTATION, DIVIDER_STROKE_LINECAP, DIVIDER_TITLE_ALIGNMENT } from '../bq-divider.types';
@@ -43,25 +44,19 @@ export default meta;
 type Story = StoryObj;
 
 const Template = (args: Args) => html`
-  <style>
-    .container {
-      /* width: 40%; */
-      height: ${args.orientation === 'vertical' ? html`70vh` : 'auto'};
-    }
-  </style>
-  <div class="container">
+  <div class="is-[70dvw]">
     <bq-divider
-      orientation=${args.orientation}
+      orientation=${ifDefined(args.orientation)}
       ?dashed=${args.dashed}
-      stroke-color=${args['stroke-color']}
-      stroke-dash-width=${args['stroke-dash-width']}
-      stroke-dash-gap=${args['stroke-dash-gap']}
-      stroke-thickness=${args['stroke-thickness']}
-      stroke-basis=${args['stroke-basis']}
-      stroke-linecap=${args['stroke-linecap']}
-      title-alignment=${args['title-alignment']}
+      stroke-color=${ifDefined(args['stroke-color'])}
+      stroke-dash-width=${ifDefined(args['stroke-dash-width'])}
+      stroke-dash-gap=${ifDefined(args['stroke-dash-gap'])}
+      stroke-thickness=${ifDefined(args['stroke-thickness'])}
+      stroke-basis=${ifDefined(args['stroke-basis'])}
+      stroke-linecap=${ifDefined(args['stroke-linecap'])}
+      title-alignment=${ifDefined(args['title-alignment'])}
     >
-      ${args['title-text'] ? html`<p style="margin: 0; white-space: nowrap;">${args['title-text']}</p>` : null}
+      ${args['title-text'] ? html`<p class="m-0 text-nowrap p-0">${args['title-text']}</p>` : nothing}
     </bq-divider>
   </div>
 `;

--- a/packages/beeq/src/components/divider/scss/bq-divider.scss
+++ b/packages/beeq/src/components/divider/scss/bq-divider.scss
@@ -9,7 +9,7 @@
 }
 
 .bq-divider--stroke {
-  @apply h-[var(--bq-divider--stroke-thickness)] w-full flex-grow stroke-[color:var(--bq-divider--stroke-color)];
+  @apply flex-grow stroke-[color:var(--bq-divider--stroke-color)] bs-[var(--bq-divider--stroke-thickness)] is-full;
 
   &.end {
     @apply rotate-180;
@@ -22,9 +22,9 @@
 }
 
 .bq-divider--vertical {
-  @apply h-full flex-col items-center gap-[var(--bq-divider--title-marginX)];
+  @apply flex-col items-center gap-[var(--bq-divider--title-marginX)] is-full;
 
   .bq-divider--stroke {
-    @apply h-full w-[var(--bq-divider--stroke-thickness)];
+    @apply bs-full is-[var(--bq-divider--stroke-thickness)];
   }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR improves the code readability of the BqDivider, removes `strokeDrawPositions` from the global scope, and uses `Map()` instead of the `Switch` statement. It also replaces physical CSS values with logical properties to support the RTL layout content better.

## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

Fixes #ISSUE_NUMBER

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [ ] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [ ] I have reviewed my own code.
- [ ] I have tested the changes locally.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added unit tests and e2e tests (if applicable).
- [ ] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
