### PR TITLE
fix(deps): missing `@stencil/core` dependency for framework targets

### DIFF
--- a/.husky/branch-name.sh
+++ b/.husky/branch-name.sh
@@ -16,7 +16,7 @@ where prefix is one of:
 ${YELLOW}Please, rename your branch to a valid name and try again.${CLEARCOLOR}\\n"
 
 branch_name_check="^(($allowed_branch_names)\/[a-zA-Z0-9\-]+)$"
-if [[ ! $local_branch_name =~ $branch_name_check ]]; then
+if [[ $local_branch_name != "main" && ! $local_branch_name =~ $branch_name_check ]]; then
     echo "$message"
     exit 1
 fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beeq",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beeq",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -11703,7 +11703,6 @@
       "version": "4.19.2",
       "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.19.2.tgz",
       "integrity": "sha512-ZdnbHmHEl8E5vN0GWDtONe5w6j3CrSqqxZM4hNLBPkV/aouWKug7D5/Mi6RazfYO5U4fmHQYLwMz60rHcx0G4g==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "stencil": "bin/stencil"
@@ -43540,21 +43539,22 @@
     },
     "packages/beeq": {
       "name": "@beeq/core",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/core": "^1.6.3",
         "@floating-ui/dom": "^1.6.6",
+        "@stencil/core": "^4.19.2",
         "cally": "^0.7.1"
       }
     },
     "packages/beeq-angular": {
       "name": "@beeq/angular",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@beeq/core": "^1.5.1",
-        "tslib": "^2.6.2"
+        "@beeq/core": "^1.6.0",
+        "tslib": "^2.6.3"
       },
       "peerDependencies": {
         "@angular/common": ">=14.0.0",
@@ -43563,20 +43563,20 @@
     },
     "packages/beeq-react": {
       "name": "@beeq/react",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@beeq/core": "^1.5.1"
+        "@beeq/core": "^1.6.0"
       },
       "peerDependencies": {
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0",
-        "tslib": "^2.6.2"
+        "tslib": "^2.6.3"
       }
     },
     "packages/beeq-tailwindcss": {
       "name": "@beeq/tailwindcss",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "tailwindcss": "^3.4.4",
@@ -43585,11 +43585,11 @@
     },
     "packages/beeq-vue": {
       "name": "@beeq/vue",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@beeq/core": "^1.5.1",
-        "tslib": "^2.6.2"
+        "@beeq/core": "^1.6.0",
+        "tslib": "^2.6.3"
       },
       "peerDependencies": {
         "vue": ">=3.3.0"

--- a/packages/beeq-angular/package.json
+++ b/packages/beeq-angular/package.json
@@ -7,8 +7,8 @@
   "module": "dist/esm2015/index.js",
   "types": "index.d.ts",
   "dependencies": {
-    "@beeq/core": "^1.5.1",
-    "tslib": "^2.6.2"
+    "@beeq/core": "^1.6.0",
+    "tslib": "^2.6.3"
   },
   "peerDependencies": {
     "@angular/common": ">=14.0.0",

--- a/packages/beeq-react/package.json
+++ b/packages/beeq-react/package.json
@@ -7,12 +7,12 @@
   "module": "./src/index.js",
   "types": "./src/index.d.ts",
   "dependencies": {
-    "@beeq/core": "^1.5.1"
+    "@beeq/core": "^1.6.0"
   },
   "peerDependencies": {
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0",
-    "tslib": "^2.6.2"
+    "tslib": "^2.6.3"
   },
   "repository": {
     "type": "git",

--- a/packages/beeq-vue/package.json
+++ b/packages/beeq-vue/package.json
@@ -6,8 +6,8 @@
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
   "dependencies": {
-    "@beeq/core": "^1.5.1",
-    "tslib": "^2.6.2"
+    "@beeq/core": "^1.6.0",
+    "tslib": "^2.6.3"
   },
   "peerDependencies": {
     "vue": ">=3.3.0"

--- a/packages/beeq/.eslintrc.json
+++ b/packages/beeq/.eslintrc.json
@@ -94,6 +94,7 @@
           {
             "ignoredDependencies": [
               "@stencil/angular-output-target",
+              "@stencil/core",
               "@stencil/react-output-target",
               "@stencil/vue-output-target",
               "@stencil/sass",

--- a/packages/beeq/package.json
+++ b/packages/beeq/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@floating-ui/core": "^1.6.3",
     "@floating-ui/dom": "^1.6.6",
+    "@stencil/core": "^4.19.2",
     "cally": "^0.7.1"
   },
   "repository": {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR solves the issue where `@stencil/core` is missing as a dependency when using any framework output target within BEEQ.

![CleanShot 2024-07-25 at 12 31 09@2x](https://github.com/user-attachments/assets/23823dc1-5dc3-4316-ac38-80a42557ed9e)

It seems that `@stencil/core` should be added as a dependency of the core component library (`@beeq/core`) when using any framework output target.

Details: https://discord.com/channels/520266681499779082/1222546631816118305

![CleanShot 2024-07-25 at 12 35 55@2x](https://github.com/user-attachments/assets/aef547ca-cfbc-44a6-85c0-b8f5353ca21f)

## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

N/A

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
