### PR TITLE
chore(tailwind): support for negative values for logical properties inset/margin

### DIFF
--- a/packages/beeq-tailwindcss/src/plugins/logical-properties.ts
+++ b/packages/beeq-tailwindcss/src/plugins/logical-properties.ts
@@ -51,6 +51,18 @@ export const LogicalProperties: Partial<Config> = plugin(function ({ matchUtilit
       'border-i': (value) => ({ 'border-inline': value }),
       'border-is': (value) => ({ 'border-inline-start': value }),
       'border-ie': (value) => ({ 'border-inline-end': value }),
+      // Logical Padding properties (only those not covered by Tailwind CSS)
+      'p-b': (value) => ({ 'padding-block': value }),
+      'p-bs': (value) => ({ 'padding-block-start': value }),
+      'p-be': (value) => ({ 'padding-block-end': value }),
+      'p-i': (value) => ({ 'padding-inline': value }),
+    },
+    {
+      values: theme('spacing'),
+    },
+  );
+  matchUtilities(
+    {
       // Logical Top, Right, Bottom, and Left properties
       'inset-b': (value) => ({ 'inset-block': value }),
       'inset-bs': (value) => ({ 'inset-block-start': value }),
@@ -63,14 +75,10 @@ export const LogicalProperties: Partial<Config> = plugin(function ({ matchUtilit
       'm-bs': (value) => ({ 'margin-block-start': value }),
       'm-be': (value) => ({ 'margin-block-end': value }),
       'm-i': (value) => ({ 'margin-inline': value }),
-      // Logical Padding properties (only those not covered by Tailwind CSS)
-      'p-b': (value) => ({ 'padding-block': value }),
-      'p-bs': (value) => ({ 'padding-block-start': value }),
-      'p-be': (value) => ({ 'padding-block-end': value }),
-      'p-i': (value) => ({ 'padding-inline': value }),
     },
     {
       values: theme('spacing'),
+      supportsNegativeValues: true,
     },
   );
 });

--- a/packages/beeq/src/components/checkbox/bq-checkbox.tsx
+++ b/packages/beeq/src/components/checkbox/bq-checkbox.tsx
@@ -183,7 +183,7 @@ export class BqCheckbox {
         >
           <input
             type="checkbox"
-            class="bq-checkbox__input pointer-events-none absolute opacity-0 m-b-0 m-i-0 p-b-0 p-i-0"
+            class="bq-checkbox__input pointer-events-none absolute opacity-0 p-b-0 p-i-0 m-b-0 m-i-0"
             name={!isNil(this.name) ? this.name : undefined}
             checked={this.checked}
             disabled={this.disabled}

--- a/packages/beeq/src/components/dropdown/_storybook/bq-dropdown.stories.tsx
+++ b/packages/beeq/src/components/dropdown/_storybook/bq-dropdown.stories.tsx
@@ -201,7 +201,7 @@ export const CustomTrigger: Story = {
 
 export const KeepOpen: Story = {
   render: (args: Args) => html`
-    <div class="rounded-m border-s border-solid border-stroke-success bg-ui-success-alt m-be-l p-b-m p-i-m">
+    <div class="rounded-m border-s border-solid border-stroke-success bg-ui-success-alt p-b-m p-i-m m-be-l">
       <p class="text-m font-bold m-be-xs">💡 NOTE:</p>
       If <code class="text-text-danger">keepOpenOnSelect</code> is set, the dropdown will remain open after a selection
       is made.

--- a/packages/beeq/src/components/icon/_storybook/bq-icon.stories.tsx
+++ b/packages/beeq/src/components/icon/_storybook/bq-icon.stories.tsx
@@ -149,7 +149,7 @@ export const ExploreIcons: Story = {
           (icon) => html`
             <div class="group flex flex-col items-stretch text-center outline-0" role="button" tabindex="0">
               <div
-                class="border flex w-full justify-center rounded-m border-s border-solid border-stroke-primary transition-[shadow,transform] m-be-s p-b-m p-i-0 group-hover:scale-125 group-hover:shadow-l"
+                class="border flex w-full justify-center rounded-m border-s border-solid border-stroke-primary transition-[shadow,transform] p-b-m p-i-0 m-be-s group-hover:scale-125 group-hover:shadow-l"
               >
                 ${Template({ ...args, name: icon })}
               </div>

--- a/packages/beeq/src/components/status/bq-status.tsx
+++ b/packages/beeq/src/components/status/bq-status.tsx
@@ -71,7 +71,7 @@ export class BqStatus {
       <div class="bq-status inline-flex items-center gap-xs" part="base" role="status">
         <bq-badge class={`bq-status__circle rounded-full ${this.type}`} size="medium" part="circle" role="img" />
         <div
-          class="bq-status__text text-s font-medium leading-regular text-text-primary max-bs-[20px] m-b-0 m-i-0 p-b-0 p-i-0"
+          class="bq-status__text text-s font-medium leading-regular text-text-primary max-bs-[20px] p-b-0 p-i-0 m-b-0 m-i-0"
           part="text"
         >
           <slot />

--- a/packages/beeq/src/components/steps/bq-steps.tsx
+++ b/packages/beeq/src/components/steps/bq-steps.tsx
@@ -114,7 +114,7 @@ export class BqSteps {
       >
         <slot />
         <bq-divider
-          class={`absolute -z-10 inset-ie-0 inset-is-0 p-i-s ${dividerPaddingTop}`}
+          class={`absolute -z-10 p-i-s inset-ie-0 inset-is-0 ${dividerPaddingTop}`}
           strokeColor={this.dividerColor}
           strokeThickness={2}
           exportparts="base:divider-base,dash-start:divider-dash-start,dash-end:divider-dash-end"


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->
Adds support for negative values for logical properties inset/margin.
## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
