### PR TITLE
feat(Icon): deprecate `weight` property

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,6 +30,14 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "css.validate": false,
+  "commentAnchors.tags.anchors": {
+    "!TO BE REMOVED": {
+      "iconColor": "red",
+      "highlightColor": "#F44336",
+      "scope": "workspace"
+    },
+  },
+  "commentAnchors.workspace.excludeFiles": "**/{node_modules,.cache,.nx,.stencil,.git,.idea,target,out,build,dist,bin,tmp,obj,vendor}/**/*",
   "editor.formatOnSave": true,
   "files.associations": {
     "*.json5": "json5",

--- a/packages/beeq/src/components.d.ts
+++ b/packages/beeq/src/components.d.ts
@@ -635,7 +635,7 @@ export namespace Components {
          */
         "src"?: string;
         /**
-          * It set the icon weight/style
+          * @deprecated It set the icon weight/style
          */
         "weight"?: TIconWeight;
     }
@@ -2939,7 +2939,7 @@ declare namespace LocalJSX {
          */
         "src"?: string;
         /**
-          * It set the icon weight/style
+          * @deprecated It set the icon weight/style
          */
         "weight"?: TIconWeight;
     }

--- a/packages/beeq/src/components/drawer/bq-drawer.tsx
+++ b/packages/beeq/src/components/drawer/bq-drawer.tsx
@@ -73,7 +73,7 @@ export class BqDrawer {
   }
 
   /**
-   * !⚠️ Delete this `@Watch()` once the deprecated `placement` property is removed
+   * !TO BE REMOVED: Delete this `@Watch()` once the deprecated `placement` property is removed
    * We need to maintain retro-compatibility with the deprecated `placement` property
    */
   @Watch('placement')
@@ -97,7 +97,7 @@ export class BqDrawer {
     validatePropValue(DRAWER_POSITIONS, 'start', this.el, 'position');
     /**
      * Sync 'placement' property
-     * !⚠️ Delete the code below once the deprecated `placement` property is removed
+     * !TO BE REMOVED: Delete the code below once the deprecated `placement` property is removed
      */
     const syncPlacementMap = {
       end: 'right',
@@ -128,7 +128,7 @@ export class BqDrawer {
 
   componentWillLoad() {
     this.handlePositionChange();
-    // !⚠️ Delete this once the deprecated `placement` property is removed
+    // !TO BE REMOVED: Delete this once the deprecated `placement` property is removed
     this.handlePlacementChange();
   }
 
@@ -216,12 +216,12 @@ export class BqDrawer {
   };
 
   private get isPositionStart() {
-    // !⚠️ `placement` is deprecated and will be removed in the future
+    // !TO BE REMOVED: `placement` is deprecated and will be removed in the future
     return this.position === 'start' || this.placement === 'left';
   }
 
   private get isPositionEnd() {
-    // !⚠️ `placement` is deprecated and will be removed in the future
+    // !TO BE REMOVED: `placement` is deprecated and will be removed in the future
     return this.position === 'end' || this.placement === 'right';
   }
 

--- a/packages/beeq/src/components/drawer/bq-drawer.types.ts
+++ b/packages/beeq/src/components/drawer/bq-drawer.types.ts
@@ -1,5 +1,5 @@
 export const DRAWER_POSITIONS = ['start', 'end'] as const;
 export type TDrawerPosition = (typeof DRAWER_POSITIONS)[number];
-// !⚠️ Note: `placement` is deprecated and it will be removed in the future
+// !TO BE REMOVED: `placement` is deprecated and it will be removed in the future
 export const DRAWER_PLACEMENT = ['left', 'right'] as const;
 export type TDrawerPlacement = (typeof DRAWER_PLACEMENT)[number];

--- a/packages/beeq/src/components/icon/_storybook/bq-icon.stories.tsx
+++ b/packages/beeq/src/components/icon/_storybook/bq-icon.stories.tsx
@@ -29,7 +29,7 @@ const meta: Meta = {
     label: undefined,
     size: 24,
     src: undefined,
-    weight: 'regular',
+    weight: undefined,
   },
 };
 export default meta;

--- a/packages/beeq/src/components/icon/bq-icon.tsx
+++ b/packages/beeq/src/components/icon/bq-icon.tsx
@@ -2,7 +2,7 @@ import { Component, Event, EventEmitter, h, Host, Prop, State, Watch } from '@st
 
 import { TIconWeight } from './bq-icon.types';
 import { getSvgContent, iconContent } from './helper/request';
-import { getBasePath, getColorCSSVariable } from '../../shared/utils';
+import { getBasePath, getColorCSSVariable, isNil } from '../../shared/utils';
 
 /**
  * Icons are simplified images that graphically explain the meaning of an object on the screen.
@@ -39,7 +39,7 @@ export class BqIcon {
   @Prop({ reflect: true }) color?: string;
 
   /** Icon name to load. Please check all available icons [here](https://phosphoricons.com/) */
-  @Prop({ reflect: true }) name!: string;
+  @Prop({ reflect: true, mutable: true }) name!: string;
 
   /** Set the size of the SVG */
   @Prop({ reflect: true }) size?: string | number = 24;
@@ -47,8 +47,8 @@ export class BqIcon {
   /** Set the source of the SVG. If the source is set, the name property will be ignored */
   @Prop({ reflect: true }) src?: string;
 
-  /** It set the icon weight/style */
-  @Prop({ reflect: true }) weight?: TIconWeight = 'regular';
+  /** @deprecated It set the icon weight/style */
+  @Prop({ reflect: true }) weight?: TIconWeight = undefined;
 
   // Prop lifecycle events
   // =======================
@@ -56,9 +56,33 @@ export class BqIcon {
   @Watch('color')
   @Watch('name')
   @Watch('size')
-  @Watch('weight')
   handlePropsChange() {
-    this.loadIcon();
+    this.loadIcon(this.name);
+  }
+
+  /**
+   * !⚠️ Delete this `@Watch()` once the deprecated `weight` property is removed
+   * We need to maintain retro-compatibility until the next major release
+   */
+  @Watch('weight')
+  handleWeightChange() {
+    if (this.name.includes(this.weight)) return;
+
+    console.warn(
+      `❗️ [bq-icon]: the 'weight' property is deprecated, you should add the weight to the icon name.\n
+       For example, '<bq-icon name="bell-fill"></bq-icon>' instead of '<bq-icon name="bell" weight="fill"></bq-icon>'`,
+    );
+    // Check if the icon is weighted. An icon is considered weighted if its weight is not 'regular' and ENV_SVG_PATH is not set.
+    // Eg: if the weight is 'bold' and ENV_SVG_PATH is not set, isWeightedIcon will be true.
+    const REGULAR = 'regular';
+    const isWeightedIcon = !isNil(this.weight) && this.weight !== REGULAR;
+    // If the icon is weighted, append the weight to the icon name. Otherwise, append nothing.
+    // Eg: if isWeightedIcon is true and the weight is 'bold', weightSuffix will be '-bold'.
+    const weightSuffix = isWeightedIcon ? `-${this.weight}` : '';
+    // Construct the icon name by appending the weight suffix (if any) and the file extension.
+    // Eg: if the name is 'my-icon' and weightSuffix is '-bold', iconName will be 'my-icon-bold.svg'.
+    const iconName = `${this.name}${weightSuffix}`;
+    this.loadIcon(iconName);
   }
 
   // Events section
@@ -72,8 +96,11 @@ export class BqIcon {
   // Ordered by their natural call order
   // =====================================
 
-  componentWillLoad() {
+  connectedCallback() {
     this.handlePropsChange();
+
+    // !⚠️ Delete this once the deprecated `weight` property is removed
+    if (!isNil(this.weight)) this.handleWeightChange();
   }
 
   // Listeners
@@ -91,45 +118,23 @@ export class BqIcon {
   // These methods cannot be called from the host element.
   // =======================================================
 
-  private getIconSource = () => {
+  private getIconSource = (name: string) => {
     if (!this.name && !this.src) return;
     // Return the src if it is set
     if (this.src) return this.src;
 
-    const { iconPath } = this.getIconDetails();
-    return getBasePath(iconPath);
+    const SVG_EXTENSION = '.svg';
+    const iconFileName = `${name}${SVG_EXTENSION}`;
+
+    return getBasePath(iconFileName);
   };
 
-  private loadIcon = () => {
-    const url = this.getIconSource();
+  private loadIcon = (name: string) => {
+    const url = this.getIconSource(name);
     getSvgContent(url, true).then(() => {
       this._svgContent = iconContent.get(url);
       this.svgLoaded.emit(this._svgContent);
     });
-  };
-
-  private getIconDetails = (): { iconName: string; iconPath: string } => {
-    const REGULAR = 'regular';
-    const SVG_EXTENSION = '.svg';
-
-    // Check if the icon is weighted. An icon is considered weighted if its weight is not 'regular' and ENV_SVG_PATH is not set.
-    // Eg: if the weight is 'bold' and ENV_SVG_PATH is not set, isWeightedIcon will be true.
-    const isWeightedIcon = this.weight !== REGULAR;
-
-    // If the icon is weighted, append the weight to the icon name. Otherwise, append nothing.
-    // Eg: if isWeightedIcon is true and the weight is 'bold', weightSuffix will be '-bold'.
-    const weightSuffix = isWeightedIcon ? `-${this.weight}` : '';
-
-    // Construct the icon name by appending the weight suffix (if any) and the file extension.
-    // Eg: if the name is 'my-icon' and weightSuffix is '-bold', iconName will be 'my-icon-bold.svg'.
-    const iconName = `${this.name}${weightSuffix}${SVG_EXTENSION}`;
-
-    // Construct the path to the icon file.
-    // Eg: if iconName is 'my-icon-bold.svg', iconPath will be './svg/my-icon-bold.svg'.
-    const iconPath = `${iconName}`;
-
-    // Return the icon name and path.
-    return { iconName, iconPath };
   };
 
   // render() function

--- a/packages/beeq/src/components/icon/bq-icon.tsx
+++ b/packages/beeq/src/components/icon/bq-icon.tsx
@@ -39,7 +39,7 @@ export class BqIcon {
   @Prop({ reflect: true }) color?: string;
 
   /** Icon name to load. Please check all available icons [here](https://phosphoricons.com/) */
-  @Prop({ reflect: true, mutable: true }) name!: string;
+  @Prop({ reflect: true }) name!: string;
 
   /** Set the size of the SVG */
   @Prop({ reflect: true }) size?: string | number = 24;

--- a/packages/beeq/src/components/icon/bq-icon.tsx
+++ b/packages/beeq/src/components/icon/bq-icon.tsx
@@ -111,7 +111,6 @@ export class BqIcon {
   private getIconDetails = (): { iconName: string; iconPath: string } => {
     const REGULAR = 'regular';
     const SVG_EXTENSION = '.svg';
-    const LOCAL_SVG_PATH = './svg/';
 
     // Check if the icon is weighted. An icon is considered weighted if its weight is not 'regular' and ENV_SVG_PATH is not set.
     // Eg: if the weight is 'bold' and ENV_SVG_PATH is not set, isWeightedIcon will be true.
@@ -127,7 +126,7 @@ export class BqIcon {
 
     // Construct the path to the icon file.
     // Eg: if iconName is 'my-icon-bold.svg', iconPath will be './svg/my-icon-bold.svg'.
-    const iconPath = `${LOCAL_SVG_PATH}${iconName}`;
+    const iconPath = `${iconName}`;
 
     // Return the icon name and path.
     return { iconName, iconPath };

--- a/packages/beeq/src/components/icon/bq-icon.tsx
+++ b/packages/beeq/src/components/icon/bq-icon.tsx
@@ -61,7 +61,7 @@ export class BqIcon {
   }
 
   /**
-   * !⚠️ Delete this `@Watch()` once the deprecated `weight` property is removed
+   * !TO BE REMOVED: Delete this `@Watch()` once the deprecated `weight` property is removed
    * We need to maintain retro-compatibility until the next major release
    */
   @Watch('weight')
@@ -99,7 +99,7 @@ export class BqIcon {
   connectedCallback() {
     this.handlePropsChange();
 
-    // !⚠️ Delete this once the deprecated `weight` property is removed
+    // !TO BE REMOVED: Delete this once the deprecated `weight` property is removed
     if (!isNil(this.weight)) this.handleWeightChange();
   }
 

--- a/packages/beeq/src/components/icon/bq-icon.types.ts
+++ b/packages/beeq/src/components/icon/bq-icon.types.ts
@@ -1,2 +1,3 @@
+// !TO BE REMOVED: Remove this file when the deprecated `weight` property is removed
 export const ICON_WEIGHT = ['thin', 'light', 'regular', 'bold', 'fill', 'duotone'] as const;
 export type TIconWeight = (typeof ICON_WEIGHT)[number];

--- a/packages/beeq/src/components/icon/readme.md
+++ b/packages/beeq/src/components/icon/readme.md
@@ -16,7 +16,7 @@ Icons are simplified images that graphically explain the meaning of an object on
 | `name` _(required)_ | `name`    | Icon name to load. Please check all available icons [here](https://phosphoricons.com/)  | `string`                                                          | `undefined` |
 | `size`              | `size`    | Set the size of the SVG                                                                 | `number \| string`                                                | `24`        |
 | `src`               | `src`     | Set the source of the SVG. If the source is set, the name property will be ignored      | `string`                                                          | `undefined` |
-| `weight`            | `weight`  | It set the icon weight/style                                                            | `"bold" \| "duotone" \| "fill" \| "light" \| "regular" \| "thin"` | `'regular'` |
+| `weight`            | `weight`  | <span style="color:red">**[DEPRECATED]**</span> It set the icon weight/style<br/><br/>  | `"bold" \| "duotone" \| "fill" \| "light" \| "regular" \| "thin"` | `undefined` |
 
 
 ## Events

--- a/packages/beeq/src/components/icon/scss/bq-icon.scss
+++ b/packages/beeq/src/components/icon/scss/bq-icon.scss
@@ -13,5 +13,5 @@
  * See lines 42 and 58 for details.
  */
 .bq-icon__svg {
-  @apply scale-x-[--bq-icon--direction] fill-current;
+  @apply scale-x-[--bq-icon--direction];
 }

--- a/packages/beeq/src/shared/utils/assetsPath.ts
+++ b/packages/beeq/src/shared/utils/assetsPath.ts
@@ -31,7 +31,7 @@ export const getBasePath = (subpath = '') => {
     const script = configScript || fallbackScript;
     if (script) {
       const path = configScript ? script.getAttribute('data-beeq') : getScriptPath(script);
-      setBasePath(path);
+      setBasePath(`${path}/svg`);
     }
   }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR deprecates the `weight` property on the Icon component. This property was added when we had the SVG assets split in a different folder by weight: `thin`, `light`, `regular`, `fill`, `bold`, and `duotone`, but the SVG assets have been merged into a single folder and the weight can now be set within the icon name itself, if before we could have:

```html
<bq-icon name="bell" size="24" weight="bold"></bq-icon>
```

now we can archive the same by doing the following:

```html
<bq-icon name="bell-bold" size="24"></bq-icon>
```

Also, we have improved the `setBasePath()` and now users can specify even remote URLs in order to use a different icon library

![image](https://github.com/user-attachments/assets/be8a1460-ec08-493d-b546-0962d86824b2)

## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

N/A

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->

We have also added VSCode Anchors to highlight what needs to be removed in the future.

![CleanShot 2024-08-01 at 20 19 07@2x](https://github.com/user-attachments/assets/8f5f0838-ff22-41a7-8b26-759f8d84d93b)

