### PR TITLE
fix(Drawer): use `x-bold` icon instead and move `button-close` slot inside `<bq-button>`

### DIFF
--- a/packages/beeq/src/components/drawer/_storybook/bq-drawer.stories.tsx
+++ b/packages/beeq/src/components/drawer/_storybook/bq-drawer.stories.tsx
@@ -1,5 +1,6 @@
 import type { Args, Meta, StoryObj } from '@storybook/web-components';
 import { html, nothing } from 'lit-html';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 import mdx from './bq-drawer.mdx';
 import { DRAWER_POSITIONS } from '../bq-drawer.types';
@@ -26,6 +27,7 @@ const meta: Meta = {
     // Not part of the component API
     noFooter: { control: 'boolean', table: { disable: true } },
     customFooterDivider: { control: 'boolean', table: { disable: true } },
+    customCloseIcon: { control: 'text', table: { disable: true } },
   },
   args: {
     open: false,
@@ -69,6 +71,7 @@ const Template = (args: Args) => {
       @bqAfterOpen=${args.bqAfterOpen}
       @bqAfterClose=${args.bqAfterClose}
     >
+      ${ifDefined(args.customCloseIcon) ? args.customCloseIcon : nothing}
       <div class="flex gap-xs" slot="title">
         <bq-icon name="user-circle" weight="bold" role="img" title="Info"></bq-icon>
         Title
@@ -122,5 +125,18 @@ export const WithCustomFooterDivider: Story = {
   args: {
     'enable-backdrop': true,
     customFooterDivider: true,
+  },
+};
+
+export const WithCustomCloseIcon: Story = {
+  render: Template,
+  args: {
+    'enable-backdrop': true,
+    customCloseIcon: html`<bq-icon
+      name="arrow-fat-lines-right"
+      role="img"
+      title="Close"
+      slot="button-close"
+    ></bq-icon>`,
   },
 };

--- a/packages/beeq/src/components/drawer/bq-drawer.tsx
+++ b/packages/beeq/src/components/drawer/bq-drawer.tsx
@@ -5,7 +5,9 @@ import { enter, hasSlotContent, isNil, leave, validatePropValue } from '../../sh
 
 /**
  * @part backdrop - The `<div>` that holds the backdrop overlay
- * @part button-close - The button that close the dialog on click
+ * @part button-close - The BqButton that closes the drawer
+ * @part button-close__btn - The native button used under the hood that closes the drawer
+ * @part button-close__label - The text inside the native button that closes the drawer
  * @part panel - The `<div>` that holds the drawer entire content
  * @part header - The `<header>` that holds the icon, title, and close button
  * @part title - The `<div>` that holds the title content
@@ -262,7 +264,7 @@ export class BqDrawer {
           part="panel"
           role="dialog"
         >
-          <header class="flex" part="header">
+          <header class="flex items-center" part="header">
             <h2
               class="flex-1 items-center justify-between font-bold leading-regular text-text-primary"
               id="bq-drawer__title"
@@ -271,17 +273,18 @@ export class BqDrawer {
               <slot name="title" />
             </h2>
             <div class="flex" part="button-close">
-              <slot name="button-close">
-                <bq-button
-                  class="[&::part(button)]:rounded-s [&::part(button)]:border-0 [&::part(button)]:bs-fit [&::part(button)]:p-b-0 [&::part(button)]:p-i-0"
-                  appearance="text"
-                  size="small"
-                  slot="button-close"
-                  onClick={() => this.hide()}
-                >
-                  <bq-icon weight="bold" name="x" role="img" title="Close" />
-                </bq-button>
-              </slot>
+              <bq-button
+                class="[&::part(button)]:rounded-s [&::part(button)]:border-0 [&::part(button)]:bs-fit [&::part(button)]:p-b-0 [&::part(button)]:p-i-0 [&::part(label)]:inline-flex"
+                appearance="text"
+                size="small"
+                slot="button-close"
+                exportparts="button:button-close__btn,label:button-close__label"
+                onClick={this.hide.bind(this)}
+              >
+                <slot name="button-close">
+                  <bq-icon name="x-bold" role="img" title="Close" />
+                </slot>
+              </bq-button>
             </div>
           </header>
           <main class="block flex-auto overflow-auto" part="body">

--- a/packages/beeq/src/components/drawer/readme.md
+++ b/packages/beeq/src/components/drawer/readme.md
@@ -52,15 +52,17 @@ Type: `Promise<void>`
 
 ## Shadow Parts
 
-| Part             | Description                                                 |
-| ---------------- | ----------------------------------------------------------- |
-| `"backdrop"`     | The `<div>` that holds the backdrop overlay                 |
-| `"body"`         | The `<main>` that holds the drawer body content             |
-| `"button-close"` | The button that close the dialog on click                   |
-| `"footer"`       | The `<footer>` that holds footer content                    |
-| `"header"`       | The `<header>` that holds the icon, title, and close button |
-| `"panel"`        | The `<div>` that holds the drawer entire content            |
-| `"title"`        | The `<div>` that holds the title content                    |
+| Part                    | Description                                                  |
+| ----------------------- | ------------------------------------------------------------ |
+| `"backdrop"`            | The `<div>` that holds the backdrop overlay                  |
+| `"body"`                | The `<main>` that holds the drawer body content              |
+| `"button-close"`        | The BqButton that closes the drawer                          |
+| `"button-close__btn"`   | The native button used under the hood that closes the drawer |
+| `"button-close__label"` | The text inside the native button that closes the drawer     |
+| `"footer"`              | The `<footer>` that holds footer content                     |
+| `"header"`              | The `<header>` that holds the icon, title, and close button  |
+| `"panel"`               | The `<div>` that holds the drawer entire content             |
+| `"title"`               | The `<div>` that holds the title content                     |
 
 
 ## Dependencies


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This pull request eliminates the weight attribute from the `bq-icon` component, which is internally used to close the drawer. Additionally, it relocates the `button-close` slot within the `bq-button`, ensuring that the behavior and functionality are preserved, allowing users to concentrate solely on changing the icon without implementing the closing behavior.

![image](https://github.com/user-attachments/assets/8e86b544-a509-4420-b431-0ce33737b128)

## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

Fixes #ISSUE_NUMBER

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
