### PR TITLE
feat(Input): enable support for form-associated

### DIFF
--- a/packages/beeq/src/components/input/_storybook/bq-input.stories.tsx
+++ b/packages/beeq/src/components/input/_storybook/bq-input.stories.tsx
@@ -262,3 +262,89 @@ export const NoHelperText: Story = {
     suffix: true,
   },
 };
+
+export const WithForm: Story = {
+  render: () => {
+    const handleFormSubmit = (ev: Event) => {
+      ev.preventDefault();
+      const form = ev.target as HTMLFormElement;
+      const formData = new FormData(form);
+      const formValues = Object.fromEntries(formData.entries());
+
+      const codeElement = document.getElementById('form-data');
+      if (!codeElement) return;
+
+      codeElement.textContent = JSON.stringify(formValues, null, 2);
+    };
+
+    return html`
+      <link rel="stylesheet" href="https://unpkg.com/@highlightjs/cdn-assets@11.10.0/styles/night-owl.min.css" />
+
+      <div class="grid auto-cols-auto grid-cols-1 gap-y-l sm:grid-cols-2 sm:gap-x-l">
+        <bq-card>
+          <h4 class="m-be-m">Shipping Information</h4>
+          <form class="flex flex-col gap-y-m" @submit=${handleFormSubmit}>
+            <div class="grid grid-cols-1 gap-y-m sm:grid-cols-2 sm:gap-x-m">
+              <bq-input name="firstName" value="Brad Bernie" autocomplete="given-name" required>
+                <label class="flex flex-grow items-center" slot="label">First Name</label>
+              </bq-input>
+              <bq-input name="lastName" value="Beckett" autocomplete="family-name" required>
+                <label class="flex flex-grow items-center" slot="label">Last Name</label>
+              </bq-input>
+            </div>
+            <bq-input name="company" value="Endava" autocomplete="organization" required>
+              <label class="flex flex-grow items-center" slot="label">Company</label>
+            </bq-input>
+            <bq-input name="address" value="413 South Ohio Ave" autocomplete="shipping street-address" required>
+              <label class="flex flex-grow items-center" slot="label">Address</label>
+            </bq-input>
+            <div class="grid grid-cols-1 gap-y-m sm:grid-cols-2 sm:gap-x-m" autocomplete="address-level2">
+              <bq-input name="city" value="Oklahoma" required>
+                <label class="flex flex-grow items-center" slot="label">City</label>
+              </bq-input>
+              <bq-select name="country" value="us" autocomplete="country-name">
+                <label class="flex flex-grow items-center" slot="label">Country</label>
+                <bq-option value="au">Australia</bq-option>
+                <bq-option value="ca">Canada</bq-option>
+                <bq-option value="mx">Mexico</bq-option>
+                <bq-option value="pt">Portugal</bq-option>
+                <bq-option value="ro">Romania</bq-option>
+                <bq-option value="us">United States</bq-option>
+              </bq-select>
+            </div>
+            <div class="flex justify-end gap-x-s">
+              <bq-button appearance="secondary" type="reset">Cancel</bq-button>
+              <bq-button type="submit">Save</bq-button>
+            </div>
+          </form>
+        </bq-card>
+        <bq-card class="[&::part(wrapper)]:h-full">
+          <h4 class="m-be-m">Form Data</h4>
+          <div class="language-javascript overflow-x-scroll whitespace-pre rounded-s">
+            // Handle form submit<br />
+            const form = ev.target as HTMLFormElement;<br />
+            const formData = new FormData(form);<br />
+            const formValues = Object.fromEntries(formData.entries());
+          </div>
+          <pre>
+            <code id="form-data" class="rounded-s">
+              { // submit the form to see the data here }
+            </code>
+          </pre>
+        </bq-card>
+      </div>
+
+      <script type="module">
+        import hljs from 'https://unpkg.com/@highlightjs/cdn-assets@11.10.0/es/highlight.min.js';
+        import javascript from 'https://unpkg.com/@highlightjs/cdn-assets@11.10.0/es/languages/javascript.min.js';
+
+        hljs.registerLanguage('javascript', javascript);
+        hljs.highlightAll();
+
+        document.querySelectorAll('div.language-javascript').forEach((block) => {
+          hljs.highlightElement(block);
+        });
+      </script>
+    `;
+  },
+};

--- a/packages/beeq/src/components/input/bq-input.tsx
+++ b/packages/beeq/src/components/input/bq-input.tsx
@@ -1,7 +1,7 @@
 import { AttachInternals, Component, Element, Event, EventEmitter, h, Prop, State, Watch } from '@stencil/core';
 
 import { TInputType, TInputValidation, TInputValue } from './bq-input.types';
-import { debounce, hasSlotContent, isDefined, isHTMLElement, TDebounce } from '../../shared/utils';
+import { debounce, hasSlotContent, isDefined, isHTMLElement, isNil, TDebounce } from '../../shared/utils';
 
 /**
  * @part base - The component's base wrapper.
@@ -218,6 +218,8 @@ export class BqInput {
   }
 
   formResetCallback() {
+    if (isNil(this.value)) return;
+
     this.handleClear();
   }
 
@@ -276,7 +278,7 @@ export class BqInput {
   private handleClear = () => {
     if (this.disabled) return;
 
-    const { inputElem, internals, bqClear, bqInput, bqChange, el } = this;
+    const { inputElem, internals } = this;
 
     // Clear input element value
     inputElem.value = '';
@@ -284,19 +286,19 @@ export class BqInput {
 
     // Update associated form control value
     internals.setFormValue(undefined);
-
-    // Emit events
-    bqClear.emit(el);
-    bqInput.emit({ value: this.value, el });
-    bqChange.emit({ value: this.value, el });
-
-    // Refocus input element
-    inputElem.focus();
   };
 
   private handleClearClick = (ev: CustomEvent) => {
     ev.stopPropagation();
     this.handleClear();
+
+    const { bqClear, bqChange, bqInput, el, inputElem } = this;
+    // Emit events
+    bqClear.emit(el);
+    bqInput.emit({ value: this.value, el });
+    bqChange.emit({ value: this.value, el });
+    // Refocus input element
+    inputElem.focus();
   };
 
   private handleLabelSlotChange = () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR enables support for form-associated custom elements, allowing them to participate in HTML forms:
* https://stenciljs.com/docs/forms#using-form-associated-custom-elements
* https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/attachInternals

Currently, to attach the `<bq-input>` component to a form users need to do so manually. With this PR, users only need to be aware of setting the component name attribute/property to be linked to the form.

https://github.com/user-attachments/assets/07c33e4b-b77f-4b7d-a1fd-6774827241db

## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

Fixes #ISSUE_NUMBER

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
