### PR TITLE
feat(Checkbox): enable support for form-associated

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -43,7 +43,7 @@
   packageRules: [
     {
       groupName: 'Angular',
-      matchPackagePrefixes: ['@angular', '@angular-devkit' '@schematics', 'ng-packagr'],
+      matchPackagePrefixes: ['@angular', '@angular-devkit', '@schematics', 'ng-packagr'],
     },
     {
       groupName: 'Angular ESLint',

--- a/packages/beeq/src/components.d.ts
+++ b/packages/beeq/src/components.d.ts
@@ -303,6 +303,10 @@ export namespace Components {
          */
         "formId"?: string;
         /**
+          * The native form validation message
+         */
+        "formValidationMessage"?: string;
+        /**
           * A state that is neither checked nor unchecked
          */
         "indeterminate"?: boolean;
@@ -2588,6 +2592,10 @@ declare namespace LocalJSX {
           * The form ID that the checkbox is associated with
          */
         "formId"?: string;
+        /**
+          * The native form validation message
+         */
+        "formValidationMessage"?: string;
         /**
           * A state that is neither checked nor unchecked
          */

--- a/packages/beeq/src/components/checkbox/_storybook/bq-checkbox.stories.tsx
+++ b/packages/beeq/src/components/checkbox/_storybook/bq-checkbox.stories.tsx
@@ -1,5 +1,6 @@
 import type { Args, Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 import mdx from './bq-checkbox.mdx';
 
@@ -13,9 +14,10 @@ const meta: Meta = {
   },
   argTypes: {
     'background-on-hover': { control: 'boolean' },
-    'form-id': { control: 'text' },
     checked: { control: 'boolean' },
     disabled: { control: 'boolean' },
+    'form-id': { control: 'text' },
+    'form-validation-message': { control: 'text' },
     indeterminate: { control: 'boolean' },
     name: { control: 'text' },
     required: { control: 'boolean' },
@@ -29,9 +31,10 @@ const meta: Meta = {
   },
   args: {
     'background-on-hover': false,
-    'form-id': undefined,
     checked: false,
     disabled: false,
+    'form-id': undefined,
+    'form-validation-message': undefined,
     indeterminate: false,
     name: 'bq-checkbox',
     required: false,
@@ -47,13 +50,14 @@ type Story = StoryObj;
 const Template = (args: Args) => html`
   <bq-checkbox
     ?background-on-hover=${args['background-on-hover']}
-    .formId=${args['form-id']}
     ?checked=${args.checked}
     ?disabled=${args.disabled}
+    form-id=${ifDefined(args['form-id'])}
+    form-validation-message=${ifDefined(args['form-validation-message'])}
     ?indeterminate=${args.indeterminate}
-    .name=${args.name}
+    name=${ifDefined(args.name)}
     ?required=${args.required}
-    .value=${args.value}
+    value=${ifDefined(args.value)}
     @bqFocus=${args.bqFocus}
     @bqBlur=${args.bqBlur}
     @bqChange=${args.bqChange}
@@ -145,5 +149,78 @@ export const Indeterminate: Story = {
   },
   args: {
     indeterminate: true,
+  },
+};
+
+export const WithForm: Story = {
+  render: (args: Args) => {
+    const handleFormSubmit = (ev: Event) => {
+      ev.preventDefault();
+      const form = ev.target as HTMLFormElement;
+      const formData = new FormData(form);
+      const formValues = Object.fromEntries(formData.entries());
+
+      const codeElement = document.getElementById('form-data');
+      if (!codeElement) return;
+
+      codeElement.textContent = JSON.stringify(formValues, null, 2);
+    };
+
+    return html`
+      <link rel="stylesheet" href="https://unpkg.com/@highlightjs/cdn-assets@11.10.0/styles/night-owl.min.css" />
+      <div class="grid auto-cols-auto grid-cols-1 gap-y-l sm:grid-cols-2 sm:gap-x-l">
+        <bq-card>
+          <h4 class="m-be-m">Sign in to your account</h4>
+          <form class="flex flex-col gap-y-m" @submit=${handleFormSubmit}>
+            <bq-input name="email" type="email" autocomplete="email">
+              <label class="flex flex-grow items-center" slot="label">Email address</label>
+            </bq-input>
+            <bq-input name="password" type="password" autocomplete="current-password">
+              <label class="flex flex-grow items-center" slot="label">Password</label>
+            </bq-input>
+            <!-- Checkbox -->
+            ${Template({ ...args })}
+            <!-- End: Checkbox -->
+            <div class="flex justify-end gap-x-s">
+              <bq-button appearance="secondary" type="reset">Cancel</bq-button>
+              <bq-button type="submit">Log in</bq-button>
+            </div>
+          </form>
+        </bq-card>
+        <bq-card class="[&::part(wrapper)]:h-full">
+          <h4 class="m-be-m">Form Data</h4>
+          <div class="language-javascript overflow-x-scroll whitespace-pre rounded-s">
+            // Handle form submit<br />
+            const form = ev.target as HTMLFormElement;<br />
+            const formData = new FormData(form);<br />
+            const formValues = Object.fromEntries(formData.entries());
+          </div>
+          <pre>
+            <code id="form-data" class="rounded-s">
+              { // submit the form to see the data here }
+            </code>
+          </pre>
+        </bq-card>
+      </div>
+
+      <script type="module">
+        import hljs from 'https://unpkg.com/@highlightjs/cdn-assets@11.10.0/es/highlight.min.js';
+        import javascript from 'https://unpkg.com/@highlightjs/cdn-assets@11.10.0/es/languages/javascript.min.js';
+
+        hljs.registerLanguage('javascript', javascript);
+        hljs.highlightAll();
+
+        document.querySelectorAll('div.language-javascript').forEach((block) => {
+          hljs.highlightElement(block);
+        });
+      </script>
+    `;
+  },
+  args: {
+    'form-validation-message': 'Please accept the terms and conditions.',
+    label: 'By clicking here, I state that I have read and understood the terms and conditions.',
+    name: 'terms',
+    required: true,
+    value: 'terms',
   },
 };

--- a/packages/beeq/src/components/checkbox/readme.md
+++ b/packages/beeq/src/components/checkbox/readme.md
@@ -7,16 +7,17 @@
 
 ## Properties
 
-| Property             | Attribute             | Description                                                                                                                            | Type      | Default     |
-| -------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
-| `backgroundOnHover`  | `background-on-hover` | If true checkbox displays background on hover                                                                                          | `boolean` | `false`     |
-| `checked`            | `checked`             | If true checkbox is checked                                                                                                            | `boolean` | `undefined` |
-| `disabled`           | `disabled`            | If true checkbox is disabled                                                                                                           | `boolean` | `false`     |
-| `formId`             | `form-id`             | The form ID that the checkbox is associated with                                                                                       | `string`  | `undefined` |
-| `indeterminate`      | `indeterminate`       | A state that is neither checked nor unchecked                                                                                          | `boolean` | `false`     |
-| `name` _(required)_  | `name`                | Name of the HTML input form control. Submitted with the form as part of a name/value pair.                                             | `string`  | `undefined` |
-| `required`           | `required`            | If `true`, it will indicate that the user must specify a value for the checkbox before the owning form can be submitted                | `boolean` | `undefined` |
-| `value` _(required)_ | `value`               | A string representing the value of the checkbox. Primarily used to differentiate a list of related checkboxes that have the same name. | `string`  | `undefined` |
+| Property                | Attribute                 | Description                                                                                                                            | Type      | Default     |
+| ----------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
+| `backgroundOnHover`     | `background-on-hover`     | If true checkbox displays background on hover                                                                                          | `boolean` | `false`     |
+| `checked`               | `checked`                 | If true checkbox is checked                                                                                                            | `boolean` | `undefined` |
+| `disabled`              | `disabled`                | If true checkbox is disabled                                                                                                           | `boolean` | `false`     |
+| `formId`                | `form-id`                 | The form ID that the checkbox is associated with                                                                                       | `string`  | `undefined` |
+| `formValidationMessage` | `form-validation-message` | The native form validation message                                                                                                     | `string`  | `undefined` |
+| `indeterminate`         | `indeterminate`           | A state that is neither checked nor unchecked                                                                                          | `boolean` | `false`     |
+| `name` _(required)_     | `name`                    | Name of the HTML input form control. Submitted with the form as part of a name/value pair.                                             | `string`  | `undefined` |
+| `required`              | `required`                | If `true`, it will indicate that the user must specify a value for the checkbox before the owning form can be submitted                | `boolean` | `undefined` |
+| `value` _(required)_    | `value`                   | A string representing the value of the checkbox. Primarily used to differentiate a list of related checkboxes that have the same name. | `string`  | `undefined` |
 
 
 ## Events


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR enables support for form-associated custom elements, allowing them to participate in HTML forms:

https://stenciljs.com/docs/forms#using-form-associated-custom-elements
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/attachInternals

Currently, adding a `<bq-checkbox>` element to a form does not result in its participation in the form submission, even when a `name` and `formId` are provided. With this pull request, users need only to set the component's name attribute/property to link it to the form. Additionally, it enables validation of the element when 'required' is present, thus preventing form submission if the BqCheckbox is not selected or checked.

https://github.com/user-attachments/assets/4ff5df81-ca8b-41c6-a4b3-0c9d119d0dbf

## Related Issue
<!-- If this PR is related to an existing issue, link it here. -->

Fixes #ISSUE_NUMBER

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please review the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my own code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
