### PR TITLE
fix(Select): display value is not shown when initial value is set

### DIFF
--- a/packages/beeq/src/components/select/bq-select.tsx
+++ b/packages/beeq/src/components/select/bq-select.tsx
@@ -13,16 +13,7 @@ import {
 } from '@stencil/core';
 
 import { Placement } from '../../services/interfaces';
-import {
-  debounce,
-  getTextContent,
-  hasSlotContent,
-  isDefined,
-  isHTMLElement,
-  isNil,
-  isString,
-  TDebounce,
-} from '../../shared/utils';
+import { debounce, hasSlotContent, isDefined, isHTMLElement, isNil, isString, TDebounce } from '../../shared/utils';
 import { TInputValidation } from '../input/bq-input.types';
 
 export type TSelectValue = string | string[];
@@ -454,15 +445,13 @@ export class BqSelect {
     const checkedItem = options.find((item) => item.value === value);
     const displayValue = checkedItem ? this.getOptionLabel(checkedItem) : '';
 
-    inputElem.value = displayValue ?? '';
+    inputElem.value = displayValue;
     this.displayValue = displayValue;
   };
 
   private getOptionLabel = (item: HTMLBqOptionElement) => {
-    const slot = item.shadowRoot.querySelector('slot:not([name])');
-    if (!slot) return;
-
-    return getTextContent(slot as HTMLSlotElement);
+    if (!item) return;
+    return item.innerText.trim() ?? '';
   };
 
   private get options() {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This pull request resolves an issue with the Select component not displaying the selected value when the initial value is set directly. For example, when having something like the following:

```jsx
<BqSelect
  name="gender"
  placeholder="Select from the list"
  value="Rather not say"
>
  <BqOption value="male">Male</BqOption>
  <BqOption value="female">Female</BqOption>
  <BqOption value="rather not say">Rather not say</BqOption>
</BqSelect>
```

The component renders with an empty display value, even though the 'Male' option is selected.

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

Fixes #ISSUE_NUMBER

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

![CleanShot 2024-08-21 at 15 31 31](https://github.com/user-attachments/assets/dca4e851-53db-4ee5-a02a-8d7b707e3d50)

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [ ] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [ ] I have reviewed my code.
- [ ] I have tested the changes locally.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added unit tests and e2e tests (if applicable).
- [ ] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
