### PR TITLE
fix(Alert): make close icon customizable via slot

### DIFF
--- a/packages/beeq/src/components.d.ts
+++ b/packages/beeq/src/components.d.ts
@@ -1636,8 +1636,8 @@ declare global {
     interface HTMLBqAlertElementEventMap {
         "bqHide": any;
         "bqShow": any;
-        "bqAfterOpen": any;
-        "bqAfterClose": any;
+        "bqAfterShow": any;
+        "bqAfterHide": any;
     }
     interface HTMLBqAlertElement extends Components.BqAlert, HTMLStencilElement {
         addEventListener<K extends keyof HTMLBqAlertElementEventMap>(type: K, listener: (this: HTMLBqAlertElement, ev: BqAlertCustomEvent<HTMLBqAlertElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2376,13 +2376,13 @@ declare namespace LocalJSX {
          */
         "hideIcon"?: boolean;
         /**
-          * Callback handler to be called after the alert has been closed
+          * Callback handler to be called after the alert has been hidden
          */
-        "onBqAfterClose"?: (event: BqAlertCustomEvent<any>) => void;
+        "onBqAfterHide"?: (event: BqAlertCustomEvent<any>) => void;
         /**
-          * Callback handler to be called after the alert has been opened
+          * Callback handler to be called after the alert has been shown
          */
-        "onBqAfterOpen"?: (event: BqAlertCustomEvent<any>) => void;
+        "onBqAfterShow"?: (event: BqAlertCustomEvent<any>) => void;
         /**
           * Callback handler to be called when the alert is hidden
          */

--- a/packages/beeq/src/components/alert/_storybook/bq-alert.stories.tsx
+++ b/packages/beeq/src/components/alert/_storybook/bq-alert.stories.tsx
@@ -1,5 +1,6 @@
 import type { Args, Meta, StoryObj } from '@storybook/web-components';
 import { html, nothing } from 'lit-html';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 import mdx from './bq-alert.mdx';
 import { ALERT_BORDER_RADIUS, ALERT_TYPE } from '../bq-alert.types';
@@ -21,6 +22,11 @@ const meta: Meta = {
     open: { control: 'boolean' },
     time: { control: 'number' },
     type: { control: 'select', options: [...ALERT_TYPE] },
+    // Events
+    bqShow: { action: 'bqShow' },
+    bqAfterShow: { action: 'bqAfterShow' },
+    bqHide: { action: 'bqHide' },
+    bqAfterHide: { action: 'bqAfterHide' },
   },
   args: {
     'auto-dismiss': false,
@@ -43,10 +49,14 @@ const Template = (args: Args) => html`
       ?auto-dismiss=${args['auto-dismiss']}
       ?disable-close=${args['disable-close']}
       ?hide-icon=${args['hide-icon']}
-      border=${args.border}
+      border=${ifDefined(args.border)}
       ?open=${args.open}
-      time=${args.time}
-      type=${args.type}
+      time=${ifDefined(args.time)}
+      type=${ifDefined(args.type)}
+      @bqShow=${args.bqShow}
+      @bqAfterShow=${args.bqAfterShow}
+      @bqHide=${args.bqHide}
+      @bqAfterHide=${args.bqAfterHide}
     >
       ${args.type === 'default' ? html`<bq-icon name="star" slot="icon"></bq-icon>` : nothing} Title
     </bq-alert>
@@ -55,10 +65,14 @@ const Template = (args: Args) => html`
       ?auto-dismiss=${args['auto-dismiss']}
       ?disable-close=${args['disable-close']}
       ?hide-icon=${args['hide-icon']}
-      border=${args.border}
+      border=${ifDefined(args.border)}
       ?open=${args.open}
-      time=${args.time}
-      type=${args.type}
+      time=${ifDefined(args.time)}
+      type=${ifDefined(args.type)}
+      @bqShow=${args.bqShow}
+      @bqAfterShow=${args.bqAfterShow}
+      @bqHide=${args.bqHide}
+      @bqAfterHide=${args.bqAfterHide}
     >
       ${args.type === 'default' ? html`<bq-icon name="star" slot="icon"></bq-icon>` : nothing} Title
       <span slot="body">
@@ -71,10 +85,14 @@ const Template = (args: Args) => html`
       ?auto-dismiss=${args['auto-dismiss']}
       ?disable-close=${args['disable-close']}
       ?hide-icon=${args['hide-icon']}
-      border=${args.border}
+      border=${ifDefined(args.border)}
       ?open=${args.open}
-      time=${args.time}
-      type=${args.type}
+      time=${ifDefined(args.time)}
+      type=${ifDefined(args.type)}
+      @bqShow=${args.bqShow}
+      @bqAfterShow=${args.bqAfterShow}
+      @bqHide=${args.bqHide}
+      @bqAfterHide=${args.bqAfterHide}
     >
       ${args.type === 'default' ? html`<bq-icon name="star" slot="icon"></bq-icon>` : nothing} Title
       ${!args.sticky
@@ -99,10 +117,14 @@ const TemplateSticky = (args: Args) => html`
     ?disable-close=${args['disable-close']}
     ?hide-icon=${args['hide-icon']}
     ?sticky=${args['sticky']}
-    border=${args.border}
+    border=${ifDefined(args.border)}
     ?open=${args.open}
-    time=${args.time}
-    type=${args.type}
+    time=${ifDefined(args.time)}
+    type=${ifDefined(args.type)}
+    @bqShow=${args.bqShow}
+    @bqAfterShow=${args.bqAfterShow}
+    @bqHide=${args.bqHide}
+    @bqAfterHide=${args.bqAfterHide}
   >
     ${args.type === 'default' ? html`<bq-icon name="star" slot="icon"></bq-icon>` : nothing} Title
     <bq-button appearance="link" size="small"> Button </bq-button>
@@ -158,6 +180,69 @@ export const Sticky: Story = {
   args: {
     open: true,
     sticky: true,
+    type: 'error',
+  },
+};
+
+export const WithTrigger: Story = {
+  render: (args: Args) => {
+    const handleFormSubmit = async (ev: Event) => {
+      ev.preventDefault();
+
+      const bqAlertElem = document.querySelector('bq-alert');
+      if (!bqAlertElem) return;
+
+      await bqAlertElem.show();
+    };
+
+    const handleFormReset = async () => {
+      const bqAlertElem = document.querySelector('bq-alert');
+      if (!bqAlertElem) return;
+
+      await bqAlertElem.hide();
+    };
+
+    return html`
+      <bq-card>
+        <form id="change-password" class="flex flex-col gap-y-m" @submit=${handleFormSubmit} @reset=${handleFormReset}>
+          <!-- Alert -->
+          <bq-alert
+            ?auto-dismiss=${args['auto-dismiss']}
+            ?disable-close=${args['disable-close']}
+            ?hide-icon=${args['hide-icon']}
+            ?sticky=${args['sticky']}
+            border=${args.border}
+            ?open=${args.open}
+            time=${args.time}
+            type=${args.type}
+            @bqShow=${args.bqShow}
+            @bqAfterShow=${args.bqAfterShow}
+            @bqHide=${args.bqHide}
+            @bqAfterHide=${args.bqAfterHide}
+          >
+            There were 2 errors with your submission
+            <span slot="body">
+              <ul class="ps-m m-be-0 m-bs-0">
+                <li>Your password must be at least 8 characters</li>
+                <li>Your password must include at least one pro wrestling finishing move</li>
+              </ul>
+            </span>
+          </bq-alert>
+          <bq-input name="password" type="password" required>
+            <label class="flex flex-grow items-center" slot="label">Password</label>
+          </bq-input>
+          <bq-input name="confirm-password" type="password" required>
+            <label class="flex flex-grow items-center" slot="label">Confirm Password</label>
+          </bq-input>
+          <div class="flex justify-end gap-x-m">
+            <bq-button appearance="secondary" type="reset">Cancel</bq-button>
+            <bq-button type="submit">Save</bq-button>
+          </div>
+        </form>
+      </bq-card>
+    `;
+  },
+  args: {
     type: 'error',
   },
 };

--- a/packages/beeq/src/components/alert/bq-alert.tsx
+++ b/packages/beeq/src/components/alert/bq-alert.tsx
@@ -15,9 +15,7 @@ import { debounce, enter, hasSlotContent, leave, TDebounce, validatePropValue } 
  * @part svg - The `<svg>` element of the predefined bq-icon component
  * @part title - The container `<div>` that wraps the alert title content
  * @part wrapper - The wrapper container `<div>` of the element inside the shadow DOM
- */
-
-/**
+ *
  * @slot - The alert title content (no slot name required)
  * @slot body - The alert description content
  * @slot footer - The alert footer content

--- a/packages/beeq/src/components/alert/readme.md
+++ b/packages/beeq/src/components/alert/readme.md
@@ -65,17 +65,19 @@ Type: `Promise<void>`
 
 ## Shadow Parts
 
-| Part             | Description |
-| ---------------- | ----------- |
-| `"body"`         |             |
-| `"btn-close"`    |             |
-| `"content"`      |             |
-| `"footer"`       |             |
-| `"icon"`         |             |
-| `"icon-outline"` |             |
-| `"main"`         |             |
-| `"title"`        |             |
-| `"wrapper"`      |             |
+| Part             | Description                                                                                                               |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `"base"`         | The `<div>` container of the predefined bq-icon component                                                                 |
+| `"body"`         | The container `<div>` that wraps the alert description content                                                            |
+| `"btn-close"`    | The `bq-button` used to close the alert                                                                                   |
+| `"content"`      | The container `<div>` that wraps all the alert content (title, description, footer)                                       |
+| `"footer"`       | The container `<div>` that wraps the alert footer content                                                                 |
+| `"icon"`         | The `<bq-icon>` element used to render a predefined icon based on the alert type (info, success, warning, error, default) |
+| `"icon-outline"` | The container `<div>` that wraps the icon element                                                                         |
+| `"main"`         | The container `<div>` that wraps the alert main content (title, description)                                              |
+| `"svg"`          | The `<svg>` element of the predefined bq-icon component                                                                   |
+| `"title"`        | The container `<div>` that wraps the alert title content                                                                  |
+| `"wrapper"`      | The wrapper container `<div>` of the element inside the shadow DOM                                                        |
 
 
 ## Dependencies

--- a/packages/beeq/src/components/alert/readme.md
+++ b/packages/beeq/src/components/alert/readme.md
@@ -21,12 +21,12 @@
 
 ## Events
 
-| Event          | Description                                                   | Type               |
-| -------------- | ------------------------------------------------------------- | ------------------ |
-| `bqAfterClose` | Callback handler to be called after the alert has been closed | `CustomEvent<any>` |
-| `bqAfterOpen`  | Callback handler to be called after the alert has been opened | `CustomEvent<any>` |
-| `bqHide`       | Callback handler to be called when the alert is hidden        | `CustomEvent<any>` |
-| `bqShow`       | Callback handler to be called when the alert is shown         | `CustomEvent<any>` |
+| Event         | Description                                                   | Type               |
+| ------------- | ------------------------------------------------------------- | ------------------ |
+| `bqAfterHide` | Callback handler to be called after the alert has been hidden | `CustomEvent<any>` |
+| `bqAfterShow` | Callback handler to be called after the alert has been shown  | `CustomEvent<any>` |
+| `bqHide`      | Callback handler to be called when the alert is hidden        | `CustomEvent<any>` |
+| `bqShow`      | Callback handler to be called when the alert is shown         | `CustomEvent<any>` |
 
 
 ## Methods
@@ -52,21 +52,30 @@ Type: `Promise<void>`
 
 
 
+## Slots
+
+| Slot          | Description                                                                          |
+| ------------- | ------------------------------------------------------------------------------------ |
+|               | The alert title content (no slot name required)                                      |
+| `"body"`      | The alert description content                                                        |
+| `"btn-close"` | The close button of the alert                                                        |
+| `"footer"`    | The alert footer content                                                             |
+| `"icon"`      | The predefined icon based on the alert type (info, success, warning, error, default) |
+
+
 ## Shadow Parts
 
-| Part             | Description                                                                                                               |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `"base"`         | The `<div>` container of the predefined bq-icon component                                                                 |
-| `"body"`         | The container `<div>` that wraps the alert description content                                                            |
-| `"btn-close"`    | The `bq-button` used to close the alert                                                                                   |
-| `"content"`      | The container `<div>` that wraps all the alert content (title, description, footer)                                       |
-| `"footer"`       | The container `<div>` that wraps the alert footer content                                                                 |
-| `"icon"`         | The `<bq-icon>` element used to render a predefined icon based on the alert type (info, success, warning, error, default) |
-| `"icon-outline"` | The container `<div>` that wraps the icon element                                                                         |
-| `"main"`         | The container `<div>` that wraps the alert main content (title, description)                                              |
-| `"svg"`          | The `<svg>` element of the predefined bq-icon component                                                                   |
-| `"title"`        | The container `<div>` that wraps the alert title content                                                                  |
-| `"wrapper"`      | The wrapper container `<div>` of the element inside the shadow DOM                                                        |
+| Part             | Description |
+| ---------------- | ----------- |
+| `"body"`         |             |
+| `"btn-close"`    |             |
+| `"content"`      |             |
+| `"footer"`       |             |
+| `"icon"`         |             |
+| `"icon-outline"` |             |
+| `"main"`         |             |
+| `"title"`        |             |
+| `"wrapper"`      |             |
 
 
 ## Dependencies


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This pull request enables users to specify an alternative close button for the Alert component through a slot, particularly when using a custom icon library.

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

Fixes #ISSUE_NUMBER

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
