### PR TITLE
refactor(Notification): set notification portal from the components lifecycle: `connectedCallback()`

### DIFF
--- a/packages/beeq/src/components/notification/readme.md
+++ b/packages/beeq/src/components/notification/readme.md
@@ -61,6 +61,17 @@ Type: `Promise<void>`
 
 
 
+## Slots
+
+| Slot          | Description                                  |
+| ------------- | -------------------------------------------- |
+|               | The notification title content               |
+| `"body"`      | The notification description content         |
+| `"btn-close"` | The close button of the notification         |
+| `"footer"`    | The notification footer content              |
+| `"icon"`      | The icon to be displayed in the notification |
+
+
 ## Shadow Parts
 
 | Part             | Description                                                                                |


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR shifts the creation of the notification portal container from outside the component into the `connectedCallback()` lifecycle method. This change is necessary to support SSR #1216 and to prevent errors when calling the window or document object from the server, where they are not available.

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

N/A

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
