### PR TITLE
refactor(Toast): set toast portal from the components lifecycle: `connectedCallback()`

### DIFF
--- a/packages/beeq/src/components/toast/__tests__/bq-toast.e2e.ts
+++ b/packages/beeq/src/components/toast/__tests__/bq-toast.e2e.ts
@@ -72,7 +72,7 @@ describe('bq-toast', () => {
 
     const iconWrapper = await page.find('bq-toast >>> bq-icon');
 
-    expect(iconWrapper).toEqualAttribute('name', 'info');
+    expect(iconWrapper).toEqualAttribute('name', 'info-bold');
   });
 
   it('should display success icon', async () => {
@@ -81,7 +81,7 @@ describe('bq-toast', () => {
 
     const iconWrapper = await page.find('bq-toast >>> bq-icon');
 
-    expect(iconWrapper).toEqualAttribute('name', 'check-circle');
+    expect(iconWrapper).toEqualAttribute('name', 'check-circle-bold');
   });
 
   it('should display custom icon', async () => {
@@ -89,7 +89,7 @@ describe('bq-toast', () => {
     await page.setContent(`
     <bq-toast>
       Text
-      <bq-icon slot="icon" size="24" weight="bold" name="star"></bq-icon>
+      <bq-icon slot="icon" size="24" name="star-bold"></bq-icon>
     </bq-toast>
     `);
 
@@ -101,7 +101,7 @@ describe('bq-toast', () => {
       return assignedElements.getAttribute('name');
     });
 
-    expect(iconWrapperName).toEqualText('star');
+    expect(iconWrapperName).toEqualText('star-bold');
   });
 
   it('should respect design style', async () => {

--- a/packages/beeq/src/components/toast/_storybook/bq-toast.stories.tsx
+++ b/packages/beeq/src/components/toast/_storybook/bq-toast.stories.tsx
@@ -58,8 +58,7 @@ const Template = (args: Args) => {
           @bqShow=${args.bqShow}
           @bqHide=${onToastHide}
         >
-          ${args.text}
-          ${type === 'custom' ? html`<bq-icon slot="icon" size="24" weight="bold" name="star"></bq-icon>` : null}
+          ${args.text} ${type === 'custom' ? html`<bq-icon slot="icon" size="24" name="star-bold"></bq-icon>` : null}
         </bq-toast>
       </div>
     `,
@@ -96,7 +95,7 @@ const CustomIconTemplate = (args: Args) => {
       @bqHide=${onToastHide}
     >
       ${args.text}
-      <bq-icon slot="icon" size="24" weight="bold" name="star"></bq-icon>
+      <bq-icon slot="icon" size="24" name="star-bold"></bq-icon>
     </bq-toast>
   `;
 };

--- a/packages/beeq/src/components/toast/readme.md
+++ b/packages/beeq/src/components/toast/readme.md
@@ -58,6 +58,14 @@ Type: `Promise<void>`
 
 
 
+## Slots
+
+| Slot     | Description                                         |
+| -------- | --------------------------------------------------- |
+|          | The content to be displayed in the toast component. |
+| `"icon"` | The icon to be displayed in the toast component.    |
+
+
 ## Shadow Parts
 
 | Part          | Description                                              |


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR shifts the creation of the toast portal container from outside the component into the connectedCallback() lifecycle method. This change is necessary to support SSR https://github.com/Endava/BEEQ/pull/1216 and prevent errors when calling the window or document object from the server, where they are unavailable.

## Related Issue
<!-- If this PR is related to an existing issue, please link it here. -->

Fixes #ISSUE_NUMBER

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
