### PR TITLE
refactor(Assets Path): set `bqSVGBasePath` when window and document objects are available

### DIFF
--- a/packages/beeq/src/components/icon/_storybook/bq-icon.stories.tsx
+++ b/packages/beeq/src/components/icon/_storybook/bq-icon.stories.tsx
@@ -127,13 +127,13 @@ export const ExploreIcons: Story = {
         </span>
       </div>
       <bq-button class="m-be-xxl" appearance="primary" href="https://phosphoricons.com/" target="_blank">
-        <bq-icon name="binoculars" weight="fill" slot="prefix"></bq-icon>
+        <bq-icon name="binoculars-fill" slot="prefix"></bq-icon>
         Explore all the icons available
-        <bq-icon class="ms-m" name="caret-right" weight="regular" slot="suffix"></bq-icon>
+        <bq-icon class="ms-m" name="caret-right" slot="suffix"></bq-icon>
       </bq-button>
       <!-- Warning block -->
       <bq-alert class="m-be-l" type="warning" disable-close open>
-        <bq-icon name="warning" weight="fill" slot="icon"></bq-icon>
+        <bq-icon name="warning-fill" slot="icon"></bq-icon>
         Please notice
         <span slot="body">
           The SVG icons will be flipped horizontally when the <code>dir="rtl"</code> attribute is used.

--- a/packages/beeq/src/shared/utils/assetsPath.ts
+++ b/packages/beeq/src/shared/utils/assetsPath.ts
@@ -13,15 +13,23 @@ declare global {
   }
 }
 
-Object.defineProperty(window, 'bqSVGBasePath', {
-  configurable: true,
-  enumerable: false,
-  writable: true,
-});
+/**
+ * Define the `bqSVGBasePath` property on the global window object, but only when the window object is available.
+ */
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'bqSVGBasePath', {
+    configurable: true,
+    enumerable: false,
+    writable: true,
+  });
+}
 
 const DATA_BEEQ_ATTRIBUTE = 'data-beeq';
 const DEFAULT_SVG_PATH = 'svg';
-const scripts = [...document.getElementsByTagName('script')] as HTMLScriptElement[];
+const scripts: HTMLScriptElement[] =
+  typeof document !== 'undefined' && document
+    ? ([...document.getElementsByTagName('script')] as HTMLScriptElement[])
+    : [];
 
 /**
  * Sets the `bqSVGBasePath` in the global window object,
@@ -30,8 +38,10 @@ const scripts = [...document.getElementsByTagName('script')] as HTMLScriptElemen
  *
  * @param path - The new base path to set.
  */
-export const setBasePath = (path: string) => {
-  window.bqSVGBasePath = path;
+export const setBasePath = (path: string): void => {
+  if (typeof window !== 'undefined') {
+    window.bqSVGBasePath = path;
+  }
 };
 
 /**
@@ -40,7 +50,9 @@ export const setBasePath = (path: string) => {
  * @param subpath - The subpath to append to the base path.
  * @returns The full base path including the subpath.
  */
-export const getBasePath = (subpath = ''): string => {
+export const getBasePath = (subpath = ''): string | undefined => {
+  if (typeof window === 'undefined') return undefined;
+
   const { bqSVGBasePath } = window;
   if (!bqSVGBasePath) {
     initializeBasePath();
@@ -80,8 +92,9 @@ const formatBasePath = (subpath: string): string => {
   return window.bqSVGBasePath.replace(/\/$/, '') + formattedSubpath;
 };
 
-const findConfigScript = () => scripts.find((script) => script.hasAttribute(DATA_BEEQ_ATTRIBUTE));
+const findConfigScript = (): HTMLScriptElement => scripts.find((script) => script.hasAttribute(DATA_BEEQ_ATTRIBUTE));
 
-const findFallbackScript = () => scripts.find((script) => /beeq(\.esm)?\.js($|\?)/.test(script.src));
+const findFallbackScript = (): HTMLScriptElement => scripts.find((script) => /beeq(\.esm)?\.js($|\?)/.test(script.src));
 
-const getScriptPath = (script: HTMLScriptElement) => script.getAttribute('src').split('/').slice(0, -1).join('/');
+const getScriptPath = (script: HTMLScriptElement): string =>
+  script.getAttribute('src').split('/').slice(0, -1).join('/');


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This pull request ensures that `bqSVGBasePath` is assigned to the global window object only when both the window and document (_including a query to the document object_) are accessible on the client side. This adjustment is crucial for enabling SSR as seen in https://github.com/Endava/BEEQ/pull/1216, and it helps avoid errors that occur when the window or document objects are referenced server-side, where they do not exist.
## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

Fixes #ISSUE_NUMBER

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [X] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
