### PR TITLE
feat(BEEQ Angular): enable `inlineProperties` config

### DIFF
--- a/packages/beeq-angular/tsconfig.lib.prod.json
+++ b/packages/beeq-angular/tsconfig.lib.prod.json
@@ -1,15 +1,18 @@
 {
   "extends": "./tsconfig.lib.json",
-  "compilerOptions": {
-    "declarationMap": false,
-    "removeComments": false
-  },
   "angularCompilerOptions": {
     "annotateForClosureCompiler": true,
     "compilationMode": "partial",
     "enableResourceInlining": true,
+    "flatModuleId": "@beeq/angular",
+    "flatModuleOutFile": "core.js",
     "fullTemplateTypeCheck": false,
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true
+  },
+  "compilerOptions": {
+    "declarationMap": false,
+    "removeComments": false,
+    "useDefineForClassFields": false
   }
 }

--- a/packages/beeq/stencil.config.ts
+++ b/packages/beeq/stencil.config.ts
@@ -72,6 +72,7 @@ export const config: Config = {
       directivesProxyFile: resolve(__dirname, '../beeq-angular/src/directives/components.ts').replace(/\\/g, '/'),
       directivesArrayFile: resolve(__dirname, '../beeq-angular/src/directives/index.ts').replace(/\\/g, '/'),
       valueAccessorConfigs: angularValueAccessorBindings,
+      inlineProperties: true,
       customElementsDir,
     }),
     angular({


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This option allows Angular Language Service to type-check and show jsdocs when using the components in html-templates.

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

N/A

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

![CleanShot 2024-11-01 at 15 29 36](https://github.com/user-attachments/assets/83a15a79-c033-4986-a553-aa71a63d0182)

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
