### PR TITLE
feat(Date picker): enable support for form-associated

### DIFF
--- a/packages/beeq/src/components/date-picker/_storybook/bq-date-picker.stories.tsx
+++ b/packages/beeq/src/components/date-picker/_storybook/bq-date-picker.stories.tsx
@@ -157,31 +157,31 @@ const Template = (args: Args) => {
     ${style}
     <bq-date-picker
       ?autofocus=${args.autofocus}
-      clear-button-label=${args['clear-button-label']}
-      distance=${args.distance}
+      clear-button-label=${ifDefined(args['clear-button-label'])}
+      distance=${ifDefined(args.distance)}
       ?disable-clear=${args['disable-clear']}
       ?disabled=${args.disabled}
-      first-day-of-week=${args['first-day-of-week']}
+      first-day-of-week=${ifDefined(args['first-day-of-week'])}
       form=${ifDefined(args.form)}
       .formatOptions=${args.formatOptions}
       .isDateDisallowed=${dateDisallowed}
       locale=${ifDefined(args.locale)}
       max=${ifDefined(args.max)}
       min=${ifDefined(args.min)}
-      months=${args.months}
-      months-per-view=${args['months-per-view']}
+      months=${ifDefined(args.months)}
+      months-per-view=${ifDefined(args['months-per-view'])}
       name=${ifDefined(args.name)}
       ?open=${args.open}
-      panel-height=${args['panel-height']}
-      placeholder=${args.placeholder}
-      placement=${args.placement}
+      panel-height=${ifDefined(args['panel-height'])}
+      placeholder=${ifDefined(args.placeholder)}
+      placement=${ifDefined(args.placement)}
       ?required=${args.required}
-      show-outside-days=${args['show-outside-days']}
-      skidding=${args.skidding}
-      strategy=${args.strategy}
-      tentative=${args.tentative}
-      type=${args.type}
-      validation-status=${args['validation-status']}
+      ?show-outside-days=${args['show-outside-days']}
+      skidding=${ifDefined(args.skidding)}
+      strategy=${ifDefined(args.strategy)}
+      tentative=${ifDefined(args.tentative)}
+      type=${ifDefined(args.type)}
+      validation-status=${ifDefined(args['validation-status'])}
       value=${ifDefined(args.value)}
       @bqBlur=${args.bqBlur}
       @bqChange=${args.bqChange}
@@ -349,5 +349,90 @@ export const NoLabel: Story = {
   args: {
     noLabel: true,
     value: '2024-10-13',
+  },
+};
+
+export const WithForm: Story = {
+  render: () => {
+    const handleFormSubmit = (ev: Event) => {
+      ev.preventDefault();
+      const form = ev.target as HTMLFormElement;
+      const formData = new FormData(form);
+      const formValues = Object.fromEntries(formData.entries());
+
+      const codeElement = document.getElementById('form-data');
+      if (!codeElement) return;
+
+      codeElement.textContent = JSON.stringify(formValues, null, 2);
+    };
+
+    return html`
+      <link rel="stylesheet" href="https://unpkg.com/@highlightjs/cdn-assets@11.10.0/styles/night-owl.min.css" />
+
+      <div class="grid auto-cols-auto grid-cols-1 gap-y-l sm:grid-cols-2 sm:gap-x-l">
+        <bq-card>
+          <h4 class="m-be-m">Travel information</h4>
+          <form class="flex flex-col gap-y-m" @submit=${handleFormSubmit}>
+            <bq-input name="fullName" value="Brad Bernie Beckett" autocomplete="name" required>
+              <label class="flex flex-grow items-center" slot="label">Full Name</label>
+            </bq-input>
+            <div class="grid grid-cols-1 gap-y-m sm:grid-cols-2 sm:gap-x-m">
+              <bq-input name="passportNumber" value="052763786" autocomplete="bday-year" required>
+                <label class="flex flex-grow items-center" slot="label">Passport number</label>
+              </bq-input>
+              <bq-date-picker
+                name="passportExpDate"
+                value="2024-05-20"
+                placeholder="Select a date"
+                type="single"
+                required
+              >
+                <label class="flex flex-grow items-center" slot="label"> Expiration date </label>
+              </bq-date-picker>
+            </div>
+            <bq-date-picker
+              name="tripDate"
+              placeholder="Select a start and end date for your travel"
+              value="2024-12-25/2025-01-10"
+              type="range"
+              months="2"
+              required
+            >
+              <label class="flex flex-grow items-center" slot="label"> Travel dates </label>
+            </bq-date-picker>
+            <div class="flex justify-end gap-x-s">
+              <bq-button appearance="secondary" type="reset">Cancel</bq-button>
+              <bq-button type="submit">Save</bq-button>
+            </div>
+          </form>
+        </bq-card>
+        <bq-card class="[&::part(wrapper)]:h-full">
+          <h4 class="m-be-m">Form Data</h4>
+          <div class="language-javascript overflow-x-scroll whitespace-pre rounded-s">
+            // Handle form submit<br />
+            const form = ev.target as HTMLFormElement;<br />
+            const formData = new FormData(form);<br />
+            const formValues = Object.fromEntries(formData.entries());
+          </div>
+          <pre>
+            <code id="form-data" class="rounded-s">
+              { // submit the form to see the data here }
+            </code>
+          </pre>
+        </bq-card>
+      </div>
+
+      <script type="module">
+        import hljs from 'https://unpkg.com/@highlightjs/cdn-assets@11.10.0/es/highlight.min.js';
+        import javascript from 'https://unpkg.com/@highlightjs/cdn-assets@11.10.0/es/languages/javascript.min.js';
+
+        hljs.registerLanguage('javascript', javascript);
+        hljs.highlightAll();
+
+        document.querySelectorAll('div.language-javascript').forEach((block) => {
+          hljs.highlightElement(block);
+        });
+      </script>
+    `;
   },
 };

--- a/packages/beeq/src/components/input/bq-input.tsx
+++ b/packages/beeq/src/components/input/bq-input.tsx
@@ -245,14 +245,15 @@ export class BqInput {
 
   @Watch('value')
   handleValueChange() {
-    if (Array.isArray(this.value)) {
-      this.hasValue = this.value.some((val) => val.length > 0);
-      this.internals.setFormValue(this.value.join(','));
+    const { internals, value } = this;
+    if (Array.isArray(value)) {
+      this.hasValue = value.some((val) => val.length > 0);
+      this.internals.setFormValue(value.join(','));
       return;
     }
 
-    this.hasValue = isDefined(this.value);
-    this.internals.setFormValue(`${this.value}`);
+    this.hasValue = isDefined(value);
+    internals.setFormValue(!isNil(value) ? `${value}` : undefined);
   }
 
   // Events section


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR enables support for form-associated custom elements, allowing them to participate in HTML forms:

https://stenciljs.com/docs/forms#using-form-associated-custom-elements
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/attachInternals

To attach the <bq-date-picker> component to a form, users need to do so manually. With this PR, users only need to be aware of setting the component name attribute/property to be linked to the form.

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

Fixes N/A

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

![CleanShot 2024-12-09 at 18 53 56](https://github.com/user-attachments/assets/8af2748c-2960-4179-85bf-5b927c3a9af6)

https://github.com/user-attachments/assets/82059f12-b2b2-4d1a-abfb-03c2d8bcb026

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
