### PR TITLE
feat(Switch): enable support for form-associated

### DIFF
--- a/packages/beeq/src/components/switch/_storybook/bq-switch.stories.tsx
+++ b/packages/beeq/src/components/switch/_storybook/bq-switch.stories.tsx
@@ -124,3 +124,70 @@ export const FullWidth: Story = {
     'reverse-order': true,
   },
 };
+
+export const WithForm: Story = {
+  render: (args: Args) => {
+    const handleFormSubmit = (ev: Event) => {
+      ev.preventDefault();
+      const form = ev.target as HTMLFormElement;
+      const formData = new FormData(form);
+      const formValues = Object.fromEntries(formData.entries());
+
+      const codeElement = document.getElementById('form-data');
+      if (!codeElement) return;
+
+      codeElement.textContent = JSON.stringify(formValues, null, 2);
+    };
+
+    return html`
+      <link rel="stylesheet" href="https://unpkg.com/@highlightjs/cdn-assets@11.10.0/styles/night-owl.min.css" />
+      <div class="grid auto-cols-auto grid-cols-1 gap-y-l sm:grid-cols-2 sm:gap-x-l">
+        <bq-card style="--bq-card--background: transparent">
+          <h4 class="m-be-m">Account settings</h4>
+          <form class="flex flex-col gap-y-m" @submit=${handleFormSubmit}>
+            ${Template({ ...args, text: 'Show app list in menu', name: 'showAppList' })}
+            ${Template({ ...args, text: 'Show recently added apps', name: 'showRecentlyApps', checked: true })}
+            ${Template({ ...args, text: 'Show most used apps', name: 'showUsedApps', disabled: true })}
+            ${Template({ ...args, text: 'Show app notifications', name: 'showAppNotifications', checked: true })}
+            <div class="flex justify-end gap-x-s">
+              <bq-button appearance="secondary" type="reset">Cancel</bq-button>
+              <bq-button type="submit">Save</bq-button>
+            </div>
+          </form>
+        </bq-card>
+        <bq-card class="[&::part(wrapper)]:h-full">
+          <h4 class="m-be-m">Form Data</h4>
+          <div class="language-javascript overflow-x-scroll whitespace-pre rounded-s">
+            // Handle form submit<br />
+            const form = ev.target as HTMLFormElement;<br />
+            const formData = new FormData(form);<br />
+            const formValues = Object.fromEntries(formData.entries());
+          </div>
+          <pre>
+            <code id="form-data" class="rounded-s">
+              { // submit the form to see the data here }
+            </code>
+          </pre>
+        </bq-card>
+      </div>
+
+      <script type="module">
+        import hljs from 'https://unpkg.com/@highlightjs/cdn-assets@11.10.0/es/highlight.min.js';
+        import javascript from 'https://unpkg.com/@highlightjs/cdn-assets@11.10.0/es/languages/javascript.min.js';
+
+        hljs.registerLanguage('javascript', javascript);
+        hljs.highlightAll();
+
+        document.querySelectorAll('div.language-javascript').forEach((block) => {
+          hljs.highlightElement(block);
+        });
+      </script>
+    `;
+  },
+  args: {
+    'background-on-hover': true,
+    'full-width': true,
+    'justify-content': 'space-between',
+    'reverse-order': true,
+  },
+};

--- a/packages/beeq/src/components/switch/bq-switch.tsx
+++ b/packages/beeq/src/components/switch/bq-switch.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, h, Host, Method, Prop, State } from '@stencil/core';
+import { AttachInternals, Component, Element, Event, EventEmitter, h, Host, Method, Prop, State } from '@stencil/core';
 
 import { TSwitchInnerLabel, TSwitchJustifyContent } from './bq-switch.types';
 import { getTextContent, isNil } from '../../shared/utils';
@@ -51,6 +51,7 @@ import { getTextContent, isNil } from '../../shared/utils';
 @Component({
   tag: 'bq-switch',
   styleUrl: './scss/bq-switch.scss',
+  formAssociated: true,
   shadow: {
     delegatesFocus: true,
   },
@@ -66,6 +67,7 @@ export class BqSwitch {
   // Reference to host HTML element
   // ===================================
 
+  @AttachInternals() internals!: ElementInternals;
   @Element() el!: HTMLBqSwitchElement;
 
   // State() variables
@@ -150,6 +152,15 @@ export class BqSwitch {
     }
   }
 
+  formAssociatedCallback() {
+    this.setFormValue(this.checked);
+  }
+
+  formResetCallback() {
+    // Reset the form validity state
+    this.internals.setValidity({});
+  }
+
   // Listeners
   // ==============
 
@@ -195,6 +206,7 @@ export class BqSwitch {
   private handleChange = () => {
     this.checked = !this.checked;
     this.inputElem.setAttribute('checked', `${this.checked}`);
+    this.setFormValue(this.checked);
   };
 
   private handleOnFocus = () => {
@@ -210,6 +222,15 @@ export class BqSwitch {
     if (isNil(slot)) return;
 
     this.hasLabel = !!getTextContent(slot, { recurse: true }).length;
+  };
+
+  private setFormValue = (checked: boolean) => {
+    console.log('setFormValue', checked);
+    const value = checked ? 'on' : 'off';
+    // Set form value based on the checked state
+    // Here we also pass the state of the component (2nd argument) as the state of the form control
+    // Details: https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/setFormValue
+    this.internals?.setFormValue(value, `${this.checked}`);
   };
 
   // render() function


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR enables support for form-associated custom elements, allowing them to participate in HTML forms:

https://stenciljs.com/docs/forms#using-form-associated-custom-elements
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/attachInternals

To attach the <bq-switch> component to a form, users need to do so manually. With this PR, users only need to be aware of setting the component name attribute/property to be linked to the form.

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

N/A

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

![CleanShot 2024-12-10 at 14 43 39](https://github.com/user-attachments/assets/24e5e2f2-d157-4d8a-acf0-eef013373495)

https://github.com/user-attachments/assets/21b505a6-17f1-4d5d-a15e-d3f99aa3fe7d

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
