### PR TITLE
refactor(Accordion): replace `calc-size()` animation with `interpolate-size`

### DIFF
--- a/packages/beeq/src/components/accordion/bq-accordion.tsx
+++ b/packages/beeq/src/components/accordion/bq-accordion.tsx
@@ -174,7 +174,7 @@ export class BqAccordion {
     } else {
       this.accordion?.close();
     }
-    if (!this.isCssCalcSizeSupported) return;
+    if (!this.isCssInterpolateSizeSupported) return;
 
     // NOTE: This is a workaround to trigger the transitionEnd event
     // when the open/close animation is handled via CSS instead of JS
@@ -192,10 +192,10 @@ export class BqAccordion {
 
   @Watch('noAnimation')
   handleJsAnimation() {
-    if (this.isCssCalcSizeSupported) return;
+    if (this.isCssInterpolateSizeSupported) return;
 
     console.warn(
-      `[bq-accordion] calc-size() is not supported and animation will be set through JS
+      `[bq-accordion] animating to/from intrinsic sizing keywords (interpolate-size: allow-keywords) is not supported and animation will be set through JS.
         For vertical layout, consider using the 'noAnimation' prop ('no-animation' attribute) to disable it`,
     );
     this.accordion = !this.noAnimation ? new Accordion(this.detailsElem) : null;
@@ -298,8 +298,8 @@ export class BqAccordion {
     return this.expanded && !this.disabled;
   }
 
-  private get isCssCalcSizeSupported() {
-    return window.CSS?.supports('(block-size: calc-size(auto))');
+  private get isCssInterpolateSizeSupported() {
+    return window.CSS?.supports('(interpolate-size: allow-keywords)');
   }
 
   // render() function

--- a/packages/beeq/src/components/accordion/scss/bq-accordion.scss
+++ b/packages/beeq/src/components/accordion/scss/bq-accordion.scss
@@ -8,6 +8,14 @@
   @apply block;
 }
 
+.bq-accordion:not(.no-animation) {
+  /* -------------------------------------------------------------------- */
+  /* Opt-in the component to animating to/from intrinsic sizing keywords  */
+  /* Details: https://chrome.dev/css-wrapped-2024/#animate-to-height-auto */
+  /* -------------------------------------------------------------------- */
+  @apply supports-[interpolate-size:_allow-keywords]:[interpolate-size:_allow-keywords];
+}
+
 .bq-accordion {
   &.disabled {
     @apply cursor-not-allowed opacity-60;
@@ -108,16 +116,11 @@
 }
 
 .bq-accordion::details-content {
-  @apply block overflow-hidden transition-[block-size,content-visibility] duration-300 ease-in-out bs-0 [transition-behavior:allow-discrete];
+  @apply block overflow-clip transition-all duration-300 ease-in-out bs-0 [transition-behavior:allow-discrete];
 }
 
 .bq-accordion[open]::details-content {
-  /* block-size: auto is just a fallback for browsers that don't support the calc-size() function */
   @apply bs-auto;
-}
-
-.bq-accordion[open]:not(.no-animation)::details-content {
-  @apply supports-[block-size:calc-size(auto)]:bs-[calc-size(auto)];
 }
 
 .bq-accordion__header {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

With this PR, we replace the use of the calc-size() feature, which is only supported if a feature flag is enabled in the browser, with the interpolate-size property to animate the accordion's opening and closing. Chrome browsers already support this without the need to enable something extra in the client's browser.
More details can be found here: [https://chrome.dev/css-wrapped-2024/#animate-to-height-auto](https://chrome.dev/css-wrapped-2024/#animate-to-height-auto)

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

N/A

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
