### PR TITLE
chore(deps): replace `cem-plugin-custom-jsdoc-tags` dependency with `@wc-toolkit/jsdoc-tags`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beeq",
-  "version": "1.8.1",
+  "version": "1.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beeq",
-      "version": "1.8.1",
+      "version": "1.8.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -88,7 +88,6 @@
         "@wc-toolkit/jsdoc-tags": "1.0.3",
         "autoprefixer": "10.4.20",
         "babel-jest": "29.7.0",
-        "cem-plugin-custom-jsdoc-tags": "1.1.2",
         "cem-plugin-expanded-types": "1.3.3",
         "cem-plugin-jsdoc-example": "0.0.9",
         "chromatic": "11.22.2",
@@ -16310,13 +16309,6 @@
         "tslib": "^2.0.3",
         "upper-case-first": "^2.0.2"
       }
-    },
-    "node_modules/cem-plugin-custom-jsdoc-tags": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cem-plugin-custom-jsdoc-tags/-/cem-plugin-custom-jsdoc-tags-1.1.2.tgz",
-      "integrity": "sha512-vYermZIrZ8UulEN19LGPkbfwmqES1M8rzq6I8rem2AnM1E5o0EI3PNkRz/fDDOPwCdf5qusFhIlbg+UG7TcKYw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/cem-plugin-expanded-types": {
       "version": "1.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
         "@types/node": "22.10.5",
         "@types/react": "19.0.8",
         "@types/react-dom": "19.0.3",
+        "@wc-toolkit/jsdoc-tags": "1.0.3",
         "autoprefixer": "10.4.20",
         "babel-jest": "29.7.0",
         "cem-plugin-custom-jsdoc-tags": "1.1.2",
@@ -14285,6 +14286,13 @@
       "version": "3.5.13",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
       "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
+      "license": "MIT"
+    },
+    "node_modules/@wc-toolkit/jsdoc-tags": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@wc-toolkit/jsdoc-tags/-/jsdoc-tags-1.0.3.tgz",
+      "integrity": "sha512-nXJNuZ7HHHMEOhh43JRB404Rvdsq2Z6c17E+Y6hmh9WQC5ZL0jbVTr+9uoafwHotIWwHnQ2i7DsbGsmjQFo0YA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@web/config-loader": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beeq",
-  "version": "1.8.1",
+  "version": "1.8.3",
   "description": "BEEQ Design System",
   "license": "Apache-2.0",
   "private": true,
@@ -110,7 +110,6 @@
     "@wc-toolkit/jsdoc-tags": "1.0.3",
     "autoprefixer": "10.4.20",
     "babel-jest": "29.7.0",
-    "cem-plugin-custom-jsdoc-tags": "1.1.2",
     "cem-plugin-expanded-types": "1.3.3",
     "cem-plugin-jsdoc-example": "0.0.9",
     "chromatic": "11.22.2",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "@types/node": "22.10.5",
     "@types/react": "19.0.8",
     "@types/react-dom": "19.0.3",
+    "@wc-toolkit/jsdoc-tags": "1.0.3",
     "autoprefixer": "10.4.20",
     "babel-jest": "29.7.0",
     "cem-plugin-custom-jsdoc-tags": "1.1.2",

--- a/packages/beeq/cem.config.mjs
+++ b/packages/beeq/cem.config.mjs
@@ -10,7 +10,7 @@
  * https://custom-elements-manifest.open-wc.org/analyzer/
  */
 
-import { customJSDocTagsPlugin } from 'cem-plugin-custom-jsdoc-tags';
+import { jsDocTagsPlugin } from '@wc-toolkit/jsdoc-tags';
 import { expandTypesPlugin, getTsProgram } from 'cem-plugin-expanded-types';
 import { jsdocExamplePlugin } from 'cem-plugin-jsdoc-example';
 import { customElementVsCodePlugin } from 'custom-element-vs-code-integration';
@@ -74,7 +74,7 @@ export default {
   plugins: [
     expandTypesPlugin(),
     jsdocExamplePlugin(),
-    customJSDocTagsPlugin({
+    jsDocTagsPlugin({
       tags: {
         dependency: {
           mappedName: 'dependencies',

--- a/packages/beeq/eslint.config.js
+++ b/packages/beeq/eslint.config.js
@@ -122,7 +122,7 @@ module.exports = [
             '@stencil/react-output-target',
             '@stencil/sass',
             '@stencil/vue-output-target',
-            'cem-plugin-custom-jsdoc-tags',
+            '@wc-toolkit/jsdoc-tags',
             'cem-plugin-expanded-types',
             'cem-plugin-jsdoc-example',
             'custom-element-jsx-integration',

--- a/patches/@nxext+stencil+20.0.6.patch
+++ b/patches/@nxext+stencil+20.0.6.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@nxext/stencil/src/executors/stencil-runtime/stencil-config.js b/node_modules/@nxext/stencil/src/executors/stencil-runtime/stencil-config.js
+index 4e17cca..df259f9 100644
+--- a/node_modules/@nxext/stencil/src/executors/stencil-runtime/stencil-config.js
++++ b/node_modules/@nxext/stencil/src/executors/stencil-runtime/stencil-config.js
+@@ -38,7 +38,7 @@ function initializeStencilConfig(taskCommand, options, context, flags) {
+             sys,
+         });
+         const loadedConfig = loadConfigResults.config;
+-        const strictConfig = Object.assign(Object.assign({}, loadedConfig), { flags: flags, logger, outputTargets: (_a = loadedConfig.outputTargets) !== null && _a !== void 0 ? _a : [], rootDir: (_b = loadedConfig.rootDir) !== null && _b !== void 0 ? _b : '/', sys: sys !== null && sys !== void 0 ? sys : loadedConfig.sys, testing: (_c = loadedConfig.testing) !== null && _c !== void 0 ? _c : {} });
++        const strictConfig = Object.assign(Object.assign({}, loadedConfig), { flags: flags, logger, outputTargets: (_a = loadedConfig === null || loadedConfig === void 0 ? void 0 : loadedConfig.outputTargets) !== null && _a !== void 0 ? _a : [], rootDir: (_b = loadedConfig === null || loadedConfig === void 0 ? void 0 : loadedConfig.rootDir) !== null && _b !== void 0 ? _b : '/', sys: sys !== null && sys !== void 0 ? sys : loadedConfig === null || loadedConfig === void 0 ? void 0 : loadedConfig.sys, testing: (_c = loadedConfig === null || loadedConfig === void 0 ? void 0 : loadedConfig.testing) !== null && _c !== void 0 ? _c : {} });
+         if (strictConfig.flags.task === 'build') {
+             strictConfig.rootDir = distDir;
+             strictConfig.packageJsonFilePath = (0, normalize_path_1.normalizePath)((0, path_1.join)(distDir, 'package.json'));


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

The `cem-plugin-custom-jsdoc-tags` package has been marked as `deprecated` by the author.

![CleanShot 2025-02-14 at 17 28 07](https://github.com/user-attachments/assets/613dd744-bc10-4839-b71e-b495daee9dbf)

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

N/A

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
