### PR TITLE
fix(Select): change value clearing logic to use empty string instead undefined

### DIFF
--- a/packages/beeq/src/components/select/bq-select.tsx
+++ b/packages/beeq/src/components/select/bq-select.tsx
@@ -340,13 +340,13 @@ export class BqSelect {
     const { multiple, inputElem, bqClear, el } = this;
 
     // Clear value and selected options
-    this.value = undefined;
+    this.value = '';
     this.selectedOptions = [];
 
     // Clear display value and input element if not multiple
     if (!multiple) {
-      this.displayValue = undefined;
-      inputElem.value = undefined;
+      this.displayValue = '';
+      inputElem.value = '';
     }
 
     // Update form value and reset options visibility


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

Fixed and issue where clelaring the select input with Backspace leads into having `undefined` string as input value and cannot be removed.

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

Fixes #1461 

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

![CleanShot 2025-04-28 at 12 44 13](https://github.com/user-attachments/assets/a2f9ec9f-f789-4669-8611-03ae9bc12008)

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
