### PR TITLE
feat(Select): add bqInput event for real-time input value changes when filtering

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,19 +1,14 @@
 # These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-* @dgonzalezr @endv-bogdanb @Cata1989
+# the repo. Unless a later match takes precedence, the following people will be requested for review
+# when someone opens a pull request.
+* @dgonzalezr
 
-# Any change related to the .github workflows
-# will require approval from @dgonzalezr.
-.github/ @dgonzalezr @endv-bogdanb
+# Any change related to the .github workflows will require approval from the following people:
+.github/ @dgonzalezr
 
-# Any change related to the NPM dependencies
-# will require approval from @dgonzalezr @endv-bogdanb.
+# Any change related to the NPM dependencies will require approval from the following people:
+package.json @dgonzalezr
+package-lock.json @dgonzalezr
 
-package.json @dgonzalezr @endv-bogdanb
-package-lock.json @dgonzalezr @endv-bogdanb
-
-# Any change inside the `/packages` directory
-# will require approval from @dgonzalezr @endv-bogdanb.
-/packages @dgonzalezr @endv-bogdanb @Cata1989
+# Any change inside the `/packages` directory will require approval from the following people:
+/packages @dgonzalezr @endv-bogdanb

--- a/packages/beeq/src/components.d.ts
+++ b/packages/beeq/src/components.d.ts
@@ -4365,6 +4365,7 @@ declare global {
         "bqClear": HTMLBqSelectElement;
         "bqFocus": HTMLBqSelectElement;
         "bqSelect": { value: string | number | string[]; item: HTMLBqOptionElement };
+        "bqInput": { value: string | number | string[] };
     }
     /**
      * The select input component lets users choose from a predefined list, commonly used in forms for easy data selection.
@@ -7227,6 +7228,10 @@ declare namespace LocalJSX {
           * Callback handler emitted when the Select input has received focus
          */
         "onBqFocus"?: (event: BqSelectCustomEvent<HTMLBqSelectElement>) => void;
+        /**
+          * Callback handler emitted when the Select input changes its value while typing
+         */
+        "onBqInput"?: (event: BqSelectCustomEvent<{ value: string | number | string[] }>) => void;
         /**
           * Callback handler emitted when the selected value has changed
          */

--- a/packages/beeq/src/components/select/_storybook/bq-select.stories.tsx
+++ b/packages/beeq/src/components/select/_storybook/bq-select.stories.tsx
@@ -465,7 +465,7 @@ export const CustomFiltering: Story = {
       await new Promise((resolve) => setTimeout(resolve, 500));
       return args.options.filter(
         (option) =>
-          option.label.toLowerCase().includes(query.toLowerCase()) ||
+          option.label.toLowerCase().includes(query.toLowerCase()) ??
           option.value.toLowerCase().includes(query.toLowerCase()),
       );
     };

--- a/packages/beeq/src/components/select/readme.md
+++ b/packages/beeq/src/components/select/readme.md
@@ -39,12 +39,13 @@ The select input component lets users choose from a predefined list, commonly us
 
 ## Events
 
-| Event      | Description                                                       | Type                                                                               |
-| ---------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `bqBlur`   | Callback handler emitted when the Select input loses focus        | `CustomEvent<HTMLBqSelectElement>`                                                 |
-| `bqClear`  | Callback handler emitted when the selected value has been cleared | `CustomEvent<HTMLBqSelectElement>`                                                 |
-| `bqFocus`  | Callback handler emitted when the Select input has received focus | `CustomEvent<HTMLBqSelectElement>`                                                 |
-| `bqSelect` | Callback handler emitted when the selected value has changed      | `CustomEvent<{ value: string \| number \| string[]; item: HTMLBqOptionElement; }>` |
+| Event      | Description                                                                   | Type                                                                               |
+| ---------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `bqBlur`   | Callback handler emitted when the Select input loses focus                    | `CustomEvent<HTMLBqSelectElement>`                                                 |
+| `bqClear`  | Callback handler emitted when the selected value has been cleared             | `CustomEvent<HTMLBqSelectElement>`                                                 |
+| `bqFocus`  | Callback handler emitted when the Select input has received focus             | `CustomEvent<HTMLBqSelectElement>`                                                 |
+| `bqInput`  | Callback handler emitted when the Select input changes its value while typing | `CustomEvent<{ value: string \| number \| string[]; }>`                            |
+| `bqSelect` | Callback handler emitted when the selected value has changed                  | `CustomEvent<{ value: string \| number \| string[]; item: HTMLBqOptionElement; }>` |
 
 
 ## Methods


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR adds a new `bqInput` event emitted by the `BqSelect` component when filtering (typing in the input used under the hood). This will allow consumers to customize the behavior of the Select by having the ability to `preventDefault()` the event and implement their custom logic. E.g., show loading state while fetching the options upon query filter, show `No results`, etc.

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

Fixes #ISSUE_NUMBER

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

![CleanShot 2025-04-28 at 20 09 13](https://github.com/user-attachments/assets/76a8f823-8eb2-47a8-85eb-88d2424c68ea)

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
