### PR TITLE
feat(Select): add reset method to restore to a previous value

### DIFF
--- a/packages/beeq/src/components.d.ts
+++ b/packages/beeq/src/components.d.ts
@@ -2025,6 +2025,13 @@ export namespace Components {
          */
         "required"?: boolean;
         /**
+          * Resets the Select input to a previous value.
+          * @param value - The value to reset the Select input to.
+          * @return 
+          * @memberof BqSelect
+         */
+        "reset": (value: TSelectValue) => Promise<void>;
+        /**
           * Whether the panel should have the Select same width as the input element
          */
         "sameWidth"?: boolean;

--- a/packages/beeq/src/components/select/_storybook/bq-select.stories.tsx
+++ b/packages/beeq/src/components/select/_storybook/bq-select.stories.tsx
@@ -373,6 +373,33 @@ export const NoHelperText: Story = {
   },
 };
 
+export const Reset: Story = {
+  render: (args: Args) => {
+    const handleSelect = async (event: CustomEvent<{ value: string }>) => {
+      args.bqSelect(event);
+
+      const bqElement = event.target as HTMLBqSelectElement;
+      setTimeout(async () => {
+        await bqElement.reset(args.value);
+      }, 2000);
+    };
+
+    return html`
+      <div class="flex flex-col">
+        <h4>Reset</h4>
+        <p class="text-secondary m-be-l">
+          This example demonstrates the <code>reset</code> method. After 2 seconds, the value will be reset to the
+          initial value.
+        </p>
+        ${Template({ ...args, bqSelect: handleSelect })}
+      </div>
+    `;
+  },
+  args: {
+    value: 'swimming',
+  },
+};
+
 export const WithForm: Story = {
   render: () => {
     const handleFormSubmit = (ev: Event) => {
@@ -557,14 +584,14 @@ export const CustomFiltering: Story = {
     // Handle selection to restore original options
     const handleSelect = (event: CustomEvent<{ value: string; item: HTMLBqOptionElement }>) => {
       const select = event.target as HTMLBqSelectElement;
-      // Clear the input value after selection
-      select.querySelector('input').value = '';
       // Show all options again
       showAllOptions(select);
       // Remove any temporary options (loading/no results)
       select.querySelectorAll('bq-option[data-temp]').forEach((option) => option.remove());
       // Call the original bqSelect handler
       args.bqSelect(event);
+      // Clear the input value after selection
+      select.value = '';
     };
 
     return html`

--- a/packages/beeq/src/components/select/readme.md
+++ b/packages/beeq/src/components/select/readme.md
@@ -60,6 +60,22 @@ Type: `Promise<void>`
 
 
 
+### `reset(value: TSelectValue) => Promise<void>`
+
+Resets the Select input to a previous value.
+
+#### Parameters
+
+| Name    | Type                 | Description                               |
+| ------- | -------------------- | ----------------------------------------- |
+| `value` | `string \| string[]` | - The value to reset the Select input to. |
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 
 ## Slots
 

--- a/packages/beeq/src/shared/utils/__tests__/stringToArray.spec.ts
+++ b/packages/beeq/src/shared/utils/__tests__/stringToArray.spec.ts
@@ -1,0 +1,104 @@
+import { stringToArray } from '../stringToArray';
+
+describe('stringToArray', () => {
+  it('should convert a JSON string array to an array', () => {
+    const input = '["a", "b", "c"]';
+    const result = stringToArray(input);
+    expect(result).toEqual(['a', 'b', 'c']);
+  });
+
+  it('should return the same array when input is already an array', () => {
+    const input = ['x', 'y', 'z'];
+    const result = stringToArray(input);
+    expect(result).toBe(input); // Check reference equality
+    expect(result).toEqual(['x', 'y', 'z']);
+  });
+
+  it('should handle empty JSON array string', () => {
+    const input = '[]';
+    const result = stringToArray(input);
+    expect(result).toEqual([]);
+  });
+
+  it('should handle empty array input', () => {
+    const input: string[] = [];
+    const result = stringToArray(input);
+    expect(result).toEqual([]);
+  });
+
+  it('should handle single item JSON array string', () => {
+    const input = '["test"]';
+    const result = stringToArray(input);
+    expect(result).toEqual(['test']);
+  });
+
+  it('should handle JSON array string with numbers as strings', () => {
+    const input = '["1", "2", "3"]';
+    const result = stringToArray(input);
+    expect(result).toEqual(['1', '2', '3']);
+  });
+
+  it('should handle JSON array string with special characters', () => {
+    const input = '["@test", "#test", "$test"]';
+    const result = stringToArray(input);
+    expect(result).toEqual(['@test', '#test', '$test']);
+  });
+
+  it('should handle JSON array string with spaces', () => {
+    const input = '["hello world", "test space"]';
+    const result = stringToArray(input);
+    expect(result).toEqual(['hello world', 'test space']);
+  });
+
+  // Error cases
+  it('should throw for invalid JSON string', () => {
+    const input = 'invalid json';
+    expect(() => stringToArray(input)).toThrow();
+  });
+
+  it('should throw for malformed JSON array string', () => {
+    const input = '[1, 2, 3'; // Missing closing bracket
+    expect(() => stringToArray(input)).toThrow();
+  });
+
+  // Edge cases
+  it('should handle JSON array string with empty strings', () => {
+    const input = '["", "", ""]';
+    const result = stringToArray(input);
+    expect(result).toEqual(['', '', '']);
+  });
+
+  // Non-string array elements
+  it('should convert non-array JSON to array', () => {
+    const input = '{"key": "value"}';
+    const result = stringToArray(input);
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it('should handle array with null values', () => {
+    const input = '["a", null, "c"]';
+    const result = stringToArray(input);
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it('should handle array with nested arrays', () => {
+    const input = '["a", ["b", "c"], "d"]';
+    const result = stringToArray(input);
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  // Type checking
+  it('should return array type', () => {
+    const input = '["test"]';
+    const result = stringToArray(input);
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it('should maintain string type for array elements when input is valid', () => {
+    const input = '["1", "2", "3"]';
+    const result = stringToArray(input);
+    result.forEach((item) => {
+      expect(typeof item).toBe('string');
+    });
+  });
+});

--- a/packages/beeq/src/shared/utils/index.ts
+++ b/packages/beeq/src/shared/utils/index.ts
@@ -14,4 +14,5 @@ export * from './isString';
 export * from './props';
 export * from './setRafTimeout';
 export * from './slot';
+export * from './stringToArray';
 export * from './transition';

--- a/packages/beeq/src/shared/utils/stringToArray.ts
+++ b/packages/beeq/src/shared/utils/stringToArray.ts
@@ -5,14 +5,16 @@ import { isString } from './isString';
  *
  * @param {string | string[]} value - The value to convert.
  * @return {string[]} The converted array.
- * @throws {Error} If the JSON string cannot be parsed
+ * @throws {Error} If the input string is not a valid JSON array
  */
 export const stringToArray = (value: string | string[]): string[] => {
   if (isString(value)) {
     try {
       return Array.from(JSON.parse(String(value)));
     } catch (error) {
-      throw error;
+      throw new Error(
+        `Failed to parse string to array. Input must be a valid JSON array string. Details: ${error.message}`,
+      );
     }
   }
   return Array.isArray(value) ? value : [];

--- a/packages/beeq/src/shared/utils/stringToArray.ts
+++ b/packages/beeq/src/shared/utils/stringToArray.ts
@@ -1,0 +1,19 @@
+import { isString } from './isString';
+
+/**
+ * Converts a string or array to an array.
+ *
+ * @param {string | string[]} value - The value to convert.
+ * @return {string[]} The converted array.
+ * @throws {Error} If the JSON string cannot be parsed
+ */
+export const stringToArray = (value: string | string[]): string[] => {
+  if (isString(value)) {
+    try {
+      return Array.from(JSON.parse(String(value)));
+    } catch (error) {
+      throw error;
+    }
+  }
+  return Array.isArray(value) ? value : [];
+};


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR adds a new reset memthod to the BqSelect component, allowing consumers to reset the select value to a previous value without triggering BqChange event.

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

N/A

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

With the following changes, consumers will be able to do something like:

```ts
  const bqSelectRef = useRef<HTMLBqSelectElement>(null);

  const handleSelectChange = async (
    event: BqSelectCustomEvent<{ value: TSelectValue | number; item: HTMLBqOptionElement }>,
  ) => {
    console.log('Selected value', event.detail.value);
    //... other logic here
    if (bqSelectRef.current) {
      await bqSelectRef.current.reset(String(3)); 
    }
  };

  return (
    <BqSelect onBqSelect={handleSelectChange} ref={bqSelectRef}>
      <BqOption value="1">1</BqOption>
      <BqOption value="2">2</BqOption>
      <BqOption value="3">3</BqOption>
    </BqSelect>
  )
```

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
