### PR TITLE
fix(Slider): fix progress tracker when min is negative

### DIFF
--- a/packages/beeq/src/components/slider/bq-slider.tsx
+++ b/packages/beeq/src/components/slider/bq-slider.tsx
@@ -267,11 +267,12 @@ export class BqSlider {
     const { internals, isRangeType, maxValue, minValue } = this;
     this.value = isRangeType ? [minValue, maxValue] : minValue;
     internals?.setFormValue(isRangeType ? JSON.stringify(this.value) : this.value.toString());
+    if (isRangeType) this.el.setAttribute('value', JSON.stringify(this.value));
   };
 
   private calculatePercent = (value: number) => {
     const totalRange = Number(this.max) - Number(this.min);
-    return (value / totalRange) * 100;
+    return ((value - this.min) / totalRange) * 100;
   };
 
   private updateProgressTrack = () => {
@@ -281,7 +282,7 @@ export class BqSlider {
     // For non-range type, left starts from 0 and width is the `min` value.
     const left = this.isRangeType ? this.calculatePercent(this.minValue) : 0;
     const width = this.isRangeType
-      ? this.calculatePercent(Number(this.maxValue) - Number(this.minValue))
+      ? this.calculatePercent(Number(this.maxValue) - Number(this.minValue) + this.min)
       : this.calculatePercent(this.minValue);
 
     this.progressElem.style.insetInlineStart = `${left}%`;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->
This PR fixes
- when min has negative value progress is offset by that amount 
- on type rage value property not being updated

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->
before|after
-|-
![image](https://github.com/user-attachments/assets/7afcb9ba-abed-4a05-9ff3-b01164a27bc3)|<img width="1304" alt="image" src="https://github.com/user-attachments/assets/6ca0321c-6b5b-4e87-964f-5a4c6a28e221" />
![image](https://github.com/user-attachments/assets/65b31822-bde0-416a-8f3d-adfea29b2cbd)|<img width="1299" alt="image" src="https://github.com/user-attachments/assets/2d7e0a24-d5b6-40c7-9a7b-6aa82e79c9c2" />

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
