### PR TITLE
fix(Step Item): improve accessibility and interaction behaviour

### DIFF
--- a/packages/beeq-tailwindcss/src/theme/default/dark.ts
+++ b/packages/beeq-tailwindcss/src/theme/default/dark.ts
@@ -74,7 +74,7 @@ export const DefaultDarkTheme = {
   /** Primary */
   'bq-ui--primary': 'var(--bq-neutral-900)',
   /** Secondary */
-  'bq-ui--secondary': 'var(--bq-neutral-800)',
+  'bq-ui--secondary': 'var(--bq-neutral-950)',
   /** Tertiary */
   'bq-ui--tertiary': 'var(--bq-neutral-700)',
   /** Inverse */

--- a/packages/beeq-tailwindcss/src/theme/default/light.ts
+++ b/packages/beeq-tailwindcss/src/theme/default/light.ts
@@ -73,7 +73,7 @@ export const DefaultLightTheme = {
   /** Primary */
   'bq-ui--primary': 'var(--bq-white)',
   /** Secondary */
-  'bq-ui--secondary': 'var(--bq-neutral-200)',
+  'bq-ui--secondary': 'var(--bq-neutral-100)',
   /** Tertiary */
   'bq-ui--tertiary': 'var(--bq-neutral-500)',
   /** Inverse */

--- a/packages/beeq-tailwindcss/src/theme/endava/dark.ts
+++ b/packages/beeq-tailwindcss/src/theme/endava/dark.ts
@@ -75,7 +75,7 @@ export const EndavaDarkTheme = {
   /** Primary */
   'bq-ui--primary': 'var(--bq-neutral-900)',
   /** Secondary */
-  'bq-ui--secondary': 'var(--bq-neutral-800)',
+  'bq-ui--secondary': 'var(--bq-neutral-950)',
   /** Tertiary */
   'bq-ui--tertiary': 'var(--bq-neutral-700)',
   /** Inverse */

--- a/packages/beeq-tailwindcss/src/theme/endava/light.ts
+++ b/packages/beeq-tailwindcss/src/theme/endava/light.ts
@@ -75,7 +75,7 @@ export const EndavaLightTheme = {
   /** Primary */
   'bq-ui--primary': 'var(--bq-white)',
   /** Secondary */
-  'bq-ui--secondary': 'var(--bq-neutral-200)',
+  'bq-ui--secondary': 'var(--bq-neutral-100)',
   /** Tertiary */
   'bq-ui--tertiary': 'var(--bq-neutral-500)',
   /** Inverse */

--- a/packages/beeq/src/components.d.ts
+++ b/packages/beeq/src/components.d.ts
@@ -4873,6 +4873,8 @@ declare global {
     };
     interface HTMLBqStepItemElementEventMap {
         "bqClick": HTMLBqStepItemElement;
+        "bqFocus": HTMLBqStepItemElement;
+        "bqBlur": HTMLBqStepItemElement;
     }
     /**
      * The Step Item Component is a UI element used to display a single step or stage in a process or task.
@@ -7953,9 +7955,17 @@ declare namespace LocalJSX {
      */
     interface BqStepItem {
         /**
+          * Callback handler triggered when the step item loses focus
+         */
+        "onBqBlur"?: (event: BqStepItemCustomEvent<HTMLBqStepItemElement>) => void;
+        /**
           * Callback handler triggered when the step item is clicked
          */
         "onBqClick"?: (event: BqStepItemCustomEvent<HTMLBqStepItemElement>) => void;
+        /**
+          * Callback handler triggered when the step item is focused
+         */
+        "onBqFocus"?: (event: BqStepItemCustomEvent<HTMLBqStepItemElement>) => void;
         /**
           * It defines prefix size
           * @default 'medium'

--- a/packages/beeq/src/components.d.ts
+++ b/packages/beeq/src/components.d.ts
@@ -2516,6 +2516,11 @@ export namespace Components {
          */
         "dividerColor": string;
         /**
+          * Set the current step item.
+          * @param newCurrentStep - The step item to set as current.
+         */
+        "setCurrentStepItem": (newCurrentStep: HTMLBqStepItemElement) => Promise<void>;
+        /**
           * The size of the steps
           * @default 'medium'
          */

--- a/packages/beeq/src/components.d.ts
+++ b/packages/beeq/src/components.d.ts
@@ -4872,7 +4872,7 @@ declare global {
         new (): HTMLBqStatusElement;
     };
     interface HTMLBqStepItemElementEventMap {
-        "bqClick": { target: HTMLBqStepItemElement; value: string };
+        "bqClick": HTMLBqStepItemElement;
     }
     /**
      * The Step Item Component is a UI element used to display a single step or stage in a process or task.
@@ -7953,9 +7953,9 @@ declare namespace LocalJSX {
      */
     interface BqStepItem {
         /**
-          * Callback handler emitted when the step item is clicked
+          * Callback handler triggered when the step item is clicked
          */
-        "onBqClick"?: (event: BqStepItemCustomEvent<{ target: HTMLBqStepItemElement; value: string }>) => void;
+        "onBqClick"?: (event: BqStepItemCustomEvent<HTMLBqStepItemElement>) => void;
         /**
           * It defines prefix size
           * @default 'medium'

--- a/packages/beeq/src/components/step-item/__tests__/bq-step-item.e2e.ts
+++ b/packages/beeq/src/components/step-item/__tests__/bq-step-item.e2e.ts
@@ -83,6 +83,26 @@ describe('bq-step-item', () => {
     expect(prefix).toMatch(/bq-icon/i);
   });
 
+  it('should emit bqFocus and bqBlur events when focused and blurred', async () => {
+    const page = await newE2EPage({
+      html: `
+        <bq-step-item status="default">
+          <span>Title</span>
+        </bq-step-item>
+      `,
+    });
+
+    const bqFocus = await page.spyOnEvent('bqFocus');
+    const bqBlur = await page.spyOnEvent('bqBlur');
+
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await page.waitForChanges();
+
+    expect(bqFocus).toHaveReceivedEventTimes(1);
+    expect(bqBlur).toHaveReceivedEventTimes(1);
+  });
+
   it('should emit bqClick event when clicked', async () => {
     const page = await newE2EPage({
       html: `

--- a/packages/beeq/src/components/step-item/__tests__/bq-step-item.e2e.ts
+++ b/packages/beeq/src/components/step-item/__tests__/bq-step-item.e2e.ts
@@ -82,4 +82,76 @@ describe('bq-step-item', () => {
     });
     expect(prefix).toMatch(/bq-icon/i);
   });
+
+  it('should emit bqClick event when clicked', async () => {
+    const page = await newE2EPage({
+      html: `
+        <bq-step-item status="default">
+          <span>Title</span>
+        </bq-step-item>
+      `,
+    });
+
+    const bqClick = await page.spyOnEvent('bqClick');
+
+    const element = await page.find('bq-step-item >>> [part="base"]');
+    await element.click();
+    await page.waitForChanges();
+
+    expect(bqClick).toHaveReceivedEventTimes(1);
+  });
+
+  it('should emit bqClick event on Space key press', async () => {
+    const page = await newE2EPage({
+      html: `
+        <bq-step-item status="default">
+          <span>Title</span>
+        </bq-step-item>
+      `,
+    });
+
+    const event = await page.spyOnEvent('bqClick');
+
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Space');
+    await page.waitForChanges();
+
+    expect(event).toHaveReceivedEventTimes(1);
+  });
+
+  it('should emit bqClick event on Enter key press', async () => {
+    const page = await newE2EPage({
+      html: `
+        <bq-step-item status="default">
+          <span>Title</span>
+        </bq-step-item>
+      `,
+    });
+
+    const event = await page.spyOnEvent('bqClick');
+
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Enter');
+    await page.waitForChanges();
+
+    expect(event).toHaveReceivedEventTimes(1);
+  });
+
+  it('should not emit bqClick event when disabled', async () => {
+    const page = await newE2EPage({
+      html: `
+        <bq-step-item status="disabled">
+          <span>Title</span>
+        </bq-step-item>
+      `,
+    });
+
+    const element = await page.find('bq-step-item >>> [part="base"]');
+    const event = await page.spyOnEvent('bqClick');
+
+    await element.click();
+    await page.waitForChanges();
+
+    expect(event).not.toHaveReceivedEvent();
+  });
 });

--- a/packages/beeq/src/components/step-item/bq-step-item.tsx
+++ b/packages/beeq/src/components/step-item/bq-step-item.tsx
@@ -89,8 +89,8 @@ export class BqStepItem {
   // Requires JSDocs for public API documentation
   // ==============================================
 
-  /** Callback handler emitted when the step item is clicked */
-  @Event() bqClick: EventEmitter<{ target: HTMLBqStepItemElement; value: string }>;
+  /** Callback handler triggered when the step item is clicked */
+  @Event() bqClick: EventEmitter<HTMLBqStepItemElement>;
 
   // Component lifecycle events
   // Ordered by their natural call order
@@ -123,13 +123,11 @@ export class BqStepItem {
   // These methods cannot be called from the host element.
   // =======================================================
 
-  private get isDisabled(): boolean {
-    return this.status === 'disabled';
-  }
+  private handleClick = () => {
+    if (this.isDisabled) return;
 
-  private get isCurrent(): boolean {
-    return this.status === 'current';
-  }
+    this.bqClick.emit(this.el);
+  };
 
   private handleIconPrefix = () => {
     const iconElem = this.el.querySelector('[slot="prefix"]');
@@ -138,6 +136,14 @@ export class BqStepItem {
     iconElem.size = this.size === 'small' ? 24 : 32;
   };
 
+  private get isDisabled(): boolean {
+    return this.status === 'disabled';
+  }
+
+  private get isCurrent(): boolean {
+    return this.status === 'current';
+  }
+
   // render() function
   // Always the last one in the class.
   // ===================================
@@ -145,13 +151,14 @@ export class BqStepItem {
   render() {
     return (
       <button
-        type="button"
         class={{
-          'bq-step-item flex gap-s rounded-m border-none bg-transparent p-0 pe-[--bq-steps--gap] p-b-xs2 focus-visible:focus': true,
+          'bq-step-item': true,
           [`bq-step-item--${this.status}`]: true,
           'pointer-events-none opacity-60': this.isDisabled,
         }}
         disabled={this.isDisabled}
+        onClick={this.handleClick}
+        type="button"
         part="base"
       >
         <div class={`bq-step-item__prefix relative ${this.type} ${this.size} ${this.status}`}>

--- a/packages/beeq/src/components/step-item/bq-step-item.tsx
+++ b/packages/beeq/src/components/step-item/bq-step-item.tsx
@@ -139,27 +139,16 @@ export class BqStepItem {
     this.bqBlur.emit(this.el);
   };
 
-  private handleClick = () => {
-    if (this.isDisabled) return;
+  private handleClick = async () => {
+    if (this.isDisabled || this.isCurrent) return;
 
     const clickEvent = this.bqClick.emit(this.el);
     if (clickEvent.defaultPrevented) return;
 
-    this.setCurrentStepItem();
-  };
+    const stepsParent = this.el.closest('bq-steps') as HTMLBqStepsElement;
+    if (!stepsParent) return;
 
-  private setCurrentStepItem = () => {
-    const stepItemContainer = this.el.parentElement;
-    if (!stepItemContainer) return;
-
-    const currentStepItem = stepItemContainer.querySelector<HTMLBqStepItemElement>('bq-step-item[status="current"]');
-    // Ideally, only one step item should be current.
-    // So we change the status of the current step item to default.
-    if (currentStepItem && currentStepItem !== this.el) {
-      currentStepItem.status = 'default';
-    }
-    // And then we set the status of the clicked step item to current.
-    this.status = 'current';
+    await stepsParent.setCurrentStepItem(this.el);
   };
 
   private handleIconPrefix = () => {

--- a/packages/beeq/src/components/step-item/bq-step-item.tsx
+++ b/packages/beeq/src/components/step-item/bq-step-item.tsx
@@ -47,7 +47,9 @@ import type { TStepsSize, TStepsType } from '../steps/bq-steps.types';
 @Component({
   tag: 'bq-step-item',
   styleUrl: './scss/bq-step-item.scss',
-  shadow: true,
+  shadow: {
+    delegatesFocus: true,
+  },
 })
 export class BqStepItem {
   // Own Properties

--- a/packages/beeq/src/components/step-item/bq-step-item.tsx
+++ b/packages/beeq/src/components/step-item/bq-step-item.tsx
@@ -94,6 +94,12 @@ export class BqStepItem {
   /** Callback handler triggered when the step item is clicked */
   @Event() bqClick: EventEmitter<HTMLBqStepItemElement>;
 
+  /** Callback handler triggered when the step item is focused */
+  @Event() bqFocus: EventEmitter<HTMLBqStepItemElement>;
+
+  /** Callback handler triggered when the step item loses focus */
+  @Event() bqBlur: EventEmitter<HTMLBqStepItemElement>;
+
   // Component lifecycle events
   // Ordered by their natural call order
   // =====================================
@@ -124,6 +130,14 @@ export class BqStepItem {
   // Internal business logic.
   // These methods cannot be called from the host element.
   // =======================================================
+
+  private handleFocus = () => {
+    this.bqFocus.emit(this.el);
+  };
+
+  private handleBlur = () => {
+    this.bqBlur.emit(this.el);
+  };
 
   private handleClick = () => {
     if (this.isDisabled) return;
@@ -160,6 +174,8 @@ export class BqStepItem {
         }}
         disabled={this.isDisabled}
         onClick={this.handleClick}
+        onFocus={this.handleFocus}
+        onBlur={this.handleBlur}
         type="button"
         part="base"
       >

--- a/packages/beeq/src/components/step-item/bq-step-item.tsx
+++ b/packages/beeq/src/components/step-item/bq-step-item.tsx
@@ -70,7 +70,7 @@ export class BqStepItem {
   @Prop({ reflect: true }) size?: TStepsSize = 'medium';
 
   /** It defines step item appearance based on its status */
-  @Prop({ reflect: true }) status?: TStepItemStatus = 'default';
+  @Prop({ reflect: true, mutable: true }) status?: TStepItemStatus = 'default';
 
   /** It defines the step item type used */
   @Prop({ reflect: true }) type?: TStepsType;
@@ -142,7 +142,24 @@ export class BqStepItem {
   private handleClick = () => {
     if (this.isDisabled) return;
 
-    this.bqClick.emit(this.el);
+    const clickEvent = this.bqClick.emit(this.el);
+    if (clickEvent.defaultPrevented) return;
+
+    this.setCurrentStepItem();
+  };
+
+  private setCurrentStepItem = () => {
+    const stepItemContainer = this.el.parentElement;
+    if (!stepItemContainer) return;
+
+    const currentStepItem = stepItemContainer.querySelector<HTMLBqStepItemElement>('bq-step-item[status="current"]');
+    // Ideally, only one step item should be current.
+    // So we change the status of the current step item to default.
+    if (currentStepItem && currentStepItem !== this.el) {
+      currentStepItem.status = 'default';
+    }
+    // And then we set the status of the clicked step item to current.
+    this.status = 'current';
   };
 
   private handleIconPrefix = () => {

--- a/packages/beeq/src/components/step-item/bq-step-item.tsx
+++ b/packages/beeq/src/components/step-item/bq-step-item.tsx
@@ -136,7 +136,6 @@ export class BqStepItem {
     if (!iconElem || !isHTMLElement(iconElem, 'bq-icon')) return;
 
     iconElem.size = this.size === 'small' ? 24 : 32;
-    iconElem.weight = this.isCurrent ? 'fill' : 'regular';
   };
 
   // render() function
@@ -145,18 +144,20 @@ export class BqStepItem {
 
   render() {
     return (
-      <div
+      <button
+        type="button"
         class={{
-          'bq-step-item flex gap-s': true,
+          'bq-step-item flex gap-s rounded-m border-none bg-transparent p-0 pe-[--bq-steps--gap] p-b-xs2 focus-visible:focus': true,
           [`bq-step-item--${this.status}`]: true,
           'pointer-events-none opacity-60': this.isDisabled,
         }}
+        disabled={this.isDisabled}
         part="base"
       >
         <div class={`bq-step-item__prefix relative ${this.type} ${this.size} ${this.status}`}>
           <slot name="prefix" onSlotchange={this.handleIconPrefix} />
         </div>
-        <div class="bq-step-item__content">
+        <div class="bq-step-item__content items-start text-start">
           {/* TITLE */}
           <div
             class={{
@@ -179,7 +180,7 @@ export class BqStepItem {
             <slot name="description" />
           </div>
         </div>
-      </div>
+      </button>
     );
   }
 }

--- a/packages/beeq/src/components/step-item/readme.md
+++ b/packages/beeq/src/components/step-item/readme.md
@@ -21,9 +21,11 @@ It should be used inside the Steps component.
 
 ## Events
 
-| Event     | Description                                              | Type                                 |
-| --------- | -------------------------------------------------------- | ------------------------------------ |
-| `bqClick` | Callback handler triggered when the step item is clicked | `CustomEvent<HTMLBqStepItemElement>` |
+| Event     | Description                                               | Type                                 |
+| --------- | --------------------------------------------------------- | ------------------------------------ |
+| `bqBlur`  | Callback handler triggered when the step item loses focus | `CustomEvent<HTMLBqStepItemElement>` |
+| `bqClick` | Callback handler triggered when the step item is clicked  | `CustomEvent<HTMLBqStepItemElement>` |
+| `bqFocus` | Callback handler triggered when the step item is focused  | `CustomEvent<HTMLBqStepItemElement>` |
 
 
 ## Slots

--- a/packages/beeq/src/components/step-item/readme.md
+++ b/packages/beeq/src/components/step-item/readme.md
@@ -21,9 +21,9 @@ It should be used inside the Steps component.
 
 ## Events
 
-| Event     | Description                                            | Type                                                             |
-| --------- | ------------------------------------------------------ | ---------------------------------------------------------------- |
-| `bqClick` | Callback handler emitted when the step item is clicked | `CustomEvent<{ target: HTMLBqStepItemElement; value: string; }>` |
+| Event     | Description                                              | Type                                 |
+| --------- | -------------------------------------------------------- | ------------------------------------ |
+| `bqClick` | Callback handler triggered when the step item is clicked | `CustomEvent<HTMLBqStepItemElement>` |
 
 
 ## Slots

--- a/packages/beeq/src/components/step-item/scss/bq-step-item.scss
+++ b/packages/beeq/src/components/step-item/scss/bq-step-item.scss
@@ -11,7 +11,7 @@
 }
 
 .bq-step-item {
-  @apply flex gap-s rounded-m border-none bg-transparent p-0 pe-[--bq-steps--gap] p-b-xs2 focus-visible:focus hover:bg-hover-ui-secondary;
+  @apply flex gap-s rounded-m border-none bg-transparent pe-[--bq-steps--gap] ps-0 p-b-xs2 focus-visible:focus hover:bg-hover-ui-secondary;
   @apply transition-colors duration-300;
 }
 

--- a/packages/beeq/src/components/step-item/scss/bq-step-item.scss
+++ b/packages/beeq/src/components/step-item/scss/bq-step-item.scss
@@ -6,8 +6,13 @@
 
 :host {
   --bq-icon--color: theme(stroke.icon.primary);
-
+  // !Note: The use of the `bg-primary` is to avoid the divider to be visible behind the step item.
   @apply bg-primary;
+}
+
+.bq-step-item {
+  @apply flex gap-s rounded-m border-none bg-transparent p-0 pe-[--bq-steps--gap] p-b-xs2 focus-visible:focus hover:bg-hover-ui-secondary;
+  @apply transition-colors duration-300;
 }
 
 .bq-step-item__prefix.dot,

--- a/packages/beeq/src/components/steps/__tests__/bq-steps.e2e.ts
+++ b/packages/beeq/src/components/steps/__tests__/bq-steps.e2e.ts
@@ -30,20 +30,55 @@ describe('bq-steps', () => {
   it('should render the correct number of steps', async () => {
     const page = await newE2EPage({
       html: `
-      <bq-steps type="numeric" size="medium">
-        <bq-step-item>
-          <span slot="prefix">1</span>
-          <span>Title</span>
-        </bq-step-item>
-        <bq-step-item>
-          <span slot="prefix">2</span>
-          <span>Title</span>
-        </bq-step-item>
-      </bq-steps>
+        <bq-steps type="numeric" size="medium">
+          <bq-step-item>
+            <span slot="prefix">1</span>
+            <span>Title</span>
+          </bq-step-item>
+          <bq-step-item>
+            <span slot="prefix">2</span>
+            <span>Title</span>
+          </bq-step-item>
+        </bq-steps>
       `,
     });
 
     const steps = await page.findAll('bq-step-item');
     expect(steps).toHaveLength(2);
+  });
+
+  it('should set the current step item when clicked', async () => {
+    const page = await newE2EPage({
+      html: `
+        <bq-steps type="numeric" size="medium">
+          <bq-step-item>
+            <span slot="prefix">1</span>
+            <span>Title</span>
+          </bq-step-item>
+          <bq-step-item>
+            <span slot="prefix">2</span>
+            <span>Title</span>
+          </bq-step-item>
+        </bq-steps>
+      `,
+    });
+
+    const steps = await page.findAll('bq-step-item');
+    expect(steps).toHaveLength(2);
+
+    const step1 = steps[0];
+    const step2 = steps[1];
+
+    await step1.click();
+    await page.waitForChanges();
+
+    expect(step1.getAttribute('status')).toBe('current');
+    expect(step2.getAttribute('status')).toBe('default');
+
+    await step2.click();
+    await page.waitForChanges();
+
+    expect(step2.getAttribute('status')).toBe('current');
+    expect(step1.getAttribute('status')).toBe('default');
   });
 });

--- a/packages/beeq/src/components/steps/_storybook/bq-steps.stories.tsx
+++ b/packages/beeq/src/components/steps/_storybook/bq-steps.stories.tsx
@@ -20,6 +20,8 @@ const meta: Meta = {
     size: { control: 'select', options: [...STEPS_SIZE] },
     // Events
     bqClick: { action: 'bqClick', table: { disable: true } },
+    bqFocus: { action: 'bqFocus', table: { disable: true } },
+    bqBlur: { action: 'bqBlur', table: { disable: true } },
     // Not part of the public API
     children: { control: 'text', table: { disable: true } },
   },
@@ -32,7 +34,14 @@ export default meta;
 
 const Template = (args: Args) => {
   return html`
-    <bq-steps divider-color=${args['divider-color']} type=${args.type} size=${args.size} @bqClick=${args.bqClick}>
+    <bq-steps
+      divider-color=${args['divider-color']}
+      type=${args.type}
+      size=${args.size}
+      @bqClick=${args.bqClick}
+      @bqFocus=${args.bqFocus}
+      @bqBlur=${args.bqBlur}
+    >
       ${ifDefined(args.children) ? unsafeHTML(args.children) : nothing}
     </bq-steps>
   `;

--- a/packages/beeq/src/components/steps/_storybook/bq-steps.stories.tsx
+++ b/packages/beeq/src/components/steps/_storybook/bq-steps.stories.tsx
@@ -18,6 +18,8 @@ const meta: Meta = {
     'divider-color': { control: 'text' },
     type: { control: 'select', options: [...STEPS_TYPE] },
     size: { control: 'select', options: [...STEPS_SIZE] },
+    // Events
+    bqClick: { action: 'bqClick', table: { disable: true } },
     // Not part of the public API
     children: { control: 'text', table: { disable: true } },
   },
@@ -30,7 +32,7 @@ export default meta;
 
 const Template = (args: Args) => {
   return html`
-    <bq-steps divider-color=${args['divider-color']} type=${args.type} size=${args.size}>
+    <bq-steps divider-color=${args['divider-color']} type=${args.type} size=${args.size} @bqClick=${args.bqClick}>
       ${ifDefined(args.children) ? unsafeHTML(args.children) : nothing}
     </bq-steps>
   `;

--- a/packages/beeq/src/components/steps/bq-steps.tsx
+++ b/packages/beeq/src/components/steps/bq-steps.tsx
@@ -132,7 +132,8 @@ export class BqSteps {
   // ===================================
 
   render() {
-    const dividerPaddingTop = this.size === 'small' ? 'p-bs-s' : 'p-bs-m';
+    // !Note: We use a custom padding value for the medium size to avoid misalignment between the steps and the divider.
+    const dividerPaddingTop = this.size === 'small' ? 'p-bs-m' : 'p-bs-5';
 
     return (
       <div

--- a/packages/beeq/src/components/steps/bq-steps.tsx
+++ b/packages/beeq/src/components/steps/bq-steps.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, h, Prop, Watch } from '@stencil/core';
+import { Component, Element, h, Method, Prop, Watch } from '@stencil/core';
 
 import { STEPS_SIZE, STEPS_TYPE } from './bq-steps.types';
 import type { TStepsSize, TStepsType } from './bq-steps.types';
@@ -102,6 +102,20 @@ export class BqSteps {
   // Requires JSDocs for public API documentation.
   // ===============================================
 
+  /**
+   * Set the current step item.
+   * @param newCurrentStep - The step item to set as current.
+   */
+  @Method()
+  async setCurrentStepItem(newCurrentStep: HTMLBqStepItemElement): Promise<void> {
+    // Ideally, only one step item should be current.
+    // So we change the status of the current step item to default.
+    const currentStep = this.bqSteps.find((step) => step.status === 'current');
+    if (currentStep) currentStep.status = 'default';
+    // And then we set the status of the new current step item to current.
+    newCurrentStep.status = 'current';
+  }
+
   // Local methods
   // Internal business logic.
   // These methods cannot be called from the host element.
@@ -122,10 +136,6 @@ export class BqSteps {
       bqStepElem.type = this.type;
     });
   };
-
-  // private handleChange = (event) => {
-  //   this.bqChange.emit(event);
-  // }
 
   // render() function
   // Always the last one in the class.

--- a/packages/beeq/src/components/steps/readme.md
+++ b/packages/beeq/src/components/steps/readme.md
@@ -19,6 +19,25 @@ It is used to guide users through a process or task and to indicate their progre
 | `type`         | `type`          | The type of prefix element to use on the step items                                          | `"dot" \| "icon" \| "numeric"` | `undefined`         |
 
 
+## Methods
+
+### `setCurrentStepItem(newCurrentStep: HTMLBqStepItemElement) => Promise<void>`
+
+Set the current step item.
+
+#### Parameters
+
+| Name             | Type                    | Description                        |
+| ---------------- | ----------------------- | ---------------------------------- |
+| `newCurrentStep` | `HTMLBqStepItemElement` | - The step item to set as current. |
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+
 ## Slots
 
 | Slot | Description    |

--- a/packages/beeq/src/components/steps/scss/bq-steps.scss
+++ b/packages/beeq/src/components/steps/scss/bq-steps.scss
@@ -11,7 +11,3 @@
 ::slotted(bq-step-item:not(:first-child)) {
   @apply ps-[--bq-steps--gap];
 }
-
-::slotted(bq-step-item::part(base):not(:last-child)) {
-  @apply pe-[--bq-steps--gap];
-}

--- a/packages/beeq/src/components/steps/scss/bq-steps.scss
+++ b/packages/beeq/src/components/steps/scss/bq-steps.scss
@@ -12,6 +12,6 @@
   @apply ps-[--bq-steps--gap];
 }
 
-::slotted(bq-step-item:not(:last-child)) {
+::slotted(bq-step-item::part(base):not(:last-child)) {
   @apply pe-[--bq-steps--gap];
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR changes the component's internal wrapper from `div` to `button` enabling interaction behaviour and improving accessibility. The component now emits the `bqClick`, `bqFocus`, and `bqBlur` events as expected, as they were missed in the initial implementation.
When clicking a new step item, it will become the current active step. The behaviour can be changed by using `event.PreventDefault()` on the `bqClick` handler of the step item.

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

Fixes #1498 

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

https://github.com/user-attachments/assets/19227856-ee78-44d4-8424-6b34a2443da2

<img width="1678" height="880" alt="CleanShot 2025-07-30 at 13 38 15@2x" src="https://github.com/user-attachments/assets/86df1ab9-15b0-4487-a714-69993766b8a6" />

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
