### PR TITLE
fix(Radio group, Radio): allow radio group focus when no radio is checked

### DIFF
--- a/packages/beeq/src/components.d.ts
+++ b/packages/beeq/src/components.d.ts
@@ -4501,10 +4501,10 @@ declare global {
         new (): HTMLBqProgressElement;
     };
     interface HTMLBqRadioElementEventMap {
-        "bqClick": HTMLBqRadioElement;
+        "bqClick": { value: string; target: HTMLBqRadioElement };
         "bqFocus": HTMLBqRadioElement;
         "bqBlur": HTMLBqRadioElement;
-        "bqKeyDown": KeyboardEvent;
+        "bqKeyDown": { key: string; target: HTMLBqRadioElement };
     }
     /**
      * The radio button is a user interface element that allows users to select a single option.
@@ -7364,7 +7364,7 @@ declare namespace LocalJSX {
         /**
           * Handler to be called when the radio state changes
          */
-        "onBqClick"?: (event: BqRadioCustomEvent<HTMLBqRadioElement>) => void;
+        "onBqClick"?: (event: BqRadioCustomEvent<{ value: string; target: HTMLBqRadioElement }>) => void;
         /**
           * Handler to be called when the radio gets focus
          */
@@ -7372,7 +7372,7 @@ declare namespace LocalJSX {
         /**
           * Handler to be called when the radio key is pressed
          */
-        "onBqKeyDown"?: (event: BqRadioCustomEvent<KeyboardEvent>) => void;
+        "onBqKeyDown"?: (event: BqRadioCustomEvent<{ key: string; target: HTMLBqRadioElement }>) => void;
         /**
           * If `true`, it will indicate that the user must specify a value for the radio before the owning form can be submitted
          */

--- a/packages/beeq/src/components/radio-group/__tests__/bq-radio-group.e2e.ts
+++ b/packages/beeq/src/components/radio-group/__tests__/bq-radio-group.e2e.ts
@@ -1,0 +1,190 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+import { setProperties } from '../../../shared/test-utils';
+
+describe('bq-radio-group', () => {
+  it('should render', async () => {
+    const page = await newE2EPage({
+      html: '<bq-radio-group></bq-radio-group>',
+    });
+
+    const element = await page.find('bq-radio-group');
+    expect(element).toHaveClass('hydrated');
+  });
+
+  it('should have shadow root', async () => {
+    const page = await newE2EPage({
+      html: '<bq-radio-group></bq-radio-group>',
+    });
+
+    const element = await page.find('bq-radio-group');
+    expect(element.shadowRoot).not.toBeNull();
+  });
+
+  it('should set value attribute when a radio is clicked', async () => {
+    const page = await newE2EPage({
+      html: `
+        <bq-radio-group name="test-option">
+          <bq-radio value="option1">Option 1</bq-radio>
+          <bq-radio value="option2">Option 2</bq-radio>
+        </bq-radio-group>
+      `,
+    });
+
+    const bqRadioGroup = await page.find('bq-radio-group');
+    const option2 = await page.find('bq-radio[value="option2"]');
+
+    await option2.click();
+    await page.waitForChanges();
+
+    expect(bqRadioGroup).toHaveAttribute('value');
+    expect(bqRadioGroup).toEqualAttribute('value', 'option2');
+  });
+
+  it('should check the first radio if required and no value or checked radio is set', async () => {
+    const page = await newE2EPage({
+      html: `
+        <bq-radio-group name="test-option">
+          <bq-radio value="option1">Option 1</bq-radio>
+          <bq-radio value="option2">Option 2</bq-radio>
+          <bq-radio value="option3">Option 3</bq-radio>
+        </bq-radio-group>
+      `,
+    });
+    await page.waitForChanges();
+
+    const bqRadioGroup = await page.find('bq-radio-group');
+    const option1 = await page.find('bq-radio[value="option1"]');
+    const option2 = await page.find('bq-radio[value="option2"]');
+    const option3 = await page.find('bq-radio[value="option3"]');
+
+    await setProperties(page, 'bq-radio-group', { required: true });
+    await page.waitForChanges();
+
+    expect(await option1.getProperty('checked')).toBe(true);
+    expect(await option2.getProperty('checked')).toBe(false);
+    expect(await option3.getProperty('checked')).toBe(false);
+    expect(bqRadioGroup).toEqualAttribute('value', 'option1');
+  });
+
+  it('should check a radio when the value attribute is set', async () => {
+    const page = await newE2EPage({
+      html: `
+        <bq-radio-group name="test-option" value="option2">
+          <bq-radio value="option1">Option 1</bq-radio>
+          <bq-radio value="option2">Option 2</bq-radio>
+          <bq-radio value="option3">Option 3</bq-radio>
+        </bq-radio-group>
+      `,
+    });
+
+    await page.waitForChanges();
+
+    const option1 = await page.find('bq-radio[value="option1"]');
+    const option2 = await page.find('bq-radio[value="option2"]');
+    const option3 = await page.find('bq-radio[value="option3"]');
+
+    expect(await option1.getProperty('checked')).toBe(false);
+    expect(await option2.getProperty('checked')).toBe(true);
+    expect(await option3.getProperty('checked')).toBe(false);
+  });
+
+  it('should handle the checked state correctly', async () => {
+    const page = await newE2EPage({
+      html: `
+        <bq-radio-group name="test-option">
+          <bq-radio value="option1">Option 1</bq-radio>
+          <bq-radio value="option2">Option 2</bq-radio>
+          <bq-radio value="option3">Option 3</bq-radio>
+        </bq-radio-group>
+      `,
+    });
+
+    const bqRadioGroup = await page.find('bq-radio-group');
+    const option1 = await page.find('bq-radio[value="option1"]');
+    const option2 = await page.find('bq-radio[value="option2"]');
+    const option3 = await page.find('bq-radio[value="option3"]');
+
+    await option1.click();
+    await page.waitForChanges();
+
+    expect(bqRadioGroup).toEqualAttribute('value', 'option1');
+    expect(await option1.getProperty('checked')).toBe(true);
+    expect(await option2.getProperty('checked')).toBe(false);
+    expect(await option3.getProperty('checked')).toBe(false);
+
+    await option2.click();
+    await page.waitForChanges();
+
+    expect(bqRadioGroup).toEqualAttribute('value', 'option2');
+    expect(await option1.getProperty('checked')).toBe(false);
+    expect(await option2.getProperty('checked')).toBe(true);
+    expect(await option3.getProperty('checked')).toBe(false);
+
+    await option3.click();
+    await page.waitForChanges();
+
+    expect(bqRadioGroup).toEqualAttribute('value', 'option3');
+    expect(await option1.getProperty('checked')).toBe(false);
+    expect(await option2.getProperty('checked')).toBe(false);
+    expect(await option3.getProperty('checked')).toBe(true);
+  });
+
+  it('should emit the bqChange event when a radio is clicked', async () => {
+    const page = await newE2EPage({
+      html: `
+        <bq-radio-group name="test-option">
+          <bq-radio value="option1">Option 1</bq-radio>
+          <bq-radio value="option2">Option 2</bq-radio>
+          <bq-radio value="option3">Option 3</bq-radio>
+        </bq-radio-group>
+      `,
+    });
+
+    const bqChange = await page.spyOnEvent('bqChange');
+    const option1 = await page.find('bq-radio[value="option1"]');
+
+    await option1.click();
+    await page.waitForChanges();
+
+    expect(bqChange).toHaveReceivedEventTimes(1);
+  });
+
+  it('should be keyboard accessible', async () => {
+    const page = await newE2EPage({
+      html: `
+        <bq-radio-group name="test-option">
+          <bq-radio value="option1">Option 1</bq-radio>
+          <bq-radio value="option2">Option 2</bq-radio>
+          <bq-radio value="option3">Option 3</bq-radio>
+        </bq-radio-group>
+      `,
+    });
+
+    await page.waitForChanges();
+
+    await page.keyboard.press('Tab');
+    await page.waitForChanges();
+
+    const bqRadioGroup = await page.find('bq-radio-group');
+    expect(await bqRadioGroup.getProperty('value')).toBeUndefined();
+
+    await bqRadioGroup.press('ArrowRight');
+    await page.waitForChanges();
+
+    expect(await bqRadioGroup.getProperty('value')).toBe('option2');
+    expect(await page.find('bq-radio[value="option2"]')).toHaveAttribute('checked');
+
+    await page.keyboard.press('ArrowDown');
+    await page.waitForChanges();
+
+    expect(await bqRadioGroup.getProperty('value')).toBe('option3');
+    expect(await page.find('bq-radio[value="option3"]')).toHaveAttribute('checked');
+
+    await page.keyboard.press('ArrowDown');
+    await page.waitForChanges();
+
+    expect(await bqRadioGroup.getProperty('value')).toBe('option1');
+    expect(await page.find('bq-radio[value="option1"]')).toHaveAttribute('checked');
+  });
+});

--- a/packages/beeq/src/components/radio/bq-radio.tsx
+++ b/packages/beeq/src/components/radio/bq-radio.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, h, Method, Prop } from '@stencil/core';
+import { Component, Element, Event, h, Host, Method, Prop } from '@stencil/core';
 import type { EventEmitter } from '@stencil/core';
 
 /**
@@ -64,14 +64,14 @@ export class BqRadio {
   // Public Property API
   // ========================
 
+  /** If true radio displays background on hover */
+  @Prop({ reflect: true }) backgroundOnHover? = false;
+
   /** If true radio input is checked */
   @Prop({ reflect: true, mutable: true }) checked?: boolean;
 
   /** If true radio input is disabled */
   @Prop({ reflect: true }) disabled? = false;
-
-  /** If true radio displays background on hover */
-  @Prop({ reflect: true }) backgroundOnHover? = false;
 
   /** The form ID that the radio input is associated with */
   @Prop({ reflect: true }) formId?: string;
@@ -93,7 +93,7 @@ export class BqRadio {
   // ==============================================
 
   /** Handler to be called when the radio state changes */
-  @Event() bqClick: EventEmitter<HTMLBqRadioElement>;
+  @Event() bqClick: EventEmitter<{ value: string; target: HTMLBqRadioElement }>;
 
   /** Handler to be called when the radio gets focus */
   @Event() bqFocus: EventEmitter<HTMLBqRadioElement>;
@@ -102,7 +102,7 @@ export class BqRadio {
   @Event() bqBlur: EventEmitter<HTMLBqRadioElement>;
 
   /** Handler to be called when the radio key is pressed */
-  @Event() bqKeyDown: EventEmitter<KeyboardEvent>;
+  @Event() bqKeyDown: EventEmitter<{ key: string; target: HTMLBqRadioElement }>;
 
   // Component lifecycle events
   // Ordered by their natural call order
@@ -158,9 +158,18 @@ export class BqRadio {
   // These methods cannot be called from the host element.
   // =======================================================
 
-  private handleClick = () => {
-    this.checked = true;
-    this.bqClick.emit(this.el);
+  private handleClick = (event: MouseEvent) => {
+    // Prevent the native input click default behavior
+    event.preventDefault();
+    if (this.disabled) return;
+
+    // Emit the event without changing state
+    // Let the radio-group handle all state management and event propagation
+    const bqClickEvent = this.bqClick.emit({ value: this.value, target: this.el });
+    if (bqClickEvent.defaultPrevented) {
+      event.stopImmediatePropagation();
+      return;
+    }
   };
 
   private handleOnFocus = () => {
@@ -172,13 +181,8 @@ export class BqRadio {
   };
 
   private handleOnKeyDown = (event: KeyboardEvent) => {
-    this.bqKeyDown.emit(event);
+    this.bqKeyDown.emit({ key: event.key, target: this.el });
   };
-
-  private get tabindex(): string {
-    // NOTE: this.checked is undefined when is not part of bq-radio-group
-    return `${-1 + +(this.checked ?? 1)}`;
-  }
 
   // render() function
   // Always the last one in the class.
@@ -186,46 +190,48 @@ export class BqRadio {
 
   render() {
     return (
-      <label
-        class={{
-          'bq-radio group': true,
-          'is-disabled !cursor-not-allowed': this.disabled,
-          'is-checked': this.checked,
-          'has-background': this.backgroundOnHover,
-        }}
-        part="base"
-      >
-        <div class="bq-radio__control">
-          <input
-            class="bq-radio__input"
-            ref={(element) => (this.inputElement = element)}
-            type="radio"
-            form={this.formId}
-            name={this.name}
-            value={this.value}
-            required={this.required}
-            disabled={this.disabled}
-            onBlur={this.handleOnBlur}
-            onClick={this.handleClick}
-            onFocus={this.handleOnFocus}
-            onKeyDown={this.handleOnKeyDown}
-            aria-checked={this.checked ? 'true' : 'false'}
-            aria-disabled={this.disabled ? 'true' : 'false'}
-            aria-labelledby="bq-radio__label"
-            tabindex={this.tabindex}
-            part="input"
-          />
-          <div class="bq-radio__circle" part="radio">
-            <div class="bq-radio__checked" />
-          </div>
-        </div>
-        <span
-          class="bq-radio__label group-hover:text-text-primary-hover group-[.is-disabled]:text-text-primary-disabled"
-          part="label"
+      <Host tabindex={this.checked ? '0' : '-1'}>
+        <label
+          class={{
+            'bq-radio group': true,
+            'is-disabled': this.disabled,
+            'is-checked': this.checked,
+            'has-background': this.backgroundOnHover,
+          }}
+          part="base"
         >
-          <slot id="bq-radio__label"></slot>
-        </span>
-      </label>
+          <div class="bq-radio__control">
+            <input
+              class="bq-radio__input"
+              ref={(element) => (this.inputElement = element)}
+              type="radio"
+              form={this.formId}
+              name={this.name}
+              value={this.value}
+              required={this.required}
+              disabled={this.disabled}
+              checked={this.checked}
+              onBlur={this.handleOnBlur}
+              onClick={this.handleClick}
+              onFocus={this.handleOnFocus}
+              onKeyDown={this.handleOnKeyDown}
+              aria-checked={this.checked ? 'true' : 'false'}
+              aria-disabled={this.disabled ? 'true' : 'false'}
+              aria-labelledby="bq-radio__label"
+              part="input"
+            />
+            <div class="bq-radio__circle" part="radio">
+              <div class="bq-radio__checked" />
+            </div>
+          </div>
+          <span
+            class="bq-radio__label group-hover:text-text-primary-hover group-[.is-disabled]:text-text-primary-disabled"
+            part="label"
+          >
+            <slot id="bq-radio__label"></slot>
+          </span>
+        </label>
+      </Host>
     );
   }
 }

--- a/packages/beeq/src/components/radio/readme.md
+++ b/packages/beeq/src/components/radio/readme.md
@@ -24,12 +24,12 @@ The radio button is a user interface element that allows users to select a singl
 
 ## Events
 
-| Event       | Description                                        | Type                              |
-| ----------- | -------------------------------------------------- | --------------------------------- |
-| `bqBlur`    | Handler to be called when the radio loses focus    | `CustomEvent<HTMLBqRadioElement>` |
-| `bqClick`   | Handler to be called when the radio state changes  | `CustomEvent<HTMLBqRadioElement>` |
-| `bqFocus`   | Handler to be called when the radio gets focus     | `CustomEvent<HTMLBqRadioElement>` |
-| `bqKeyDown` | Handler to be called when the radio key is pressed | `CustomEvent<KeyboardEvent>`      |
+| Event       | Description                                        | Type                                                          |
+| ----------- | -------------------------------------------------- | ------------------------------------------------------------- |
+| `bqBlur`    | Handler to be called when the radio loses focus    | `CustomEvent<HTMLBqRadioElement>`                             |
+| `bqClick`   | Handler to be called when the radio state changes  | `CustomEvent<{ value: string; target: HTMLBqRadioElement; }>` |
+| `bqFocus`   | Handler to be called when the radio gets focus     | `CustomEvent<HTMLBqRadioElement>`                             |
+| `bqKeyDown` | Handler to be called when the radio key is pressed | `CustomEvent<{ key: string; target: HTMLBqRadioElement; }>`   |
 
 
 ## Methods

--- a/packages/beeq/src/components/radio/scss/bq-radio.scss
+++ b/packages/beeq/src/components/radio/scss/bq-radio.scss
@@ -13,9 +13,7 @@
   @apply rounded-s p-b-xs p-i-xs;
 
   &.is-disabled {
-    .bq-radio__circle {
-      @apply opacity-60;
-    }
+    @apply cursor-not-allowed opacity-60;
 
     &.is-checked .bq-radio__circle {
       @apply border-icon-brand;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR refactors the Radio and Radio Group components to improve event handling, state management, and accessibility. The changes include updated event types, improved focus state management, and comprehensive end-to-end tests.

### Changes
- Modified bq-radio.tsx to emit `bqClick` events with value and target and delegate state management to `bq-radio-group`.
- Removed direct state modification in `bq-radio`.
- Refactored bq-radio-group.tsx to manage radio selection and focus, debounce change events, and improve initialisation logic. Introduced KEY_MAP for keyboard navigation.
- Added new end-to-end tests for both `bq-radio` and `bq-radio-group` to ensure functionality and accessibility.

### Impact
- Improved event handling by providing more context with `bqClick` and `bqKeyDown` events.
- Enhanced accessibility and keyboard navigation in the `bq-radio-group` component.
- Centralised state management in `bq-radio-group` for more predictable behaviour.
- The value change logic moved to the `bq-radio-group`, it now emits the `bqChange` event after updating its value.
- Added tests ensure the components function as expected and are accessible.

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

Fixes #1500 

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
