### PR TITLE
feat(Tooltip): enable prevention of behaviour for click, focus, and hover events

### DIFF
--- a/packages/beeq/src/components.d.ts
+++ b/packages/beeq/src/components.d.ts
@@ -3282,6 +3282,10 @@ export interface BqToastCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLBqToastElement;
 }
+export interface BqTooltipCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLBqTooltipElement;
+}
 declare global {
     interface HTMLBqAccordionElementEventMap {
         "bqBlur": HTMLBqAccordionElement;
@@ -5293,6 +5297,13 @@ declare global {
         prototype: HTMLBqToastElement;
         new (): HTMLBqToastElement;
     };
+    interface HTMLBqTooltipElementEventMap {
+        "bqClick": HTMLBqTooltipElement;
+        "bqFocusIn": HTMLBqTooltipElement;
+        "bqFocusOut": HTMLBqTooltipElement;
+        "bqHoverIn": HTMLBqTooltipElement;
+        "bqHoverOut": HTMLBqTooltipElement;
+    }
     /**
      * The Tooltip component is a small pop-up box that appears when a user hovers over or clicks on an element, providing additional information or context.
      * @example How to use it
@@ -5327,6 +5338,14 @@ declare global {
      * @cssprop --bq-tooltip--z-index: Tooltip z-index
      */
     interface HTMLBqTooltipElement extends Components.BqTooltip, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLBqTooltipElementEventMap>(type: K, listener: (this: HTMLBqTooltipElement, ev: BqTooltipCustomEvent<HTMLBqTooltipElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLBqTooltipElementEventMap>(type: K, listener: (this: HTMLBqTooltipElement, ev: BqTooltipCustomEvent<HTMLBqTooltipElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLBqTooltipElement: {
         prototype: HTMLBqTooltipElement;
@@ -8683,6 +8702,26 @@ declare namespace LocalJSX {
           * @default false
          */
         "hideArrow"?: boolean;
+        /**
+          * Emitted when the tooltip trigger is clicked
+         */
+        "onBqClick"?: (event: BqTooltipCustomEvent<HTMLBqTooltipElement>) => void;
+        /**
+          * Emitted when the tooltip trigger is focused in
+         */
+        "onBqFocusIn"?: (event: BqTooltipCustomEvent<HTMLBqTooltipElement>) => void;
+        /**
+          * Emitted when the tooltip trigger is focused out
+         */
+        "onBqFocusOut"?: (event: BqTooltipCustomEvent<HTMLBqTooltipElement>) => void;
+        /**
+          * Emitted when the tooltip trigger is hovered in
+         */
+        "onBqHoverIn"?: (event: BqTooltipCustomEvent<HTMLBqTooltipElement>) => void;
+        /**
+          * Emitted when the tooltip trigger is hovered out
+         */
+        "onBqHoverOut"?: (event: BqTooltipCustomEvent<HTMLBqTooltipElement>) => void;
         /**
           * @default 'top'
          */

--- a/packages/beeq/src/components/tooltip/__tests__/bq-tooltip.e2e.ts
+++ b/packages/beeq/src/components/tooltip/__tests__/bq-tooltip.e2e.ts
@@ -2,123 +2,149 @@ import { newE2EPage } from '@stencil/core/testing';
 
 import { computedStyle } from '../../../shared/test-utils';
 
+const tooltipPanelSelector = 'bq-tooltip >>> [part="panel"]';
+const buttonSelector = 'bq-button >>> button';
+const html = `
+  <bq-tooltip>
+    Yuhu! A tooltip!
+    <bq-button slot="trigger"> Hover me! </bq-button>
+  </bq-tooltip>
+`;
+
 describe('bq-tooltip', () => {
   it('should render', async () => {
-    const page = await newE2EPage({
-      html: '<bq-tooltip></bq-tooltip>',
-    });
+    const page = await newE2EPage({ html });
 
     const tooltipElem = await page.find('bq-tooltip');
     expect(tooltipElem).toHaveClass('hydrated');
   });
 
   it('should have shadow root', async () => {
-    const page = await newE2EPage({
-      html: '<bq-tooltip></bq-tooltip>',
-    });
+    const page = await newE2EPage({ html });
 
     const tooltipElem = await page.find('bq-tooltip');
     expect(tooltipElem.shadowRoot).not.toBeNull();
   });
 
-  // TODO: this test is flaky, sometimes it passes, sometimes it fails
-  it.skip('should be visible on hover', async () => {
-    const page = await newE2EPage({
-      html: `
-        <bq-tooltip>
-          Yuhu! A tooltip!
-          <bq-button slot="trigger"> Hover me! </bq-button>
-        </bq-tooltip>
-      `,
-    });
+  it('should be visible on hover', async () => {
+    const page = await newE2EPage({ html });
 
     await page.waitForChanges();
 
-    const tooltipPanelSelector = 'bq-tooltip >>> [part="panel"]';
-    await page.waitForSelector(tooltipPanelSelector);
+    // Ensure no element is initially focused (headless Linux can auto-focus the first tabbable element)
+    await page.click('body');
+    await page.waitForChanges();
 
     const initialPanel = await page.find(tooltipPanelSelector);
-    expect(initialPanel).toHaveAttribute('aria-hidden');
+    expect(initialPanel).toHaveAttribute('hidden');
 
-    const button = await page.find('bq-button >>> button');
+    const button = await page.find(buttonSelector);
     await button.hover();
 
     await page.waitForChanges();
 
     const visiblePanel = await page.find(tooltipPanelSelector);
-    expect(visiblePanel).not.toHaveAttribute('aria-hidden');
+    expect(visiblePanel).not.toHaveAttribute('hidden');
   });
 
-  it('should hide on mouse out', async () => {
-    const page = await newE2EPage({
-      html: `
-      <bq-tooltip visible>
-        Yuhu! A tooltip!
-        <bq-button slot="trigger"> Hover me! </bq-button>
-      </bq-tooltip>
-    `,
-    });
+  it('should not be visible on hover if defaultPrevented', async () => {
+    const page = await newE2EPage({ html });
+    const bqTooltipPanel = await page.find(tooltipPanelSelector);
+    const bqHoverInSpy = await page.spyOnEvent('bqHoverIn');
 
     await page.waitForChanges();
 
-    const tooltipPanelSelector = 'bq-tooltip >>> [part="panel"]';
+    // Ensure no element is initially focused (headless Linux can auto-focus the first tabbable element)
+    await page.click('body');
+    await page.waitForChanges();
 
-    await page.waitForSelector(tooltipPanelSelector);
+    await page.$eval('bq-tooltip', (el: HTMLElement) => {
+      el.addEventListener('bqHoverIn', (e: Event) => e.preventDefault(), { once: true });
+    });
+
+    const button = await page.find(buttonSelector);
+    await button.hover();
+
+    await page.waitForChanges();
+
+    expect(bqTooltipPanel).toHaveAttribute('hidden');
+    expect(bqHoverInSpy).toHaveReceivedEventTimes(1);
+  });
+
+  it('should hide on mouse out', async () => {
+    const page = await newE2EPage({ html });
+
+    (await page.find('bq-tooltip')).setProperty('visible', 'true');
+    await page.waitForChanges();
+
     const initialPanel = await page.find(tooltipPanelSelector);
-    expect(initialPanel).not.toHaveAttribute('aria-hidden');
+    expect(initialPanel).not.toHaveAttribute('hidden');
 
     await page.click('body');
     await page.waitForChanges();
 
     const hiddenPanel = await page.find(tooltipPanelSelector);
-    expect(hiddenPanel).toHaveAttribute('aria-hidden');
+    expect(hiddenPanel).toHaveAttribute('hidden');
   });
 
   it('should be visible only on click if specified', async () => {
-    const page = await newE2EPage({
-      html: `
-        <bq-tooltip display-on="click">
-          Yuhu! A tooltip!
-          <bq-button slot="trigger"> Hover me! </bq-button>
-        </bq-tooltip>
-      `,
-    });
+    const page = await newE2EPage({ html });
 
+    (await page.find('bq-tooltip')).setProperty('displayOn', 'click');
     await page.waitForChanges();
 
-    const tooltipPanelSelector = 'bq-tooltip >>> [part="panel"]';
+    // Ensure no element is initially focused (headless Linux can auto-focus the first tabbable element)
+    await page.click('body');
+    await page.waitForChanges();
 
     const initialPanel = await page.find(tooltipPanelSelector);
-    expect(initialPanel).toHaveAttribute('aria-hidden');
+    expect(initialPanel).toHaveAttribute('hidden');
 
-    const button = await page.find('bq-button');
+    const button = await page.find(buttonSelector);
     await button.hover();
 
     const hoveredPanel = await page.find(tooltipPanelSelector);
-    expect(hoveredPanel).toHaveAttribute('aria-hidden');
+    expect(hoveredPanel).toHaveAttribute('hidden');
 
     await button.click();
 
     const clickedPanel = await page.find(tooltipPanelSelector);
-    expect(clickedPanel).not.toHaveAttribute('aria-hidden');
+    expect(clickedPanel).not.toHaveAttribute('hidden');
+  });
+
+  it('should not be visible on click if defaultPrevented', async () => {
+    const page = await newE2EPage({ html });
+
+    (await page.find('bq-tooltip')).setProperty('displayOn', 'click');
+    await page.waitForChanges();
+
+    // Ensure no element is initially focused (headless Linux can auto-focus the first tabbable element)
+    await page.click('body');
+    await page.waitForChanges();
+
+    const initialPanel = await page.find(tooltipPanelSelector);
+    expect(initialPanel).toHaveAttribute('hidden');
+
+    await page.$eval('bq-tooltip', (el: HTMLElement) => {
+      el.addEventListener('bqClick', (e: Event) => e.preventDefault(), { once: true });
+    });
+
+    const button = await page.find(buttonSelector);
+    await button.click();
+
+    const clickedPanel = await page.find(tooltipPanelSelector);
+    expect(clickedPanel).toHaveAttribute('hidden');
   });
 
   it('should show in specified position', async () => {
-    const page = await newE2EPage({
-      html: `
-        <bq-tooltip placement="left">
-          Yuhu! A tooltip!
-          <bq-button slot="trigger"> Hover me! </bq-button>
-        </bq-tooltip>
-      `,
-    });
+    const page = await newE2EPage({ html });
 
     await page.waitForChanges();
 
-    const button = await page.find('bq-button');
+    const button = await page.find(buttonSelector);
     await button.hover();
 
-    const tooltipStyle = await computedStyle(page, 'bq-tooltip >>> [part="panel"]');
+    const tooltipStyle = await computedStyle(page, tooltipPanelSelector);
     const sign = tooltipStyle.left.slice(-1);
     // left position should be positive if tooltip is placed to the left
     expect(sign).not.toEqual('-');

--- a/packages/beeq/src/components/tooltip/bq-tooltip.tsx
+++ b/packages/beeq/src/components/tooltip/bq-tooltip.tsx
@@ -1,4 +1,5 @@
-import { Component, Element, h, Listen, Method, Prop, Watch } from '@stencil/core';
+import { Component, Element, Event, h, Listen, Method, Prop, Watch } from '@stencil/core';
+import type { EventEmitter } from '@stencil/core';
 
 import type { Placement } from '../../services/interfaces';
 import { FloatingUI } from '../../services/libraries';
@@ -122,9 +123,25 @@ export class BqTooltip {
       strategy: 'fixed',
     });
   }
+
   // Events section
   // Requires JSDocs for public API documentation
   // ==============================================
+
+  /** Emitted when the tooltip trigger is clicked */
+  @Event() bqClick: EventEmitter<HTMLBqTooltipElement>;
+
+  /** Emitted when the tooltip trigger is focused in */
+  @Event() bqFocusIn: EventEmitter<HTMLBqTooltipElement>;
+
+  /** Emitted when the tooltip trigger is focused out */
+  @Event() bqFocusOut: EventEmitter<HTMLBqTooltipElement>;
+
+  /** Emitted when the tooltip trigger is hovered in */
+  @Event() bqHoverIn: EventEmitter<HTMLBqTooltipElement>;
+
+  /** Emitted when the tooltip trigger is hovered out */
+  @Event() bqHoverOut: EventEmitter<HTMLBqTooltipElement>;
 
   // Component lifecycle events
   // Ordered by their natural call order
@@ -205,26 +222,46 @@ export class BqTooltip {
 
   private handleTriggerMouseOver = async () => {
     if (this.displayOn !== 'hover') return;
+
+    const hoverEvent = this.bqHoverIn.emit(this.el);
+    if (hoverEvent.defaultPrevented) return;
+
     await this.show();
   };
 
   private handleTriggerMouseLeave = async () => {
     if (this.displayOn !== 'hover') return;
+
+    const hoverEvent = this.bqHoverOut.emit(this.el);
+    if (hoverEvent.defaultPrevented) return;
+
     await this.hide();
   };
 
   private handleTriggerOnClick = async () => {
     if (this.displayOn !== 'click') return;
+
+    const clickEvent = this.bqClick.emit(this.el);
+    if (clickEvent.defaultPrevented) return;
+
     await (this.visible ? this.hide() : this.show());
   };
 
   private handleTriggerFocusin = async () => {
     if (this.visible || this.displayOn === 'click') return;
+
+    const focusEvent = this.bqFocusIn.emit(this.el);
+    if (focusEvent.defaultPrevented) return;
+
     await this.show();
   };
 
   private handleTriggerFocusout = async () => {
     if (!this.visible || this.displayOn === 'click') return;
+
+    const focusEvent = this.bqFocusOut.emit(this.el);
+    if (focusEvent.defaultPrevented) return;
+
     await this.hide();
   };
 

--- a/packages/beeq/src/components/tooltip/readme.md
+++ b/packages/beeq/src/components/tooltip/readme.md
@@ -22,6 +22,17 @@ The Tooltip component is a small pop-up box that appears when a user hovers over
 | `visible`       | `visible`        | Indicates whether or not the tooltip is visible when the component is first rendered, and when interacting with the trigger          | `boolean`                                                                                                                                                            | `false`   |
 
 
+## Events
+
+| Event        | Description                                     | Type                                |
+| ------------ | ----------------------------------------------- | ----------------------------------- |
+| `bqClick`    | Emitted when the tooltip trigger is clicked     | `CustomEvent<HTMLBqTooltipElement>` |
+| `bqFocusIn`  | Emitted when the tooltip trigger is focused in  | `CustomEvent<HTMLBqTooltipElement>` |
+| `bqFocusOut` | Emitted when the tooltip trigger is focused out | `CustomEvent<HTMLBqTooltipElement>` |
+| `bqHoverIn`  | Emitted when the tooltip trigger is hovered in  | `CustomEvent<HTMLBqTooltipElement>` |
+| `bqHoverOut` | Emitted when the tooltip trigger is hovered out | `CustomEvent<HTMLBqTooltipElement>` |
+
+
 ## Methods
 
 ### `hide() => Promise<void>`


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR adds event emissions for tooltip interactions and enhances end-to-end tests. This allows developers to respond to click, focus, and hover events on the tooltip trigger.

**Changes**
- Added `bqClick`, `bqFocusIn`, `bqFocusOut`, `bqHoverIn`, and `bqHoverOut` events to `bq-tooltip` component.
- Modified bq-tooltip.tsx to emit these events during corresponding trigger interactions.
- Enhanced bq-tooltip.e2e.ts to include tests for event prevention and interaction behaviors.

**Impact**
- Developers can now listen for and react to click, focus, and hover events on the tooltip trigger, providing greater control and customization options.
- The new events allow for more complex tooltip interactions and integration with other components.
- The end-to-end tests ensure the events are triggered correctly and that `preventDefault()` works as expected.

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

Fixes #1505 

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

https://github.com/user-attachments/assets/516988c6-8bb4-4fc0-900f-434e7d469491

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
