### PR TITLE
fix(Select): enhance value initialisation and ensure input element exists before updates

### DIFF
--- a/packages/beeq/src/components/select/bq-select.tsx
+++ b/packages/beeq/src/components/select/bq-select.tsx
@@ -416,7 +416,7 @@ export class BqSelect {
   // =======================================================
 
   private initMultipleValue = () => {
-    if (!this.multiple) return;
+    if (!this.multiple || !isDefined(this.value)) return;
 
     this.value = Array.isArray(this.value) ? this.value : Array.from(JSON.parse(String(this.value)));
   };
@@ -588,8 +588,10 @@ export class BqSelect {
     const checkedItem = options.find((item) => item.value === value);
     const displayValue = checkedItem ? this.getOptionLabel(checkedItem) : '';
 
-    inputElem.value = displayValue;
     this.displayValue = displayValue;
+    if (inputElem) {
+      inputElem.value = displayValue;
+    }
   };
 
   private getOptionLabel = (item: HTMLBqOptionElement) => {

--- a/packages/beeq/src/shared/utils/stringToArray.ts
+++ b/packages/beeq/src/shared/utils/stringToArray.ts
@@ -1,3 +1,4 @@
+import { isDefined } from './isDefined';
 import { isString } from './isString';
 
 /**
@@ -8,7 +9,7 @@ import { isString } from './isString';
  * @throws {Error} If the input string is not a valid JSON array
  */
 export const stringToArray = (value: string | string[]): string[] => {
-  if (isString(value)) {
+  if (isString(value) && isDefined(value)) {
     try {
       return Array.from(JSON.parse(String(value)));
     } catch (error) {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This change fixes an issue in BqSelect's multiple value initialisation and ensures correct input element updates. It also handles potential errors when parsing string values.

### Changes
- Modified `BqSelect.tsx` to conditionally initialise multiple values only when both `this.multiple` and `this.value` are defined.
- Added a null check for `inputElem` before updating its value in `BqSelect.tsx`.
- Modified `stringToArray.ts` to include a check to ensure the string value is defined before attempting to parse it.
- Added `isDefined` import to `stringToArray.ts`.

### Impact
- Fixes a bug where `BqSelect` might incorrectly initialise its value when `this.value` is not defined.
- Prevents potential errors when `inputElem` is null or undefined.
- Avoids errors when attempting to parse undefined string values into arrays.
- Improves the robustness of the `BqSelect` component.


## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

Fixes #1509 

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
