### PR TITLE
fix(RadioGroup): focus and blur emit only once

### DIFF
--- a/packages/beeq/src/components.d.ts
+++ b/packages/beeq/src/components.d.ts
@@ -4557,6 +4557,7 @@ declare global {
     };
     interface HTMLBqRadioGroupElementEventMap {
         "bqChange": { value: string; target: HTMLBqRadioElement };
+        "bqBlur": HTMLBqRadioElement;
     }
     /**
      * The radio group is a user interface component that groups radio buttons to enable a single selection within the group.
@@ -7463,6 +7464,10 @@ declare namespace LocalJSX {
           * Name of the HTML input form control. Submitted with the form as part of a name/value pair.
          */
         "name": string;
+        /**
+          * Handler to be called when the radio loses focus
+         */
+        "onBqBlur"?: (event: BqRadioGroupCustomEvent<HTMLBqRadioElement>) => void;
         /**
           * Handler to be called when the radio state changes
          */

--- a/packages/beeq/src/components/radio-group/readme.md
+++ b/packages/beeq/src/components/radio-group/readme.md
@@ -28,6 +28,7 @@ The radio group is a user interface component that groups radio buttons to enabl
 
 | Event      | Description                                       | Type                                                          |
 | ---------- | ------------------------------------------------- | ------------------------------------------------------------- |
+| `bqBlur`   | Handler to be called when the radio loses focus   | `CustomEvent<HTMLBqRadioElement>`                             |
 | `bqChange` | Handler to be called when the radio state changes | `CustomEvent<{ value: string; target: HTMLBqRadioElement; }>` |
 
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

Fixes #ISSUE_NUMBER

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [ ] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [ ] I have reviewed my code.
- [ ] I have tested the changes locally.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added unit tests and e2e tests (if applicable).
- [ ] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
