### PR TITLE
fix(Assets Path): use the `data-beeq` path value as it is, if provided

### DIFF
--- a/packages/beeq/src/shared/utils/assetsPath.ts
+++ b/packages/beeq/src/shared/utils/assetsPath.ts
@@ -24,16 +24,14 @@ export const setBasePath = (path: string): void => {
 export const getBasePath = (subpath: string = ''): string => {
   if (!beeqBasePath) {
     const configScript = findConfigScript();
-    const fallbackScript = configScript ? null : findFallbackScript();
+    // Get the path from the config script that uses the data-beeq attribute
+    const configPath = configScript?.getAttribute(DATA_BEEQ_ATTRIBUTE);
 
-    const script = configScript || fallbackScript;
-    if (script) {
-      const path = configScript ? script.getAttribute(DATA_BEEQ_ATTRIBUTE) : getScriptPath(script);
-      setBasePath(`${path}/${DEFAULT_SVG_PATH}`);
-    } else {
-      // Fallback: use the default path
-      setBasePath(`./${DEFAULT_SVG_PATH}`);
-    }
+    const fallbackScript = findFallbackScript();
+    // If no data-beeq attribute is found, use the script path
+    const fallbackPath = fallbackScript ? `${getScriptPath(fallbackScript)}/${DEFAULT_SVG_PATH}` : '';
+
+    setBasePath(configPath || fallbackPath);
   }
 
   // Return the base path without a trailing slash. If one exists, append the subpath separated by a slash.


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR allows the `data-beeq` path value attribute to be used directly and only adds `svg` at the end of the config path if the attribute is not set. The `data-beeq` can serve as an alternative for defining the SVG icons path in microfrontend applications, where child apps depend on the settings of the host.

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

N/A

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

<img width="2556" height="1412" alt="image" src="https://github.com/user-attachments/assets/719a2f94-1780-471c-984f-b21cb09cb117" />

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
