### PR TITLE
fix(Accordion): update medium size corner radius according to design spec

### DIFF
--- a/packages/beeq/src/components/accordion/__tests__/bq-accordion.e2e.ts
+++ b/packages/beeq/src/components/accordion/__tests__/bq-accordion.e2e.ts
@@ -117,7 +117,7 @@ describe('bq-accordion', () => {
 
     expect(smallHeaderStyle).toEqual({ borderRadius: '4px', padding: '8px 12px' });
     expect(smallPanelStyle).toEqual({ borderRadius: '0px 0px 4px 4px', padding: '12px' });
-    expect(mediumHeaderStyle).toEqual({ borderRadius: '4px', padding: '12px 16px' });
-    expect(mediumPanelStyle).toEqual({ borderRadius: '0px 0px 4px 4px', padding: '16px' });
+    expect(mediumHeaderStyle).toEqual({ borderRadius: '12px', padding: '12px 16px' });
+    expect(mediumPanelStyle).toEqual({ borderRadius: '0px 0px 12px 12px', padding: '16px' });
   });
 });

--- a/packages/beeq/src/components/accordion/scss/bq-accordion.variables.scss
+++ b/packages/beeq/src/components/accordion/scss/bq-accordion.variables.scss
@@ -66,7 +66,7 @@
   --bq-accordion--medium-padding-start: theme(spacing.m);
   --bq-accordion--medium-padding-end: theme(spacing.m);
   --bq-accordion--medium-gap: theme(spacing.m);
-  --bq-accordion--medium-radius: theme(borderRadius.xs);
+  --bq-accordion--medium-radius: theme(borderRadius.m);
 
   --bq-accordion--collapsed-border-color: theme(borderColor.transparent);
   --bq-accordion--collapsed-border-style: none;

--- a/packages/beeq/src/shared/test-utils/__tests__/setProperties.spec.ts
+++ b/packages/beeq/src/shared/test-utils/__tests__/setProperties.spec.ts
@@ -1,23 +1,16 @@
-import StencilCoreTesting, { type E2EPage } from '@stencil/core/testing';
+import type { E2EPage } from '@stencil/core/testing';
 
 import { setProperties } from '..';
 
-/**
- * !Note:
- * This test suite is skipped because we patched the @nxext/stencil package
- * in order to make it work with the latest version of Stencil: https://github.com/nxext/nx-extensions/issues/1086
- *
- * Applying the patch proposed in this PR: https://github.com/nxext/nx-extensions/pull/1088
- * seems to break the StencilCoreTesting and the following error is thrown:
- *
- * Cannot use spyOn on a primitive value; undefined given
- */
-describe.skip(setProperties.name, () => {
+describe(setProperties.name, () => {
+  let mockPage: E2EPage;
+
   beforeEach(() => {
-    jest.spyOn(StencilCoreTesting, 'newE2EPage').mockImplementationOnce(() =>
+    mockPage = {
       // biome-ignore lint/style/useNamingConvention: Mocking E2EPage interface properties
-      Promise.resolve({ $eval: jest.fn(), waitForChanges: () => Promise.resolve() } as unknown as E2EPage),
-    );
+      $eval: jest.fn(),
+      waitForChanges: jest.fn().mockResolvedValue(undefined),
+    } as unknown as E2EPage;
   });
 
   afterEach(() => {
@@ -27,13 +20,11 @@ describe.skip(setProperties.name, () => {
   it('should set attributes', async () => {
     const element = {};
 
-    const page = await StencilCoreTesting.newE2EPage();
-
-    (page.$eval as jest.Mock).mockImplementationOnce(
+    (mockPage.$eval as jest.Mock).mockImplementationOnce(
       (_: unknown, fn: (...args: unknown[]) => unknown, ...args: unknown[]) => fn(element, ...args),
     );
 
-    await setProperties(page, 'a', { href: 'test-href', id: 'test-id' });
+    await setProperties(mockPage, 'a', { href: 'test-href', id: 'test-id' });
 
     expect(element).toEqual({ href: 'test-href', id: 'test-id' });
   });
@@ -41,13 +32,11 @@ describe.skip(setProperties.name, () => {
   it('should return attributes', async () => {
     const element = {};
 
-    const page = await StencilCoreTesting.newE2EPage();
-
-    (page.$eval as jest.Mock).mockImplementation(
+    (mockPage.$eval as jest.Mock).mockImplementation(
       (_: unknown, fn: (...args: unknown[]) => unknown, ...args: unknown[]) => fn(element, ...args),
     );
 
-    expect(await setProperties(page, 'div', { title: 'test-title', id: 'test-id' })).toEqual({
+    expect(await setProperties(mockPage, 'div', { title: 'test-title', id: 'test-id' })).toEqual({
       title: 'test-title',
       id: 'test-id',
     });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

The corner radius for the medium size accordion header and panel has been updated. This change ensures the component adheres to the latest design specifications.

### Changes
- Updated the `--bq-accordion--medium-radius` CSS variable in `bq-accordion.variables.scss` from `theme(borderRadius.xs)` to `theme(borderRadius.m)`.
- Modified the expected `borderRadius` values in `bq-accordion.e2e.ts` for medium header and panel styles to reflect the new radius.
- Removed skip from `setProperties.spec.ts` and adjusted mock implementation to align with testing requirements.

### Impact
- The visual appearance of the medium-sized accordion will change, with a larger corner radius.
- The change directly affects the `bq-accordion` component.
- E2E tests for the `bq-accordion` component have been updated to validate the correct styling.

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

Fixes #1535 

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

<img width="3624" height="1500" alt="CleanShot 2025-10-10 at 23 58 02@2x" src="https://github.com/user-attachments/assets/d1890e0d-b123-404b-bb68-e56f2b5d77eb" />


## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
