### PR TITLE
fix(Select): search filter matches label/value, case-insensitive

### DIFF
--- a/packages/beeq/src/components/select/bq-select.tsx
+++ b/packages/beeq/src/components/select/bq-select.tsx
@@ -477,18 +477,24 @@ export class BqSelect {
 
     this.debounceQuery?.cancel();
 
-    if (!isDefined(value)) {
+    const trimmedValue = value?.trim();
+    if (!isDefined(trimmedValue)) {
       this.clear();
-    } else {
-      this.debounceQuery = debounce(() => {
-        this.options.forEach((item: HTMLBqOptionElement) => {
-          const itemLabel = this.getOptionLabel(item).toLowerCase();
-          item.hidden = !itemLabel.includes(value);
-        });
-      }, this.debounceTime);
-
-      this.debounceQuery();
+      return;
     }
+
+    this.debounceQuery = debounce(() => {
+      this.options.forEach((item: HTMLBqOptionElement) => {
+        const optionLabel = this.getOptionLabel(item)?.toLowerCase();
+        const optionValue = item.value?.toLowerCase();
+        // Show item if EITHER label OR value matches
+        const matches =
+          optionLabel.includes(trimmedValue.toLowerCase()) || optionValue.includes(trimmedValue.toLowerCase());
+        item.hidden = !matches;
+      });
+    }, this.debounceTime);
+
+    this.debounceQuery();
 
     // The panel will close once a selection is made
     // so we need to make sure it's open when the user is typing and the query is not empty
@@ -574,7 +580,7 @@ export class BqSelect {
       if (multiple && Array.isArray(value)) {
         option.selected = value.includes(option.value);
       } else {
-        option.selected = option.value.toLowerCase() === lowerCaseValue;
+        option.selected = option.value?.toLowerCase() === lowerCaseValue;
       }
     });
   };


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

The select component's search filter is improved to match options based on either the label or the value, regardless of case. The input value is also trimmed.

### Changes
- Input `value` is now trimmed using `value?.trim()` before processing.
- The search logic now checks if either the `optionLabel` or `optionValue` includes the (trimmed and lowercased) input `value`.

### Impact
- **Behavioural changes:** The select component's search now matches options if either the label *or* the value contains the search term (case-insensitive). Empty input clears the selection.
- **Dependencies affected:** None.
- No breaking changes.
- Minimal performance implications. The added `trim()` and lowercasing operations are unlikely to cause a significant performance decrease.

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

Fixes #1534 

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

Uploading CleanShot 2025-10-13 at 08.43.10.mp4…

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
