### PR TITLE
fix(Spinner): correct spelling of 'below' in types value

### DIFF
--- a/packages/beeq/src/components/spinner/__tests__/bq-spinner.e2e.ts
+++ b/packages/beeq/src/components/spinner/__tests__/bq-spinner.e2e.ts
@@ -54,8 +54,8 @@ describe('bq-spinner', () => {
     const shadowDOMElem = 'bq-spinner >>> .bq-spinner';
     expect(await page.find(shadowDOMElem)).toHaveClass('text-above');
 
-    await setProperties(page, 'bq-spinner', { textPosition: 'bellow' });
-    expect(await page.find(shadowDOMElem)).toHaveClass('text-bellow');
+    await setProperties(page, 'bq-spinner', { textPosition: 'below' });
+    expect(await page.find(shadowDOMElem)).toHaveClass('text-below');
 
     await setProperties(page, 'bq-spinner', { textPosition: 'left' });
     expect(await page.find(shadowDOMElem)).toHaveClass('text-left');
@@ -95,7 +95,7 @@ describe('bq-spinner', () => {
     const console: jest.Mock<void, string[]> = jest.fn();
     page.on('console', (message) => console(message.type(), message.text()));
 
-    // @ts-expect-error we're testing that component is handling invalid properties
+    // @ts-expect-error we're testing that the component is handling invalid properties
     expect(await setProperties(page, 'bq-spinner', { size: 'invalid', textPosition: 'invalid' })).toEqual({
       size: 'medium',
       textPosition: 'none',
@@ -108,16 +108,16 @@ describe('bq-spinner', () => {
     );
     expect(console).toHaveBeenCalledWith(
       'warn',
-      '[BQ-SPINNER] Please notice that "textPosition" should be one of none|left|right|above|bellow',
+      '[BQ-SPINNER] Please notice that "textPosition" should be one of none|left|right|above|below',
     );
   });
 
   it('should respect design style', async () => {
     const page = await newE2EPage({
       html: `
-        <bq-spinner size="small" text-position="bellow"></bq-spinner>
-        <bq-spinner size="medium" text-position="bellow"></bq-spinner>
-        <bq-spinner size="large" text-position="bellow"></bq-spinner>
+        <bq-spinner size="small" text-position="below"></bq-spinner>
+        <bq-spinner size="medium" text-position="below"></bq-spinner>
+        <bq-spinner size="large" text-position="below"></bq-spinner>
       `,
     });
 

--- a/packages/beeq/src/components/spinner/bq-spinner.types.ts
+++ b/packages/beeq/src/components/spinner/bq-spinner.types.ts
@@ -1,4 +1,4 @@
-export const SPINNER_TEXT_POSITION = ['none', 'left', 'right', 'above', 'bellow'] as const;
+export const SPINNER_TEXT_POSITION = ['none', 'left', 'right', 'above', 'below'] as const;
 export const SPINNER_SIZE = ['small', 'medium', 'large'] as const;
 export type TSpinnerTextPosition = (typeof SPINNER_TEXT_POSITION)[number];
 export type TSpinnerSize = (typeof SPINNER_SIZE)[number];

--- a/packages/beeq/src/components/spinner/readme.md
+++ b/packages/beeq/src/components/spinner/readme.md
@@ -11,11 +11,11 @@ Spinners are designed for users to display data loading.
 
 ## Properties
 
-| Property       | Attribute       | Description                                                   | Type                                                 | Default    |
-| -------------- | --------------- | ------------------------------------------------------------- | ---------------------------------------------------- | ---------- |
-| `animation`    | `animation`     | If `false`, the animation on the icon element will be stopped | `boolean`                                            | `true`     |
-| `size`         | `size`          | It defines the size of the icon element displayed             | `"large" \| "medium" \| "small"`                     | `'medium'` |
-| `textPosition` | `text-position` | It defines the position of the label text                     | `"above" \| "bellow" \| "left" \| "none" \| "right"` | `'none'`   |
+| Property       | Attribute       | Description                                                   | Type                                                | Default    |
+| -------------- | --------------- | ------------------------------------------------------------- | --------------------------------------------------- | ---------- |
+| `animation`    | `animation`     | If `false`, the animation on the icon element will be stopped | `boolean`                                           | `true`     |
+| `size`         | `size`          | It defines the size of the icon element displayed             | `"large" \| "medium" \| "small"`                    | `'medium'` |
+| `textPosition` | `text-position` | It defines the position of the label text                     | `"above" \| "below" \| "left" \| "none" \| "right"` | `'none'`   |
 
 
 ## Slots

--- a/packages/beeq/src/components/spinner/scss/bq-spinner.scss
+++ b/packages/beeq/src/components/spinner/scss/bq-spinner.scss
@@ -63,7 +63,7 @@
 }
 
 .text-above,
-.text-bellow {
+.text-below {
   @apply flex-col items-center;
 
   &.has-text {
@@ -82,7 +82,7 @@
   }
 }
 
-.text-bellow {
+.text-below {
   .bq-spinner--loader,
   .bq-spinner--icon {
     @apply order-1;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

Fix: Corrected spelling of "below" in spinner component.

This PR corrects the spelling of "below" from "bellow" throughout the spinner component's code, types, documentation, and tests. This ensures consistency and correctness in the component's API and usage.

### Changes
- Renamed `bellow` to `below` in `SPINNER_TEXT_POSITION` array within `bq-spinner.types.ts`.
- Updated `textPosition` property options in `readme.md` to reflect the correct spelling.
- Corrected class names and property values in `bq-spinner.e2e.ts` to use `below` instead of `bellow`.
- Changed `.text-bellow` to `.text-below` in `bq-spinner.scss`.

### Impact
- Corrects a typographical error, improving code readability and API accuracy.
- No breaking changes or performance implications are expected.
- Updates documentation and tests to align with the corrected spelling.

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

Fixes #1541

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
