### PR TITLE
fix(Side Menu): slotted button icons in the footer are not visible on hover for brand/inverse variants

### DIFF
--- a/packages/beeq/src/components/button/scss/bq-button.scss
+++ b/packages/beeq/src/components/button/scss/bq-button.scss
@@ -14,6 +14,13 @@
     @apply disabled:cursor-not-allowed disabled:opacity-60;
     // `FOCUS` state
     @apply focus-visible:focus;
+    // Internal workaround to allow overriding icon color via CSS variables from slotted bq-buttons
+    // @see: packages/beeq/src/components/side-menu/scss/bq-side-menu.scss
+    @apply [&_::slotted(bq-icon)]:[--bq-icon--color:_var(--bq-button--icon-color,_currentColor)];
+    // On hover, update the icon color if custom property is defined
+    &:hover:not(:disabled) ::slotted(bq-icon) {
+      --bq-icon--color: var(--bq-button-hover--icon-color, var(--bq-button--icon-color, currentColor));
+    }
   }
 }
 

--- a/packages/beeq/src/components/side-menu/_storybook/bq-side-menu.stories.tsx
+++ b/packages/beeq/src/components/side-menu/_storybook/bq-side-menu.stories.tsx
@@ -128,7 +128,7 @@ export const WithFooter: Story = {
   render: Template,
   args: {
     footerContent: `
-      <div class="" slot="footer">
+      <div slot="footer">
         <bq-button appearance="text" slot="footer">
           <bq-icon name="bell"></bq-icon>
         </bq-button>

--- a/packages/beeq/src/components/side-menu/scss/bq-side-menu.scss
+++ b/packages/beeq/src/components/side-menu/scss/bq-side-menu.scss
@@ -62,7 +62,8 @@
 
   .bq-side-menu--footer ::slotted([slot='footer']) {
     --bq-ui--secondary: theme(colors.transparent);
-    --bq-text--primary: theme(textColor.inverse);
+    --bq-button--icon-color: theme(textColor.alt);
+    --bq-button-hover--icon-color: theme(textColor.primary);
   }
 }
 
@@ -82,6 +83,7 @@
 
   .bq-side-menu--footer ::slotted([slot='footer']) {
     --bq-ui--secondary: theme(colors.transparent);
-    --bq-text--primary: theme(textColor.inverse);
+    --bq-button--icon-color: theme(textColor.inverse);
+    --bq-button-hover--icon-color: theme(textColor.primary);
   }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR introduces CSS variable overrides to allow `bq-button` icons slotted in side menu footers to display appropriate colours, including hover states. Addresses visibility issues for brand/inverse variants by updating SCSS in both button and side menu components.

### Changes
- Added CSS variables `--bq-button--icon-color` and `--bq-button-hover--icon-color` to style icon colours in side menu footers (`bq-side-menu.scss`)
- Updated `bq-button.scss` to use these variables for slotted `bq-icon` elements and handle hover states
- Minor storybook adjustment to remove unnecessary class in footer slot markup

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

Fixes #1542 

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

https://github.com/user-attachments/assets/b843286b-fc08-4800-b0f4-aa011305c701

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
