### PR TITLE
docs: migrate docs (option, option-group, option-list) to Mintlify and adding Options navigation group to docs json

### DIFF
--- a/apps/beeq-docs/components/option-group.mdx
+++ b/apps/beeq-docs/components/option-group.mdx
@@ -176,7 +176,7 @@ Two groups of options inside a single `bq-option-list`. Each group carries a `he
     </bq-option-list>
     ```
 
-    ```jsx React icon="react"
+    ```tsx React icon="react"
     import { BqIcon, BqOption, BqOptionGroup, BqOptionList } from "@beeq/react";
 
     <BqOptionList>
@@ -349,7 +349,7 @@ Add a `bq-icon` in the `header-prefix` slot to give the group label a visual cat
     </bq-option-list>
     ```
 
-    ```jsx React icon="react"
+    ```tsx React icon="react"
     import { BqIcon, BqOption, BqOptionGroup, BqOptionList } from "@beeq/react";
 
     <BqOptionList>
@@ -494,7 +494,7 @@ Use the `header-suffix` slot to place a count badge, status chip, or secondary i
     </bq-option-list>
     ```
 
-    ```jsx React icon="react"
+    ```tsx React icon="react"
     import { BqBadge, BqIcon, BqOption, BqOptionGroup, BqOptionList } from "@beeq/react";
 
     <BqOptionList>

--- a/apps/beeq-docs/components/option-group.mdx
+++ b/apps/beeq-docs/components/option-group.mdx
@@ -213,41 +213,50 @@ Two groups of options inside a single `bq-option-list`. Each group carries a `he
     </BqOptionList>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqIcon, BqOption, BqOptionGroup, BqOptionList } from "@beeq/angular/standalone" -->
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqIcon, BqOption, BqOptionGroup, BqOptionList } from "@beeq/angular/standalone";
 
-    <bq-option-list>
-      <bq-option-group>
-        <span slot="header-label">Sport</span>
-        <bq-option value="running">
-          <bq-icon slot="prefix" name="sneaker-move"></bq-icon>
-          <span>Running</span>
-        </bq-option>
-        <bq-option value="hiking">
-          <bq-icon slot="prefix" name="boot"></bq-icon>
-          <span>Hiking</span>
-        </bq-option>
-        <bq-option value="biking">
-          <bq-icon slot="prefix" name="person-simple-bike"></bq-icon>
-          <span>Biking</span>
-        </bq-option>
-      </bq-option-group>
-      <bq-option-group>
-        <span slot="header-label">Food</span>
-        <bq-option value="pizza">
-          <bq-icon slot="prefix" name="pizza"></bq-icon>
-          <span>Pizza</span>
-        </bq-option>
-        <bq-option value="hamburger">
-          <bq-icon slot="prefix" name="hamburger"></bq-icon>
-          <span>Hamburger</span>
-        </bq-option>
-        <bq-option value="cookie">
-          <bq-icon slot="prefix" name="cookie"></bq-icon>
-          <span>Cookie</span>
-        </bq-option>
-      </bq-option-group>
-    </bq-option-list>
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqIcon, BqOption, BqOptionGroup, BqOptionList],
+      template: `
+        <bq-option-list>
+          <bq-option-group>
+            <span slot="header-label">Sport</span>
+            <bq-option value="running">
+              <bq-icon slot="prefix" name="sneaker-move"></bq-icon>
+              <span>Running</span>
+            </bq-option>
+            <bq-option value="hiking">
+              <bq-icon slot="prefix" name="boot"></bq-icon>
+              <span>Hiking</span>
+            </bq-option>
+            <bq-option value="biking">
+              <bq-icon slot="prefix" name="person-simple-bike"></bq-icon>
+              <span>Biking</span>
+            </bq-option>
+          </bq-option-group>
+          <bq-option-group>
+            <span slot="header-label">Food</span>
+            <bq-option value="pizza">
+              <bq-icon slot="prefix" name="pizza"></bq-icon>
+              <span>Pizza</span>
+            </bq-option>
+            <bq-option value="hamburger">
+              <bq-icon slot="prefix" name="hamburger"></bq-icon>
+              <span>Hamburger</span>
+            </bq-option>
+            <bq-option value="cookie">
+              <bq-icon slot="prefix" name="cookie"></bq-icon>
+              <span>Cookie</span>
+            </bq-option>
+          </bq-option-group>
+        </bq-option-list>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -370,23 +379,34 @@ Add a `bq-icon` in the `header-prefix` slot to give the group label a visual cat
     </BqOptionList>
     ```
 
-    ```html Angular icon="angular"
-    <bq-option-list>
-      <bq-option-group>
-        <bq-icon slot="header-prefix" name="sneaker-move"></bq-icon>
-        <span slot="header-label">Sport</span>
-        <bq-option value="running"><span>Running</span></bq-option>
-        <bq-option value="hiking"><span>Hiking</span></bq-option>
-        <bq-option value="biking"><span>Biking</span></bq-option>
-      </bq-option-group>
-      <bq-option-group>
-        <bq-icon slot="header-prefix" name="pizza"></bq-icon>
-        <span slot="header-label">Food</span>
-        <bq-option value="pizza"><span>Pizza</span></bq-option>
-        <bq-option value="hamburger"><span>Hamburger</span></bq-option>
-        <bq-option value="cookie"><span>Cookie</span></bq-option>
-      </bq-option-group>
-    </bq-option-list>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqIcon, BqOption, BqOptionGroup, BqOptionList } from "@beeq/angular/standalone";
+
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqIcon, BqOption, BqOptionGroup, BqOptionList],
+      template: `
+        <bq-option-list>
+          <bq-option-group>
+            <bq-icon slot="header-prefix" name="sneaker-move"></bq-icon>
+            <span slot="header-label">Sport</span>
+            <bq-option value="running"><span>Running</span></bq-option>
+            <bq-option value="hiking"><span>Hiking</span></bq-option>
+            <bq-option value="biking"><span>Biking</span></bq-option>
+          </bq-option-group>
+          <bq-option-group>
+            <bq-icon slot="header-prefix" name="pizza"></bq-icon>
+            <span slot="header-label">Food</span>
+            <bq-option value="pizza"><span>Pizza</span></bq-option>
+            <bq-option value="hamburger"><span>Hamburger</span></bq-option>
+            <bq-option value="cookie"><span>Cookie</span></bq-option>
+          </bq-option-group>
+        </bq-option-list>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -533,41 +553,52 @@ Use the `header-suffix` slot to place a count badge, status chip, or secondary i
     </BqOptionList>
     ```
 
-    ```html Angular icon="angular"
-    <bq-option-list>
-      <bq-option-group>
-        <span slot="header-label">Sport</span>
-        <bq-badge slot="header-suffix" type="info">3</bq-badge>
-        <bq-option value="running">
-          <bq-icon slot="prefix" name="sneaker-move"></bq-icon>
-          <span>Running</span>
-        </bq-option>
-        <bq-option value="hiking">
-          <bq-icon slot="prefix" name="boot"></bq-icon>
-          <span>Hiking</span>
-        </bq-option>
-        <bq-option value="biking">
-          <bq-icon slot="prefix" name="person-simple-bike"></bq-icon>
-          <span>Biking</span>
-        </bq-option>
-      </bq-option-group>
-      <bq-option-group>
-        <span slot="header-label">Food</span>
-        <bq-badge slot="header-suffix" type="info">3</bq-badge>
-        <bq-option value="pizza">
-          <bq-icon slot="prefix" name="pizza"></bq-icon>
-          <span>Pizza</span>
-        </bq-option>
-        <bq-option value="hamburger">
-          <bq-icon slot="prefix" name="hamburger"></bq-icon>
-          <span>Hamburger</span>
-        </bq-option>
-        <bq-option value="cookie">
-          <bq-icon slot="prefix" name="cookie"></bq-icon>
-          <span>Cookie</span>
-        </bq-option>
-      </bq-option-group>
-    </bq-option-list>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqBadge, BqIcon, BqOption, BqOptionGroup, BqOptionList } from "@beeq/angular/standalone";
+
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqBadge, BqIcon, BqOption, BqOptionGroup, BqOptionList],
+      template: `
+        <bq-option-list>
+          <bq-option-group>
+            <span slot="header-label">Sport</span>
+            <bq-badge slot="header-suffix" type="info">3</bq-badge>
+            <bq-option value="running">
+              <bq-icon slot="prefix" name="sneaker-move"></bq-icon>
+              <span>Running</span>
+            </bq-option>
+            <bq-option value="hiking">
+              <bq-icon slot="prefix" name="boot"></bq-icon>
+              <span>Hiking</span>
+            </bq-option>
+            <bq-option value="biking">
+              <bq-icon slot="prefix" name="person-simple-bike"></bq-icon>
+              <span>Biking</span>
+            </bq-option>
+          </bq-option-group>
+          <bq-option-group>
+            <span slot="header-label">Food</span>
+            <bq-badge slot="header-suffix" type="info">3</bq-badge>
+            <bq-option value="pizza">
+              <bq-icon slot="prefix" name="pizza"></bq-icon>
+              <span>Pizza</span>
+            </bq-option>
+            <bq-option value="hamburger">
+              <bq-icon slot="prefix" name="hamburger"></bq-icon>
+              <span>Hamburger</span>
+            </bq-option>
+            <bq-option value="cookie">
+              <bq-icon slot="prefix" name="cookie"></bq-icon>
+              <span>Cookie</span>
+            </bq-option>
+          </bq-option-group>
+        </bq-option-list>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/option-group.mdx
+++ b/apps/beeq-docs/components/option-group.mdx
@@ -1,0 +1,749 @@
+---
+title: Option Group
+description: Option Group is a labelled container that organizes related options into named sections inside a list or dropdown.
+---
+
+import { CodeLivePreview } from "/snippets/CodeLivePreview.jsx";
+
+<Frame className="px-4 py-4" caption="Option Group component overview">
+  <img className="block dark:hidden" src="/components/images/option-group/option-group-overview-light.svg" alt="BEEQ Option Group component overview" />
+  <img className="hidden dark:block" src="/components/images/option-group/option-group-overview-dark.svg" alt="BEEQ Option Group component overview" />
+</Frame>
+
+`bq-option-group` wraps a set of `bq-option` items under a shared label, creating a named section within a longer list. Use it to reduce cognitive load when a menu contains many choices that naturally fall into categories.
+
+<Note>
+  `bq-option-group` must be placed inside a `bq-option-list`. The group renders a `role="group"` container, which assistive technologies expect to find within a `role="listbox"` ancestor — provided by `bq-option-list`.
+</Note>
+
+## When to use
+
+<CardGroup cols={2}>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="thumbs-up" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Use option groups when
+    </span>
+
+    * A list contains many options that share a common category — grouping reduces scanning effort
+    * The menu mixes conceptually different types of choices that would be confusing in a flat list
+    * You want to communicate hierarchy or context within a dropdown or select component
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="thumbs-down" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Do not use option groups when
+    </span>
+
+    * The list has only a handful of options — adding group headers adds visual weight without benefit
+    * All options belong to the same category — a single unlabelled list communicates this more cleanly
+    * The groups would each contain only one option, which implies the grouping is artificial
+  </Card>
+</CardGroup>
+
+## Option Group patterns
+
+<CardGroup cols={3}>
+  <Card title="Category grouping">
+    Group options by domain category — for example, splitting a sports/food selection into named sections. The label names the category; the options beneath it list the choices.
+  </Card>
+  <Card title="Role or permission tier">
+    In access-control menus, group options by permission level (Admin, Editor, Viewer) so users can see which actions belong to which role at a glance.
+  </Card>
+  <Card title="Recent vs. all">
+    Separate a "Recently used" group from a full list of options. Users who revisit common choices find them faster without searching the entire list.
+  </Card>
+</CardGroup>
+
+## Anatomy
+
+<Frame className="px-4 py-4" caption="Option Group component anatomy">
+  <img className="block dark:hidden" src="/components/images/option-group/option-group-anatomy-light.svg" alt="BEEQ Option Group component anatomy" />
+  <img className="hidden dark:block" src="/components/images/option-group/option-group-anatomy-dark.svg" alt="BEEQ Option Group component anatomy" />
+</Frame>
+
+Each option group has a header row containing an optional prefix, the required label text, and an optional suffix. Below the header sits the container holding the slotted `bq-option` items.
+
+| Part | Element | Description |
+|---|---|---|
+| **1** | Prefix | Optional slot rendered before the group label — typically a `bq-icon` |
+| **2** | Label | The text that names the group, placed in the `header-label` slot |
+| **3** | Suffix | Optional slot rendered after the group label — typically a `bq-icon` or badge |
+| **4** | Group container | The `div` that holds all slotted option items |
+
+## Design guidelines
+
+### Label clarity
+
+The group label exists to help users understand why these options are grouped together. Write it as a short noun phrase — a category name, not an instruction.
+
+<Steps>
+  <Step title="Name the category">
+    Use a noun or short noun phrase: "Sport", "Food", "Recent", "Admin actions". The label names the group, not the action.
+  </Step>
+  <Step title="Keep it short">
+    The label is displayed in a constrained space and truncates on overflow. Aim for one to three words.
+  </Step>
+  <Step title="Use consistent casing">
+    Apply title case or sentence case consistently across all groups in the same list. Mixing styles creates visual noise.
+  </Step>
+</Steps>
+
+### Nesting and depth
+
+<Note>
+  Option groups are flat by design — they do not support nesting. Each group sits at the same level inside `bq-option-list`. If you find yourself needing nested groups, reconsider the information architecture: a deeper hierarchy usually belongs in a separate navigation component rather than a dropdown.
+</Note>
+
+### Prefix and suffix icons
+
+Use the `header-prefix` slot to place a category icon next to the label. This helps users identify the group at a glance in long lists. Use the `header-suffix` slot sparingly — a count badge or status indicator can add value, but too many suffix elements make the header feel cluttered.
+
+## Usage
+
+### Basic grouping
+
+Two groups of options inside a single `bq-option-list`. Each group carries a `header-label` that names the category.
+
+<CodeLivePreview code={`
+  <bq-option-list>
+    <bq-option-group>
+      <span slot="header-label">Sport</span>
+      <bq-option value="running">
+        <bq-icon slot="prefix" name="sneaker-move"></bq-icon>
+        <span>Running</span>
+      </bq-option>
+      <bq-option value="hiking">
+        <bq-icon slot="prefix" name="boot"></bq-icon>
+        <span>Hiking</span>
+      </bq-option>
+      <bq-option value="biking">
+        <bq-icon slot="prefix" name="person-simple-bike"></bq-icon>
+        <span>Biking</span>
+      </bq-option>
+    </bq-option-group>
+    <bq-option-group>
+      <span slot="header-label">Food</span>
+      <bq-option value="pizza">
+        <bq-icon slot="prefix" name="pizza"></bq-icon>
+        <span>Pizza</span>
+      </bq-option>
+      <bq-option value="hamburger">
+        <bq-icon slot="prefix" name="hamburger"></bq-icon>
+        <span>Hamburger</span>
+      </bq-option>
+      <bq-option value="cookie">
+        <bq-icon slot="prefix" name="cookie"></bq-icon>
+        <span>Cookie</span>
+      </bq-option>
+    </bq-option-group>
+  </bq-option-list>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-option-list>
+      <bq-option-group>
+        <span slot="header-label">Sport</span>
+        <bq-option value="running">
+          <bq-icon slot="prefix" name="sneaker-move"></bq-icon>
+          <span>Running</span>
+        </bq-option>
+        <bq-option value="hiking">
+          <bq-icon slot="prefix" name="boot"></bq-icon>
+          <span>Hiking</span>
+        </bq-option>
+        <bq-option value="biking">
+          <bq-icon slot="prefix" name="person-simple-bike"></bq-icon>
+          <span>Biking</span>
+        </bq-option>
+      </bq-option-group>
+      <bq-option-group>
+        <span slot="header-label">Food</span>
+        <bq-option value="pizza">
+          <bq-icon slot="prefix" name="pizza"></bq-icon>
+          <span>Pizza</span>
+        </bq-option>
+        <bq-option value="hamburger">
+          <bq-icon slot="prefix" name="hamburger"></bq-icon>
+          <span>Hamburger</span>
+        </bq-option>
+        <bq-option value="cookie">
+          <bq-icon slot="prefix" name="cookie"></bq-icon>
+          <span>Cookie</span>
+        </bq-option>
+      </bq-option-group>
+    </bq-option-list>
+    ```
+
+    ```jsx React icon="react"
+    import { BqIcon, BqOption, BqOptionGroup, BqOptionList } from "@beeq/react";
+
+    <BqOptionList>
+      <BqOptionGroup>
+        <span slot="header-label">Sport</span>
+        <BqOption value="running">
+          <BqIcon slot="prefix" name="sneaker-move" />
+          <span>Running</span>
+        </BqOption>
+        <BqOption value="hiking">
+          <BqIcon slot="prefix" name="boot" />
+          <span>Hiking</span>
+        </BqOption>
+        <BqOption value="biking">
+          <BqIcon slot="prefix" name="person-simple-bike" />
+          <span>Biking</span>
+        </BqOption>
+      </BqOptionGroup>
+      <BqOptionGroup>
+        <span slot="header-label">Food</span>
+        <BqOption value="pizza">
+          <BqIcon slot="prefix" name="pizza" />
+          <span>Pizza</span>
+        </BqOption>
+        <BqOption value="hamburger">
+          <BqIcon slot="prefix" name="hamburger" />
+          <span>Hamburger</span>
+        </BqOption>
+        <BqOption value="cookie">
+          <BqIcon slot="prefix" name="cookie" />
+          <span>Cookie</span>
+        </BqOption>
+      </BqOptionGroup>
+    </BqOptionList>
+    ```
+
+    ```html Angular icon="angular"
+    <!-- Standalone: import { BqIcon, BqOption, BqOptionGroup, BqOptionList } from "@beeq/angular/standalone" -->
+
+    <bq-option-list>
+      <bq-option-group>
+        <span slot="header-label">Sport</span>
+        <bq-option value="running">
+          <bq-icon slot="prefix" name="sneaker-move"></bq-icon>
+          <span>Running</span>
+        </bq-option>
+        <bq-option value="hiking">
+          <bq-icon slot="prefix" name="boot"></bq-icon>
+          <span>Hiking</span>
+        </bq-option>
+        <bq-option value="biking">
+          <bq-icon slot="prefix" name="person-simple-bike"></bq-icon>
+          <span>Biking</span>
+        </bq-option>
+      </bq-option-group>
+      <bq-option-group>
+        <span slot="header-label">Food</span>
+        <bq-option value="pizza">
+          <bq-icon slot="prefix" name="pizza"></bq-icon>
+          <span>Pizza</span>
+        </bq-option>
+        <bq-option value="hamburger">
+          <bq-icon slot="prefix" name="hamburger"></bq-icon>
+          <span>Hamburger</span>
+        </bq-option>
+        <bq-option value="cookie">
+          <bq-icon slot="prefix" name="cookie"></bq-icon>
+          <span>Cookie</span>
+        </bq-option>
+      </bq-option-group>
+    </bq-option-list>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqIcon, BqOption, BqOptionGroup, BqOptionList } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqOptionList>
+        <BqOptionGroup>
+          <span slot="header-label">Sport</span>
+          <BqOption value="running">
+            <BqIcon slot="prefix" name="sneaker-move" />
+            <span>Running</span>
+          </BqOption>
+          <BqOption value="hiking">
+            <BqIcon slot="prefix" name="boot" />
+            <span>Hiking</span>
+          </BqOption>
+          <BqOption value="biking">
+            <BqIcon slot="prefix" name="person-simple-bike" />
+            <span>Biking</span>
+          </BqOption>
+        </BqOptionGroup>
+        <BqOptionGroup>
+          <span slot="header-label">Food</span>
+          <BqOption value="pizza">
+            <BqIcon slot="prefix" name="pizza" />
+            <span>Pizza</span>
+          </BqOption>
+          <BqOption value="hamburger">
+            <BqIcon slot="prefix" name="hamburger" />
+            <span>Hamburger</span>
+          </BqOption>
+          <BqOption value="cookie">
+            <BqIcon slot="prefix" name="cookie" />
+            <span>Cookie</span>
+          </BqOption>
+        </BqOptionGroup>
+      </BqOptionList>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+## Options
+
+### With prefix icon on the group header
+
+Add a `bq-icon` in the `header-prefix` slot to give the group label a visual category marker. This is most useful when the list is dense and users need to scan groups without reading every label word-for-word.
+
+<CodeLivePreview code={`
+  <bq-option-list>
+    <bq-option-group>
+      <bq-icon slot="header-prefix" name="sneaker-move"></bq-icon>
+      <span slot="header-label">Sport</span>
+      <bq-option value="running">
+        <span>Running</span>
+      </bq-option>
+      <bq-option value="hiking">
+        <span>Hiking</span>
+      </bq-option>
+      <bq-option value="biking">
+        <span>Biking</span>
+      </bq-option>
+    </bq-option-group>
+    <bq-option-group>
+      <bq-icon slot="header-prefix" name="pizza"></bq-icon>
+      <span slot="header-label">Food</span>
+      <bq-option value="pizza">
+        <span>Pizza</span>
+      </bq-option>
+      <bq-option value="hamburger">
+        <span>Hamburger</span>
+      </bq-option>
+      <bq-option value="cookie">
+        <span>Cookie</span>
+      </bq-option>
+    </bq-option-group>
+  </bq-option-list>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-option-list>
+      <bq-option-group>
+        <bq-icon slot="header-prefix" name="sneaker-move"></bq-icon>
+        <span slot="header-label">Sport</span>
+        <bq-option value="running"><span>Running</span></bq-option>
+        <bq-option value="hiking"><span>Hiking</span></bq-option>
+        <bq-option value="biking"><span>Biking</span></bq-option>
+      </bq-option-group>
+      <bq-option-group>
+        <bq-icon slot="header-prefix" name="pizza"></bq-icon>
+        <span slot="header-label">Food</span>
+        <bq-option value="pizza"><span>Pizza</span></bq-option>
+        <bq-option value="hamburger"><span>Hamburger</span></bq-option>
+        <bq-option value="cookie"><span>Cookie</span></bq-option>
+      </bq-option-group>
+    </bq-option-list>
+    ```
+
+    ```jsx React icon="react"
+    import { BqIcon, BqOption, BqOptionGroup, BqOptionList } from "@beeq/react";
+
+    <BqOptionList>
+      <BqOptionGroup>
+        <BqIcon slot="header-prefix" name="sneaker-move" />
+        <span slot="header-label">Sport</span>
+        <BqOption value="running"><span>Running</span></BqOption>
+        <BqOption value="hiking"><span>Hiking</span></BqOption>
+        <BqOption value="biking"><span>Biking</span></BqOption>
+      </BqOptionGroup>
+      <BqOptionGroup>
+        <BqIcon slot="header-prefix" name="pizza" />
+        <span slot="header-label">Food</span>
+        <BqOption value="pizza"><span>Pizza</span></BqOption>
+        <BqOption value="hamburger"><span>Hamburger</span></BqOption>
+        <BqOption value="cookie"><span>Cookie</span></BqOption>
+      </BqOptionGroup>
+    </BqOptionList>
+    ```
+
+    ```html Angular icon="angular"
+    <bq-option-list>
+      <bq-option-group>
+        <bq-icon slot="header-prefix" name="sneaker-move"></bq-icon>
+        <span slot="header-label">Sport</span>
+        <bq-option value="running"><span>Running</span></bq-option>
+        <bq-option value="hiking"><span>Hiking</span></bq-option>
+        <bq-option value="biking"><span>Biking</span></bq-option>
+      </bq-option-group>
+      <bq-option-group>
+        <bq-icon slot="header-prefix" name="pizza"></bq-icon>
+        <span slot="header-label">Food</span>
+        <bq-option value="pizza"><span>Pizza</span></bq-option>
+        <bq-option value="hamburger"><span>Hamburger</span></bq-option>
+        <bq-option value="cookie"><span>Cookie</span></bq-option>
+      </bq-option-group>
+    </bq-option-list>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqIcon, BqOption, BqOptionGroup, BqOptionList } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqOptionList>
+        <BqOptionGroup>
+          <BqIcon slot="header-prefix" name="sneaker-move" />
+          <span slot="header-label">Sport</span>
+          <BqOption value="running"><span>Running</span></BqOption>
+          <BqOption value="hiking"><span>Hiking</span></BqOption>
+          <BqOption value="biking"><span>Biking</span></BqOption>
+        </BqOptionGroup>
+        <BqOptionGroup>
+          <BqIcon slot="header-prefix" name="pizza" />
+          <span slot="header-label">Food</span>
+          <BqOption value="pizza"><span>Pizza</span></BqOption>
+          <BqOption value="hamburger"><span>Hamburger</span></BqOption>
+          <BqOption value="cookie"><span>Cookie</span></BqOption>
+        </BqOptionGroup>
+      </BqOptionList>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### With suffix on the group header
+
+Use the `header-suffix` slot to place a count badge, status chip, or secondary icon after the label. The suffix is right-aligned and does not interfere with the label truncation.
+
+<CodeLivePreview code={`
+  <bq-option-list>
+    <bq-option-group>
+      <span slot="header-label">Sport</span>
+      <bq-badge slot="header-suffix" type="info">3</bq-badge>
+      <bq-option value="running">
+        <bq-icon slot="prefix" name="sneaker-move"></bq-icon>
+        <span>Running</span>
+      </bq-option>
+      <bq-option value="hiking">
+        <bq-icon slot="prefix" name="boot"></bq-icon>
+        <span>Hiking</span>
+      </bq-option>
+      <bq-option value="biking">
+        <bq-icon slot="prefix" name="person-simple-bike"></bq-icon>
+        <span>Biking</span>
+      </bq-option>
+    </bq-option-group>
+    <bq-option-group>
+      <span slot="header-label">Food</span>
+      <bq-badge slot="header-suffix" type="info">3</bq-badge>
+      <bq-option value="pizza">
+        <bq-icon slot="prefix" name="pizza"></bq-icon>
+        <span>Pizza</span>
+      </bq-option>
+      <bq-option value="hamburger">
+        <bq-icon slot="prefix" name="hamburger"></bq-icon>
+        <span>Hamburger</span>
+      </bq-option>
+      <bq-option value="cookie">
+        <bq-icon slot="prefix" name="cookie"></bq-icon>
+        <span>Cookie</span>
+      </bq-option>
+    </bq-option-group>
+  </bq-option-list>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-option-list>
+      <bq-option-group>
+        <span slot="header-label">Sport</span>
+        <bq-badge slot="header-suffix" type="info">3</bq-badge>
+        <bq-option value="running">
+          <bq-icon slot="prefix" name="sneaker-move"></bq-icon>
+          <span>Running</span>
+        </bq-option>
+        <bq-option value="hiking">
+          <bq-icon slot="prefix" name="boot"></bq-icon>
+          <span>Hiking</span>
+        </bq-option>
+        <bq-option value="biking">
+          <bq-icon slot="prefix" name="person-simple-bike"></bq-icon>
+          <span>Biking</span>
+        </bq-option>
+      </bq-option-group>
+      <bq-option-group>
+        <span slot="header-label">Food</span>
+        <bq-badge slot="header-suffix" type="info">3</bq-badge>
+        <bq-option value="pizza">
+          <bq-icon slot="prefix" name="pizza"></bq-icon>
+          <span>Pizza</span>
+        </bq-option>
+        <bq-option value="hamburger">
+          <bq-icon slot="prefix" name="hamburger"></bq-icon>
+          <span>Hamburger</span>
+        </bq-option>
+        <bq-option value="cookie">
+          <bq-icon slot="prefix" name="cookie"></bq-icon>
+          <span>Cookie</span>
+        </bq-option>
+      </bq-option-group>
+    </bq-option-list>
+    ```
+
+    ```jsx React icon="react"
+    import { BqBadge, BqIcon, BqOption, BqOptionGroup, BqOptionList } from "@beeq/react";
+
+    <BqOptionList>
+      <BqOptionGroup>
+        <span slot="header-label">Sport</span>
+        <BqBadge slot="header-suffix" type="info">3</BqBadge>
+        <BqOption value="running">
+          <BqIcon slot="prefix" name="sneaker-move" />
+          <span>Running</span>
+        </BqOption>
+        <BqOption value="hiking">
+          <BqIcon slot="prefix" name="boot" />
+          <span>Hiking</span>
+        </BqOption>
+        <BqOption value="biking">
+          <BqIcon slot="prefix" name="person-simple-bike" />
+          <span>Biking</span>
+        </BqOption>
+      </BqOptionGroup>
+      <BqOptionGroup>
+        <span slot="header-label">Food</span>
+        <BqBadge slot="header-suffix" type="info">3</BqBadge>
+        <BqOption value="pizza">
+          <BqIcon slot="prefix" name="pizza" />
+          <span>Pizza</span>
+        </BqOption>
+        <BqOption value="hamburger">
+          <BqIcon slot="prefix" name="hamburger" />
+          <span>Hamburger</span>
+        </BqOption>
+        <BqOption value="cookie">
+          <BqIcon slot="prefix" name="cookie" />
+          <span>Cookie</span>
+        </BqOption>
+      </BqOptionGroup>
+    </BqOptionList>
+    ```
+
+    ```html Angular icon="angular"
+    <bq-option-list>
+      <bq-option-group>
+        <span slot="header-label">Sport</span>
+        <bq-badge slot="header-suffix" type="info">3</bq-badge>
+        <bq-option value="running">
+          <bq-icon slot="prefix" name="sneaker-move"></bq-icon>
+          <span>Running</span>
+        </bq-option>
+        <bq-option value="hiking">
+          <bq-icon slot="prefix" name="boot"></bq-icon>
+          <span>Hiking</span>
+        </bq-option>
+        <bq-option value="biking">
+          <bq-icon slot="prefix" name="person-simple-bike"></bq-icon>
+          <span>Biking</span>
+        </bq-option>
+      </bq-option-group>
+      <bq-option-group>
+        <span slot="header-label">Food</span>
+        <bq-badge slot="header-suffix" type="info">3</bq-badge>
+        <bq-option value="pizza">
+          <bq-icon slot="prefix" name="pizza"></bq-icon>
+          <span>Pizza</span>
+        </bq-option>
+        <bq-option value="hamburger">
+          <bq-icon slot="prefix" name="hamburger"></bq-icon>
+          <span>Hamburger</span>
+        </bq-option>
+        <bq-option value="cookie">
+          <bq-icon slot="prefix" name="cookie"></bq-icon>
+          <span>Cookie</span>
+        </bq-option>
+      </bq-option-group>
+    </bq-option-list>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqBadge, BqIcon, BqOption, BqOptionGroup, BqOptionList } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqOptionList>
+        <BqOptionGroup>
+          <span slot="header-label">Sport</span>
+          <BqBadge slot="header-suffix" type="info">3</BqBadge>
+          <BqOption value="running">
+            <BqIcon slot="prefix" name="sneaker-move" />
+            <span>Running</span>
+          </BqOption>
+          <BqOption value="hiking">
+            <BqIcon slot="prefix" name="boot" />
+            <span>Hiking</span>
+          </BqOption>
+          <BqOption value="biking">
+            <BqIcon slot="prefix" name="person-simple-bike" />
+            <span>Biking</span>
+          </BqOption>
+        </BqOptionGroup>
+        <BqOptionGroup>
+          <span slot="header-label">Food</span>
+          <BqBadge slot="header-suffix" type="info">3</BqBadge>
+          <BqOption value="pizza">
+            <BqIcon slot="prefix" name="pizza" />
+            <span>Pizza</span>
+          </BqOption>
+          <BqOption value="hamburger">
+            <BqIcon slot="prefix" name="hamburger" />
+            <span>Hamburger</span>
+          </BqOption>
+          <BqOption value="cookie">
+            <BqIcon slot="prefix" name="cookie" />
+            <span>Cookie</span>
+          </BqOption>
+        </BqOptionGroup>
+      </BqOptionList>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+## Best practices
+
+<CardGroup cols={2}>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Always provide content in the `header-label` slot so screen readers and sighted users both know what the group represents.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Render a group without a label — an unnamed group header creates visual ambiguity and an unnamed `role="group"` gives screen readers nothing useful to announce.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Include at least two options in each group — a group containing a single item implies the grouping is arbitrary.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Create groups where every group contains only one option. If no meaningful category exists, use a flat `bq-option-list` instead.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Keep group labels short — one to three words. The label is displayed in a constrained header row and truncates when it overflows.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Write full sentences as group labels. Long text truncates silently and makes the header unreadable in narrow containers.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Use groups consistently — if one group has a prefix icon, give all groups a prefix icon so the header row stays visually aligned.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Mix groups with and without prefix icons in the same list. The inconsistent indentation makes the list harder to scan.
+  </Card>
+</CardGroup>
+
+## Accessibility
+
+`bq-option-group` renders a `role="group"` container div that holds the slotted option items. The `aria-label="Options"` attribute is set on this container automatically, providing a generic fallback label for assistive technologies.
+
+As a developer, you are responsible for:
+
+- **Always providing `header-label` content** — the text in this slot is what sighted users and screen reader users rely on to understand what the group is about. Without it, the group boundary is invisible to assistive technologies.
+- **Placing the component inside `bq-option-list`** — `bq-option-group` provides `role="group"`, which must be a descendant of `role="listbox"` (supplied by `bq-option-list`). Rendering option groups outside this context breaks the expected ARIA tree structure.
+- **Keeping groups non-empty** — a group with no options creates an orphaned header with no associated list items, which confuses both sighted users and screen readers.
+
+## API reference
+
+### Properties
+
+`bq-option-group` has no configurable properties. Its behaviour is entirely controlled through slots.
+
+### Slots
+
+| Slot | Description |
+|---|---|
+| *(default)* | The `bq-option` items belonging to this group |
+| `header-label` | The text label that names the group |
+| `header-prefix` | Content rendered before the label — typically a `bq-icon` |
+| `header-suffix` | Content rendered after the label — typically a `bq-icon` or badge |
+
+### Shadow parts
+
+| Part | Description |
+|---|---|
+| `label` | The `<legend>` element that acts as the group header container |
+| `prefix` | The `<span>` wrapping the `header-prefix` slot content |
+| `suffix` | The `<span>` wrapping the `header-suffix` slot content |
+| `group` | The `<div>` that holds the slotted option items |
+
+### CSS custom properties
+
+<Expandable title="CSS variables" defaultOpen={true}>
+  | Variable | Description | Default |
+  |---|---|---|
+  | `--bq-option-group--background` | Group background color | `var(--bq-ui--primary)` |
+  | `--bq-option-group--font-size` | Group label font size | `var(--bq-font-size--s)` |
+  | `--bq-option-group--line-height` | Group label line height | `var(--bq-font-line-height--regular)` |
+  | `--bq-option-group--label-padding-start` | Inline-start padding of the group header | `var(--bq-spacing-s)` |
+  | `--bq-option-group--label-padding-end` | Inline-end padding of the group header | `var(--bq-spacing-s)` |
+  | `--bq-option-group--label-paddingY` | Block padding of the group header | `var(--bq-spacing-xs)` |
+  | `--bq-option-group--label-text-padding-start` | Inline-start padding of the label text within the header | `var(--bq-spacing-s)` |
+  | `--bq-option-group--label-text-padding-end` | Inline-end padding of the label text within the header | `var(--bq-spacing-s)` |
+  | `--bq-option-group--container-padding-start` | Inline-start padding of the options container | `var(--bq-spacing-xxl)` |
+</Expandable>
+
+<Tip>
+  Learn more about [styling with shadow parts](/theming/styles) and [CSS custom properties](/theming/global-css-variables).
+</Tip>
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card horizontal title="Interactive playground" icon="code" href="https://storybook.beeq.design/?path=/story/components-option--with-option-group">
+    Explore option group variants and states in Storybook
+  </Card>
+  <Card horizontal title="Source code" icon="github" href="https://github.com/Endava/BEEQ/tree/main/packages/beeq/src/components/option-group">
+    View the component source on GitHub
+  </Card>
+</CardGroup>

--- a/apps/beeq-docs/components/option-group.mdx
+++ b/apps/beeq-docs/components/option-group.mdx
@@ -256,7 +256,7 @@ Two groups of options inside a single `bq-option-list`. Each group carries a `he
         </bq-option-list>
       `,
     })
-    export class AppComponent {}
+    export class BasicOptionGroupComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -344,16 +344,28 @@ Add a `bq-icon` in the `header-prefix` slot to give the group label a visual cat
       <bq-option-group>
         <bq-icon slot="header-prefix" name="sneaker-move"></bq-icon>
         <span slot="header-label">Sport</span>
-        <bq-option value="running"><span>Running</span></bq-option>
-        <bq-option value="hiking"><span>Hiking</span></bq-option>
-        <bq-option value="biking"><span>Biking</span></bq-option>
+        <bq-option value="running">
+          <span>Running</span>
+        </bq-option>
+        <bq-option value="hiking">
+          <span>Hiking</span>
+        </bq-option>
+        <bq-option value="biking">
+          <span>Biking</span>
+        </bq-option>
       </bq-option-group>
       <bq-option-group>
         <bq-icon slot="header-prefix" name="pizza"></bq-icon>
         <span slot="header-label">Food</span>
-        <bq-option value="pizza"><span>Pizza</span></bq-option>
-        <bq-option value="hamburger"><span>Hamburger</span></bq-option>
-        <bq-option value="cookie"><span>Cookie</span></bq-option>
+        <bq-option value="pizza">
+          <span>Pizza</span>
+        </bq-option>
+        <bq-option value="hamburger">
+          <span>Hamburger</span>
+        </bq-option>
+        <bq-option value="cookie">
+          <span>Cookie</span>
+        </bq-option>
       </bq-option-group>
     </bq-option-list>
     ```
@@ -365,16 +377,28 @@ Add a `bq-icon` in the `header-prefix` slot to give the group label a visual cat
       <BqOptionGroup>
         <BqIcon slot="header-prefix" name="sneaker-move" />
         <span slot="header-label">Sport</span>
-        <BqOption value="running"><span>Running</span></BqOption>
-        <BqOption value="hiking"><span>Hiking</span></BqOption>
-        <BqOption value="biking"><span>Biking</span></BqOption>
+        <BqOption value="running">
+          <span>Running</span>
+        </BqOption>
+        <BqOption value="hiking">
+          <span>Hiking</span>
+        </BqOption>
+        <BqOption value="biking">
+          <span>Biking</span>
+        </BqOption>
       </BqOptionGroup>
       <BqOptionGroup>
         <BqIcon slot="header-prefix" name="pizza" />
         <span slot="header-label">Food</span>
-        <BqOption value="pizza"><span>Pizza</span></BqOption>
-        <BqOption value="hamburger"><span>Hamburger</span></BqOption>
-        <BqOption value="cookie"><span>Cookie</span></BqOption>
+        <BqOption value="pizza">
+          <span>Pizza</span>
+        </BqOption>
+        <BqOption value="hamburger">
+          <span>Hamburger</span>
+        </BqOption>
+        <BqOption value="cookie">
+          <span>Cookie</span>
+        </BqOption>
       </BqOptionGroup>
     </BqOptionList>
     ```
@@ -392,21 +416,33 @@ Add a `bq-icon` in the `header-prefix` slot to give the group label a visual cat
           <bq-option-group>
             <bq-icon slot="header-prefix" name="sneaker-move"></bq-icon>
             <span slot="header-label">Sport</span>
-            <bq-option value="running"><span>Running</span></bq-option>
-            <bq-option value="hiking"><span>Hiking</span></bq-option>
-            <bq-option value="biking"><span>Biking</span></bq-option>
+            <bq-option value="running">
+              <span>Running</span>
+            </bq-option>
+            <bq-option value="hiking">
+              <span>Hiking</span>
+            </bq-option>
+            <bq-option value="biking">
+              <span>Biking</span>
+            </bq-option>
           </bq-option-group>
           <bq-option-group>
             <bq-icon slot="header-prefix" name="pizza"></bq-icon>
             <span slot="header-label">Food</span>
-            <bq-option value="pizza"><span>Pizza</span></bq-option>
-            <bq-option value="hamburger"><span>Hamburger</span></bq-option>
-            <bq-option value="cookie"><span>Cookie</span></bq-option>
+            <bq-option value="pizza">
+              <span>Pizza</span>
+            </bq-option>
+            <bq-option value="hamburger">
+              <span>Hamburger</span>
+            </bq-option>
+            <bq-option value="cookie">
+              <span>Cookie</span>
+            </bq-option>
           </bq-option-group>
         </bq-option-list>
       `,
     })
-    export class AppComponent {}
+    export class OptionGroupWithPrefixIconComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -419,16 +455,28 @@ Add a `bq-icon` in the `header-prefix` slot to give the group label a visual cat
         <BqOptionGroup>
           <BqIcon slot="header-prefix" name="sneaker-move" />
           <span slot="header-label">Sport</span>
-          <BqOption value="running"><span>Running</span></BqOption>
-          <BqOption value="hiking"><span>Hiking</span></BqOption>
-          <BqOption value="biking"><span>Biking</span></BqOption>
+          <BqOption value="running">
+            <span>Running</span>
+          </BqOption>
+          <BqOption value="hiking">
+            <span>Hiking</span>
+          </BqOption>
+          <BqOption value="biking">
+            <span>Biking</span>
+          </BqOption>
         </BqOptionGroup>
         <BqOptionGroup>
           <BqIcon slot="header-prefix" name="pizza" />
           <span slot="header-label">Food</span>
-          <BqOption value="pizza"><span>Pizza</span></BqOption>
-          <BqOption value="hamburger"><span>Hamburger</span></BqOption>
-          <BqOption value="cookie"><span>Cookie</span></BqOption>
+          <BqOption value="pizza">
+            <span>Pizza</span>
+          </BqOption>
+          <BqOption value="hamburger">
+            <span>Hamburger</span>
+          </BqOption>
+          <BqOption value="cookie">
+            <span>Cookie</span>
+          </BqOption>
         </BqOptionGroup>
       </BqOptionList>
     </template>
@@ -598,7 +646,7 @@ Use the `header-suffix` slot to place a count badge, status chip, or secondary i
         </bq-option-list>
       `,
     })
-    export class AppComponent {}
+    export class OptionGroupWithSuffixBadgeComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -716,7 +764,7 @@ Use the `header-suffix` slot to place a count badge, status chip, or secondary i
 
 ## Accessibility
 
-`bq-option-group` renders a `role="group"` container div that holds the slotted option items. The `aria-label="Options"` attribute is set on this container automatically, providing a generic fallback label for assistive technologies.
+`bq-option-group` renders a `role="group"` container div that holds the slotted option items. The internal container carries `aria-label="Options"` as a hardcoded fallback — this is not configurable via a prop. Screen readers use the text in the `header-label` slot to identify the group; the hardcoded `aria-label` is only a structural safety net for the container element itself.
 
 As a developer, you are responsible for:
 
@@ -765,7 +813,7 @@ As a developer, you are responsible for:
 </Expandable>
 
 <Tip>
-  Learn more about [styling with shadow parts](/theming/styles) and [CSS custom properties](/theming/global-css-variables).
+  Learn more about [styling with shadow parts](/guides/styles) and [CSS custom properties](/theming/global-css-variables).
 </Tip>
 
 ## Resources

--- a/apps/beeq-docs/components/option-list.mdx
+++ b/apps/beeq-docs/components/option-list.mdx
@@ -188,7 +188,7 @@ A simple list with no groups. Each `bq-option` carries a `value` so the parent c
         </bq-option-list>
       `,
     })
-    export class AppComponent {}
+    export class FlatOptionListComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -308,7 +308,7 @@ Override `aria-label` when the default `"Options"` is too generic for the contex
         </bq-option-list>
       `,
     })
-    export class AppComponent {}
+    export class AccessibleOptionListComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -449,7 +449,7 @@ As a developer, you are responsible for:
 | `--bq-option-group--gapY-list` | Vertical gap between items in the list | `var(--bq-spacing-xs)` |
 
 <Tip>
-  Learn more about [styling with shadow parts](/theming/styles) and [CSS custom properties](/theming/global-css-variables).
+  Learn more about [styling with shadow parts](/guides/styles) and [CSS custom properties](/theming/global-css-variables).
 </Tip>
 
 ## Resources

--- a/apps/beeq-docs/components/option-list.mdx
+++ b/apps/beeq-docs/components/option-list.mdx
@@ -1,0 +1,444 @@
+---
+title: Option List
+description: Option List is a listbox container that groups one or more Option items and surfaces a selection event when the user clicks or activates any of them.
+---
+
+import { CodeLivePreview } from "/snippets/CodeLivePreview.jsx";
+
+<Frame className="px-4 py-4" caption="Option List component overview">
+  <img className="block dark:hidden" src="/components/images/option-list/option-list-overview-light.svg" alt="BEEQ Option List component overview" />
+  <img className="hidden dark:block" src="/components/images/option-list/option-list-overview-dark.svg" alt="BEEQ Option List component overview" />
+</Frame>
+
+`bq-option-list` is the required wrapper for `bq-option` and `bq-option-group` elements. It sets the `role="listbox"` context, handles keyboard and click events from child options, and emits a single `bqSelect` event with the selected item's value back to the parent component.
+
+<Note>
+  `bq-option-list` is a structural container — it does not render any visible UI of its own. It is used internally by higher-level components such as `bq-select` and `bq-dropdown`. Use it directly only when you are building a custom listbox-based control.
+</Note>
+
+## When to use
+
+<CardGroup cols={2}>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="thumbs-up" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Use option list when
+    </span>
+
+    * You are composing a custom dropdown, command palette, or navigation menu from `bq-option` items
+    * You need a `role="listbox"` container that bubbles selection events from child options to your component logic
+    * You want to combine flat options with `bq-option-group` sections in the same list
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="thumbs-down" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Do not use option list when
+    </span>
+
+    * You are using `bq-select` or `bq-dropdown` — these components manage `bq-option-list` internally
+    * You need a multi-select list with checkboxes — use form controls such as `bq-checkbox` directly
+    * The items are primarily navigational links rather than discrete selectable choices
+  </Card>
+</CardGroup>
+
+## Option List patterns
+
+<CardGroup cols={3}>
+  <Card title="Flat list">
+    A plain sequence of `bq-option` items. Use when all choices belong to the same category and no visual separation is needed.
+  </Card>
+  <Card title="Grouped list">
+    One or more `bq-option-group` containers inside the list. Use when choices fall into distinct named categories that help users scan faster.
+  </Card>
+  <Card title="Mixed list">
+    Ungrouped options above or below grouped sections. Use when a "pinned" set of common choices (for example, "Recently used") should appear before the full categorized list.
+  </Card>
+</CardGroup>
+
+## Anatomy
+
+<Frame className="px-4 py-4" caption="Option List component anatomy">
+  <img className="block dark:hidden" src="/components/images/option-list/option-list-anatomy-light.svg" alt="BEEQ Option List component anatomy" />
+  <img className="hidden dark:block" src="/components/images/option-list/option-list-anatomy-dark.svg" alt="BEEQ Option List component anatomy" />
+</Frame>
+
+`bq-option-list` is a single flex column container that holds slotted option items or option groups. It has no visual chrome of its own — the border, shadow, and background typically come from the enclosing panel or dropdown trigger.
+
+| Part | Element | Description |
+|---|---|---|
+| **1** | Base | The internal `<div>` that stacks slotted options vertically with consistent gap |
+| **2** | Option items | `bq-option` or `bq-option-group` elements placed in the default slot |
+
+## Design guidelines
+
+### Use with a containing surface
+
+`bq-option-list` provides layout and interaction semantics but no background or border. Wrap it in a surface element — typically a panel, popover, or card — that provides the visual boundary users associate with a dropdown or list.
+
+<Note>
+  When used inside `bq-select` or `bq-dropdown`, the containing surface is handled automatically. The guidelines here apply when you are building a custom container from scratch.
+</Note>
+
+### Vertical rhythm
+
+The gap between items is controlled by the `--bq-option-group--gapY-list` CSS custom property. The default is tight (`var(--bq-spacing-xs)`) to keep the list compact. Increase it only when items are taller than a single text line or when the list is used in a context with generous surrounding whitespace.
+
+### Accessible label
+
+The `ariaLabel` prop (rendered as `aria-label` on the host element) names the listbox for screen readers. The default value is `"Options"`. Override it with a more specific label when the context makes the default ambiguous — for example, `"Navigation links"` or `"Assignees"`.
+
+## Usage
+
+### Flat list
+
+A simple list with no groups. Each `bq-option` carries a `value` so the parent can identify the selection via the `bqSelect` event.
+
+<CodeLivePreview code={`
+  <bq-option-list>
+    <bq-option value="profile">
+      <bq-icon slot="prefix" name="user"></bq-icon>
+      <span>User profile</span>
+    </bq-option>
+    <bq-option value="password">
+      <bq-icon slot="prefix" name="lock-simple"></bq-icon>
+      <span>Change password</span>
+    </bq-option>
+    <bq-option value="settings">
+      <bq-icon slot="prefix" name="gear"></bq-icon>
+      <span>Settings</span>
+    </bq-option>
+    <bq-option value="logout">
+      <bq-icon slot="prefix" name="sign-out"></bq-icon>
+      <span>Close session</span>
+    </bq-option>
+  </bq-option-list>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-option-list>
+      <bq-option value="profile">
+        <bq-icon slot="prefix" name="user"></bq-icon>
+        <span>User profile</span>
+      </bq-option>
+      <bq-option value="password">
+        <bq-icon slot="prefix" name="lock-simple"></bq-icon>
+        <span>Change password</span>
+      </bq-option>
+      <bq-option value="settings">
+        <bq-icon slot="prefix" name="gear"></bq-icon>
+        <span>Settings</span>
+      </bq-option>
+      <bq-option value="logout">
+        <bq-icon slot="prefix" name="sign-out"></bq-icon>
+        <span>Close session</span>
+      </bq-option>
+    </bq-option-list>
+    ```
+
+    ```jsx React icon="react"
+    import { BqIcon, BqOption, BqOptionList } from "@beeq/react";
+
+    <BqOptionList>
+      <BqOption value="profile">
+        <BqIcon slot="prefix" name="user" />
+        <span>User profile</span>
+      </BqOption>
+      <BqOption value="password">
+        <BqIcon slot="prefix" name="lock-simple" />
+        <span>Change password</span>
+      </BqOption>
+      <BqOption value="settings">
+        <BqIcon slot="prefix" name="gear" />
+        <span>Settings</span>
+      </BqOption>
+      <BqOption value="logout">
+        <BqIcon slot="prefix" name="sign-out" />
+        <span>Close session</span>
+      </BqOption>
+    </BqOptionList>
+    ```
+
+    ```html Angular icon="angular"
+    <!-- Standalone: import { BqIcon, BqOption, BqOptionList } from "@beeq/angular/standalone" -->
+
+    <bq-option-list>
+      <bq-option value="profile">
+        <bq-icon slot="prefix" name="user"></bq-icon>
+        <span>User profile</span>
+      </bq-option>
+      <bq-option value="password">
+        <bq-icon slot="prefix" name="lock-simple"></bq-icon>
+        <span>Change password</span>
+      </bq-option>
+      <bq-option value="settings">
+        <bq-icon slot="prefix" name="gear"></bq-icon>
+        <span>Settings</span>
+      </bq-option>
+      <bq-option value="logout">
+        <bq-icon slot="prefix" name="sign-out"></bq-icon>
+        <span>Close session</span>
+      </bq-option>
+    </bq-option-list>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqIcon, BqOption, BqOptionList } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqOptionList>
+        <BqOption value="profile">
+          <BqIcon slot="prefix" name="user" />
+          <span>User profile</span>
+        </BqOption>
+        <BqOption value="password">
+          <BqIcon slot="prefix" name="lock-simple" />
+          <span>Change password</span>
+        </BqOption>
+        <BqOption value="settings">
+          <BqIcon slot="prefix" name="gear" />
+          <span>Settings</span>
+        </BqOption>
+        <BqOption value="logout">
+          <BqIcon slot="prefix" name="sign-out" />
+          <span>Close session</span>
+        </BqOption>
+      </BqOptionList>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+<Tip>
+  To use grouped sections, place [`bq-option-group`](/components/option-group) elements inside `bq-option-list`. The `bqSelect` event still bubbles from whichever `bq-option` the user activates. See the [Option Group](/components/option-group) page for full grouped list examples including header prefix and suffix slots.
+</Tip>
+
+## Options
+
+### Custom accessible label
+
+Override `aria-label` when the default `"Options"` is too generic for the context. A specific label helps screen reader users understand the purpose of the list before navigating into it.
+
+<CodeLivePreview code={`
+  <bq-option-list aria-label="Navigation links">
+    <bq-option value="home">
+      <bq-icon slot="prefix" name="house"></bq-icon>
+      <span>Home</span>
+    </bq-option>
+    <bq-option value="dashboard">
+      <bq-icon slot="prefix" name="layout"></bq-icon>
+      <span>Dashboard</span>
+    </bq-option>
+    <bq-option value="reports">
+      <bq-icon slot="prefix" name="chart-bar"></bq-icon>
+      <span>Reports</span>
+    </bq-option>
+  </bq-option-list>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-option-list aria-label="Navigation links">
+      <bq-option value="home">
+        <bq-icon slot="prefix" name="house"></bq-icon>
+        <span>Home</span>
+      </bq-option>
+      <bq-option value="dashboard">
+        <bq-icon slot="prefix" name="layout"></bq-icon>
+        <span>Dashboard</span>
+      </bq-option>
+      <bq-option value="reports">
+        <bq-icon slot="prefix" name="chart-bar"></bq-icon>
+        <span>Reports</span>
+      </bq-option>
+    </bq-option-list>
+    ```
+
+    ```jsx React icon="react"
+    import { BqIcon, BqOption, BqOptionList } from "@beeq/react";
+
+    <BqOptionList ariaLabel="Navigation links">
+      <BqOption value="home">
+        <BqIcon slot="prefix" name="house" />
+        <span>Home</span>
+      </BqOption>
+      <BqOption value="dashboard">
+        <BqIcon slot="prefix" name="layout" />
+        <span>Dashboard</span>
+      </BqOption>
+      <BqOption value="reports">
+        <BqIcon slot="prefix" name="chart-bar" />
+        <span>Reports</span>
+      </BqOption>
+    </BqOptionList>
+    ```
+
+    ```html Angular icon="angular"
+    <bq-option-list aria-label="Navigation links">
+      <bq-option value="home">
+        <bq-icon slot="prefix" name="house"></bq-icon>
+        <span>Home</span>
+      </bq-option>
+      <bq-option value="dashboard">
+        <bq-icon slot="prefix" name="layout"></bq-icon>
+        <span>Dashboard</span>
+      </bq-option>
+      <bq-option value="reports">
+        <bq-icon slot="prefix" name="chart-bar"></bq-icon>
+        <span>Reports</span>
+      </bq-option>
+    </bq-option-list>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqIcon, BqOption, BqOptionList } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqOptionList ariaLabel="Navigation links">
+        <BqOption value="home">
+          <BqIcon slot="prefix" name="house" />
+          <span>Home</span>
+        </BqOption>
+        <BqOption value="dashboard">
+          <BqIcon slot="prefix" name="layout" />
+          <span>Dashboard</span>
+        </BqOption>
+        <BqOption value="reports">
+          <BqIcon slot="prefix" name="chart-bar" />
+          <span>Reports</span>
+        </BqOption>
+      </BqOptionList>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+## Best practices
+
+<CardGroup cols={2}>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Always place `bq-option` and `bq-option-group` directly inside `bq-option-list` — the component listens for `bqClick` and `bqEnter` events from child options and will not receive them if additional wrapper elements break the event path.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Wrap options in arbitrary `<div>` or `<span>` elements inside the list. Non-option wrappers break the `bqClick`/`bqEnter` event delegation that `bq-option-list` relies on to emit `bqSelect`.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Override `aria-label` with a descriptive phrase when the list is not the only `role="listbox"` on the page or when the default `"Options"` does not communicate the list's purpose.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Leave the default `aria-label="Options"` on multiple lists within the same view without making each one contextually unique — screen reader users navigating by landmark will see identical labels and cannot tell the lists apart.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Listen to the `bqSelect` event on `bq-option-list` rather than individual `bqClick` events on each `bq-option`. The list normalises both click and Enter-key activations into a single `bqSelect` event with a consistent `{ value, item }` payload.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Attach separate `bqClick` listeners to every `bq-option` when you only need the selected value — `bq-option-list` already aggregates these and emitting redundant handlers increases the chance of inconsistent state.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Use `bq-option-group` to divide a long list into named sections when the number of items makes scanning difficult.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Render dozens of flat options without any grouping. An ungrouped list longer than around eight items becomes hard to scan — users have to read every item individually rather than jumping to the relevant category.
+  </Card>
+</CardGroup>
+
+## Accessibility
+
+`bq-option-list` sets `role="listbox"` on its host element during `componentDidLoad`. This establishes the ARIA container that child `bq-option` elements (which carry `role="option"`) require in order to form a valid accessible list.
+
+The `ariaLabel` prop is reflected as `aria-label` on the host and defaults to `"Options"`. It names the listbox for assistive technologies.
+
+As a developer, you are responsible for:
+
+- **Providing a meaningful `ariaLabel`** when the default is ambiguous. Screen readers announce the listbox name before a user navigates into it, so a specific label ("Assignees", "Color palette") is more useful than the generic default.
+- **Placing only `bq-option` and `bq-option-group` elements inside the list** — inserting non-option elements breaks the `role="listbox"` / `role="option"` relationship that assistive technologies expect.
+- **Managing focus** when the list is shown or hidden — `bq-option-list` does not manage focus automatically. If you are building a custom dropdown, move focus to the first option when the list opens and return it to the trigger when it closes.
+
+## API reference
+
+### Properties
+
+| Property | Attribute | Description | Type | Default |
+|---|---|---|---|---|
+| `ariaLabel` | `aria-label` | Accessible label for the listbox | `string` | `'Options'` |
+
+### Events
+
+| Event | Description | Type |
+|---|---|---|
+| `bqSelect` | Emitted when an option is selected via click or Enter key | `CustomEvent<{ value: string; item: HTMLBqOptionElement }>` |
+
+### Slots
+
+| Slot | Description |
+|---|---|
+| *(default)* | `bq-option` and `bq-option-group` items |
+
+### Shadow parts
+
+| Part | Description |
+|---|---|
+| `base` | The internal `<div>` wrapper that stacks slotted items vertically |
+
+### CSS custom properties
+
+| Variable | Description | Default |
+|---|---|---|
+| `--bq-option-group--gapY-list` | Vertical gap between items in the list | `var(--bq-spacing-xs)` |
+
+<Tip>
+  Learn more about [styling with shadow parts](/theming/styles) and [CSS custom properties](/theming/global-css-variables).
+</Tip>
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card horizontal title="Interactive playground" icon="code" href="https://storybook.beeq.design/?path=/story/components-option--default">
+    Explore option list variants and states in Storybook
+  </Card>
+  <Card horizontal title="Source code" icon="github" href="https://github.com/Endava/BEEQ/tree/main/packages/beeq/src/components/option-list">
+    View the component source on GitHub
+  </Card>
+</CardGroup>

--- a/apps/beeq-docs/components/option-list.mdx
+++ b/apps/beeq-docs/components/option-list.mdx
@@ -159,27 +159,36 @@ A simple list with no groups. Each `bq-option` carries a `value` so the parent c
     </BqOptionList>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqIcon, BqOption, BqOptionList } from "@beeq/angular/standalone" -->
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqIcon, BqOption, BqOptionList } from "@beeq/angular/standalone";
 
-    <bq-option-list>
-      <bq-option value="profile">
-        <bq-icon slot="prefix" name="user"></bq-icon>
-        <span>User profile</span>
-      </bq-option>
-      <bq-option value="password">
-        <bq-icon slot="prefix" name="lock-simple"></bq-icon>
-        <span>Change password</span>
-      </bq-option>
-      <bq-option value="settings">
-        <bq-icon slot="prefix" name="gear"></bq-icon>
-        <span>Settings</span>
-      </bq-option>
-      <bq-option value="logout">
-        <bq-icon slot="prefix" name="sign-out"></bq-icon>
-        <span>Close session</span>
-      </bq-option>
-    </bq-option-list>
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqIcon, BqOption, BqOptionList],
+      template: `
+        <bq-option-list>
+          <bq-option value="profile">
+            <bq-icon slot="prefix" name="user"></bq-icon>
+            <span>User profile</span>
+          </bq-option>
+          <bq-option value="password">
+            <bq-icon slot="prefix" name="lock-simple"></bq-icon>
+            <span>Change password</span>
+          </bq-option>
+          <bq-option value="settings">
+            <bq-icon slot="prefix" name="gear"></bq-icon>
+            <span>Settings</span>
+          </bq-option>
+          <bq-option value="logout">
+            <bq-icon slot="prefix" name="sign-out"></bq-icon>
+            <span>Close session</span>
+          </bq-option>
+        </bq-option-list>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -274,21 +283,32 @@ Override `aria-label` when the default `"Options"` is too generic for the contex
     </BqOptionList>
     ```
 
-    ```html Angular icon="angular"
-    <bq-option-list aria-label="Navigation links">
-      <bq-option value="home">
-        <bq-icon slot="prefix" name="house"></bq-icon>
-        <span>Home</span>
-      </bq-option>
-      <bq-option value="dashboard">
-        <bq-icon slot="prefix" name="layout"></bq-icon>
-        <span>Dashboard</span>
-      </bq-option>
-      <bq-option value="reports">
-        <bq-icon slot="prefix" name="chart-bar"></bq-icon>
-        <span>Reports</span>
-      </bq-option>
-    </bq-option-list>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqIcon, BqOption, BqOptionList } from "@beeq/angular/standalone";
+
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqIcon, BqOption, BqOptionList],
+      template: `
+        <bq-option-list aria-label="Navigation links">
+          <bq-option value="home">
+            <bq-icon slot="prefix" name="house"></bq-icon>
+            <span>Home</span>
+          </bq-option>
+          <bq-option value="dashboard">
+            <bq-icon slot="prefix" name="layout"></bq-icon>
+            <span>Dashboard</span>
+          </bq-option>
+          <bq-option value="reports">
+            <bq-icon slot="prefix" name="chart-bar"></bq-icon>
+            <span>Reports</span>
+          </bq-option>
+        </bq-option-list>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/option-list.mdx
+++ b/apps/beeq-docs/components/option-list.mdx
@@ -136,7 +136,7 @@ A simple list with no groups. Each `bq-option` carries a `value` so the parent c
     </bq-option-list>
     ```
 
-    ```jsx React icon="react"
+    ```tsx React icon="react"
     import { BqIcon, BqOption, BqOptionList } from "@beeq/react";
 
     <BqOptionList>
@@ -255,7 +255,7 @@ Override `aria-label` when the default `"Options"` is too generic for the contex
     </bq-option-list>
     ```
 
-    ```jsx React icon="react"
+    ```tsx React icon="react"
     import { BqIcon, BqOption, BqOptionList } from "@beeq/react";
 
     <BqOptionList ariaLabel="Navigation links">
@@ -435,7 +435,7 @@ As a developer, you are responsible for:
 ## Resources
 
 <CardGroup cols={2}>
-  <Card horizontal title="Interactive playground" icon="code" href="https://storybook.beeq.design/?path=/story/components-option--default">
+  <Card horizontal title="Interactive playground" icon="code" href="https://storybook.beeq.design/?path=/story/components-option-list--default">
     Explore option list variants and states in Storybook
   </Card>
   <Card horizontal title="Source code" icon="github" href="https://github.com/Endava/BEEQ/tree/main/packages/beeq/src/components/option-list">

--- a/apps/beeq-docs/components/option.mdx
+++ b/apps/beeq-docs/components/option.mdx
@@ -1,0 +1,799 @@
+---
+title: Option
+description: Options are individual selectable items rendered inside a list, dropdown, or navigation menu, each carrying a label, an optional icon prefix, and an optional icon suffix.
+---
+
+import { CardTile } from '/snippets/CardTile.jsx';
+import { CodeLivePreview } from "/snippets/CodeLivePreview.jsx";
+
+<Frame className="px-4 py-4" caption="Option component overview">
+  <img className="block dark:hidden" src="/components/images/option/option-overview-light.svg" alt="BEEQ Option component overview" />
+  <img className="hidden dark:block" src="/components/images/option/option-overview-dark.svg" alt="BEEQ Option component overview" />
+</Frame>
+
+`bq-option` is a single selectable item inside a list-based UI control such as a dropdown, select, or navigation menu. It manages its own focused, selected, and disabled states, and communicates user interactions back to the parent through events.
+
+<Note>
+  `bq-option` must always be placed inside a `bq-option-list`, which provides the required `role="listbox"` context. Rendering an option outside a list breaks the ARIA relationship expected by assistive technologies.
+</Note>
+
+## When to use
+
+<CardGroup cols={2}>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="thumbs-up" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Use options when
+    </span>
+
+    * You need a single selectable item inside a dropdown, select, or menu
+    * The item requires a text label with optional prefix or suffix icons to add clarity
+    * The choice should be individually disableable without removing it from the list
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="thumbs-down" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Do not use options when
+    </span>
+
+    * You need a standalone interactive control — use `bq-button` or `bq-checkbox` instead
+    * The action is destructive and needs confirmation — surface it as a dialog or separate form element, not a list item
+    * The item will be displayed outside a `bq-option-list` context
+  </Card>
+</CardGroup>
+
+## Option patterns
+
+<CardGroup cols={3}>
+  <Card title="Label only">
+    The simplest form — a text label with no icon. Use for compact menus where space is limited and the labels are self-explanatory.
+  </Card>
+  <Card title="Prefix icon + label">
+    An icon to the left of the label visually categorizes the item. Use when the list contains many entries and users benefit from a quick visual scan.
+  </Card>
+  <Card title="Label + suffix icon">
+    An icon to the right of the label signals a secondary function — such as an external link, a shortcut key, or a status indicator. Use sparingly so it does not compete with the primary label.
+  </Card>
+</CardGroup>
+
+## Anatomy
+
+<Frame className="px-4 py-4" caption="Option component anatomy">
+  <img className="block dark:hidden" src="/components/images/option/option-anatomy-light.svg" alt="BEEQ Option component anatomy" />
+  <img className="hidden dark:block" src="/components/images/option/option-anatomy-dark.svg" alt="BEEQ Option component anatomy" />
+</Frame>
+
+Each option is a button-like surface with an optional prefix icon, a label, and an optional suffix icon. The three parts are spaced via dedicated CSS custom properties.
+
+| Part | Element | Description |
+|---|---|---|
+| **1** | Prefix | Optional slot for an icon or element rendered before the label |
+| **2** | Label | The main text content of the option |
+| **3** | Suffix | Optional slot for an icon or element rendered after the label |
+
+## Design guidelines
+
+### States
+
+<Note>
+  `bq-option` manages hover, focus, selected, and disabled styles automatically via internal CSS. You do not need to apply classes or attributes for these visual states — set the `selected` and `disabled` props and the component handles the rest.
+</Note>
+
+<CardGroup cols={2}>
+  <CardTile
+    title="Selected"
+    imageLightSrc="/components/images/option/option-state-selected-light.svg"
+    imageDarkSrc="/components/images/option/option-state-selected-dark.svg"
+  >
+    Setting `selected="true"` highlights the option with the brand accent color, signaling the current active choice to users.
+  </CardTile>
+
+  <CardTile
+    title="Disabled"
+    imageLightSrc="/components/images/option/option-state-disabled-light.svg"
+    imageDarkSrc="/components/images/option/option-state-disabled-dark.svg"
+  >
+    Setting `disabled="true"` mutes the option and blocks click and keyboard events without removing the item from the list. Use this when a choice is contextually unavailable rather than permanently absent.
+  </CardTile>
+</CardGroup>
+
+### Icon placement
+
+Place prefix icons when the list is long and icon-based scanning helps users find the right item quickly. Reserve the suffix slot for secondary information — an arrow indicating an external link, a keyboard shortcut, or a status badge — that does not compete with the label.
+
+<Steps>
+  <Step title="Prefix only">
+    The most common pattern. One icon on the left anchors the visual rhythm of the list and speeds up scanning.
+  </Step>
+  <Step title="Suffix only">
+    Use when the right-aligned indicator is the primary reason for the icon — for example, a link-out arrow that tells users this option opens a new page.
+  </Step>
+  <Step title="Prefix and suffix">
+    Acceptable for rich option lists where both a category icon (prefix) and a status indicator (suffix) genuinely add value. Avoid overusing this combination — it can make the list feel dense.
+  </Step>
+</Steps>
+
+## Usage
+
+### Default
+
+A simple list of options inside a `bq-option-list`. Each option carries a `value` attribute used by the parent to identify which item the user selected.
+
+<CodeLivePreview code={`
+  <bq-option-list>
+    <bq-option value="profile">
+      <span>User profile</span>
+    </bq-option>
+    <bq-option value="password">
+      <span>Change password</span>
+    </bq-option>
+    <bq-option value="logout">
+      <span>Close session</span>
+    </bq-option>
+  </bq-option-list>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-option-list>
+      <bq-option value="profile">
+        <span>User profile</span>
+      </bq-option>
+      <bq-option value="password">
+        <span>Change password</span>
+      </bq-option>
+      <bq-option value="logout">
+        <span>Close session</span>
+      </bq-option>
+    </bq-option-list>
+    ```
+
+    ```jsx React icon="react"
+    import { BqOption, BqOptionList } from "@beeq/react";
+
+    <BqOptionList>
+      <BqOption value="profile">
+        <span>User profile</span>
+      </BqOption>
+      <BqOption value="password">
+        <span>Change password</span>
+      </BqOption>
+      <BqOption value="logout">
+        <span>Close session</span>
+      </BqOption>
+    </BqOptionList>
+    ```
+
+    ```html Angular icon="angular"
+    <!-- Standalone: import { BqOption, BqOptionList } from "@beeq/angular/standalone" -->
+
+    <bq-option-list>
+      <bq-option value="profile">
+        <span>User profile</span>
+      </bq-option>
+      <bq-option value="password">
+        <span>Change password</span>
+      </bq-option>
+      <bq-option value="logout">
+        <span>Close session</span>
+      </bq-option>
+    </bq-option-list>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqOption, BqOptionList } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqOptionList>
+        <BqOption value="profile">
+          <span>User profile</span>
+        </BqOption>
+        <BqOption value="password">
+          <span>Change password</span>
+        </BqOption>
+        <BqOption value="logout">
+          <span>Close session</span>
+        </BqOption>
+      </BqOptionList>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### With prefix icon
+
+Add a `bq-icon` in the `prefix` slot to give each item a visual anchor. Icons make longer lists easier to scan and help users recognize options without reading every label.
+
+<CodeLivePreview code={`
+  <bq-option-list>
+    <bq-option value="profile">
+      <bq-icon slot="prefix" name="user"></bq-icon>
+      <span>User profile</span>
+    </bq-option>
+    <bq-option value="password">
+      <bq-icon slot="prefix" name="lock-simple"></bq-icon>
+      <span>Change password</span>
+    </bq-option>
+    <bq-option value="logout">
+      <bq-icon slot="prefix" name="sign-out"></bq-icon>
+      <span>Close session</span>
+    </bq-option>
+  </bq-option-list>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-option-list>
+      <bq-option value="profile">
+        <bq-icon slot="prefix" name="user"></bq-icon>
+        <span>User profile</span>
+      </bq-option>
+      <bq-option value="password">
+        <bq-icon slot="prefix" name="lock-simple"></bq-icon>
+        <span>Change password</span>
+      </bq-option>
+      <bq-option value="logout">
+        <bq-icon slot="prefix" name="sign-out"></bq-icon>
+        <span>Close session</span>
+      </bq-option>
+    </bq-option-list>
+    ```
+
+    ```jsx React icon="react"
+    import { BqIcon, BqOption, BqOptionList } from "@beeq/react";
+
+    <BqOptionList>
+      <BqOption value="profile">
+        <BqIcon slot="prefix" name="user" />
+        <span>User profile</span>
+      </BqOption>
+      <BqOption value="password">
+        <BqIcon slot="prefix" name="lock-simple" />
+        <span>Change password</span>
+      </BqOption>
+      <BqOption value="logout">
+        <BqIcon slot="prefix" name="sign-out" />
+        <span>Close session</span>
+      </BqOption>
+    </BqOptionList>
+    ```
+
+    ```html Angular icon="angular"
+    <bq-option-list>
+      <bq-option value="profile">
+        <bq-icon slot="prefix" name="user"></bq-icon>
+        <span>User profile</span>
+      </bq-option>
+      <bq-option value="password">
+        <bq-icon slot="prefix" name="lock-simple"></bq-icon>
+        <span>Change password</span>
+      </bq-option>
+      <bq-option value="logout">
+        <bq-icon slot="prefix" name="sign-out"></bq-icon>
+        <span>Close session</span>
+      </bq-option>
+    </bq-option-list>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqIcon, BqOption, BqOptionList } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqOptionList>
+        <BqOption value="profile">
+          <BqIcon slot="prefix" name="user" />
+          <span>User profile</span>
+        </BqOption>
+        <BqOption value="password">
+          <BqIcon slot="prefix" name="lock-simple" />
+          <span>Change password</span>
+        </BqOption>
+        <BqOption value="logout">
+          <BqIcon slot="prefix" name="sign-out" />
+          <span>Close session</span>
+        </BqOption>
+      </BqOptionList>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### With suffix icon
+
+Use the `suffix` slot for a right-aligned secondary indicator. Common uses include link-out arrows, keyboard shortcuts, or status icons.
+
+<CodeLivePreview code={`
+  <bq-option-list>
+    <bq-option value="profile">
+      <span>User profile</span>
+      <bq-icon slot="suffix" name="user"></bq-icon>
+    </bq-option>
+    <bq-option value="admin">
+      <span>Admin dashboard</span>
+      <bq-icon slot="suffix" name="layout"></bq-icon>
+    </bq-option>
+    <bq-option value="password">
+      <span>Change password</span>
+      <bq-icon slot="suffix" name="lock-simple"></bq-icon>
+    </bq-option>
+    <bq-option value="logout">
+      <span>Close session</span>
+      <bq-icon slot="suffix" name="sign-out"></bq-icon>
+    </bq-option>
+  </bq-option-list>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-option-list>
+      <bq-option value="profile">
+        <span>User profile</span>
+        <bq-icon slot="suffix" name="user"></bq-icon>
+      </bq-option>
+      <bq-option value="admin">
+        <span>Admin dashboard</span>
+        <bq-icon slot="suffix" name="layout"></bq-icon>
+      </bq-option>
+      <bq-option value="password">
+        <span>Change password</span>
+        <bq-icon slot="suffix" name="lock-simple"></bq-icon>
+      </bq-option>
+      <bq-option value="logout">
+        <span>Close session</span>
+        <bq-icon slot="suffix" name="sign-out"></bq-icon>
+      </bq-option>
+    </bq-option-list>
+    ```
+
+    ```jsx React icon="react"
+    import { BqIcon, BqOption, BqOptionList } from "@beeq/react";
+
+    <BqOptionList>
+      <BqOption value="profile">
+        <span>User profile</span>
+        <BqIcon slot="suffix" name="user" />
+      </BqOption>
+      <BqOption value="admin">
+        <span>Admin dashboard</span>
+        <BqIcon slot="suffix" name="layout" />
+      </BqOption>
+      <BqOption value="password">
+        <span>Change password</span>
+        <BqIcon slot="suffix" name="lock-simple" />
+      </BqOption>
+      <BqOption value="logout">
+        <span>Close session</span>
+        <BqIcon slot="suffix" name="sign-out" />
+      </BqOption>
+    </BqOptionList>
+    ```
+
+    ```html Angular icon="angular"
+    <bq-option-list>
+      <bq-option value="profile">
+        <span>User profile</span>
+        <bq-icon slot="suffix" name="user"></bq-icon>
+      </bq-option>
+      <bq-option value="admin">
+        <span>Admin dashboard</span>
+        <bq-icon slot="suffix" name="layout"></bq-icon>
+      </bq-option>
+      <bq-option value="password">
+        <span>Change password</span>
+        <bq-icon slot="suffix" name="lock-simple"></bq-icon>
+      </bq-option>
+      <bq-option value="logout">
+        <span>Close session</span>
+        <bq-icon slot="suffix" name="sign-out"></bq-icon>
+      </bq-option>
+    </bq-option-list>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqIcon, BqOption, BqOptionList } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqOptionList>
+        <BqOption value="profile">
+          <span>User profile</span>
+          <BqIcon slot="suffix" name="user" />
+        </BqOption>
+        <BqOption value="admin">
+          <span>Admin dashboard</span>
+          <BqIcon slot="suffix" name="layout" />
+        </BqOption>
+        <BqOption value="password">
+          <span>Change password</span>
+          <BqIcon slot="suffix" name="lock-simple" />
+        </BqOption>
+        <BqOption value="logout">
+          <span>Close session</span>
+          <BqIcon slot="suffix" name="sign-out" />
+        </BqOption>
+      </BqOptionList>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+## Options
+
+### Selected state
+
+Set `selected` on the option that reflects the current active value. The component applies the brand accent styling automatically.
+
+<CodeLivePreview code={`
+  <bq-option-list>
+    <bq-option selected value="profile">
+      <bq-icon slot="prefix" name="user"></bq-icon>
+      <span>User profile</span>
+    </bq-option>
+    <bq-option value="password">
+      <bq-icon slot="prefix" name="lock-simple"></bq-icon>
+      <span>Change password</span>
+    </bq-option>
+    <bq-option value="logout">
+      <bq-icon slot="prefix" name="sign-out"></bq-icon>
+      <span>Close session</span>
+    </bq-option>
+  </bq-option-list>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-option-list>
+      <bq-option selected value="profile">
+        <bq-icon slot="prefix" name="user"></bq-icon>
+        <span>User profile</span>
+      </bq-option>
+      <bq-option value="password">
+        <bq-icon slot="prefix" name="lock-simple"></bq-icon>
+        <span>Change password</span>
+      </bq-option>
+      <bq-option value="logout">
+        <bq-icon slot="prefix" name="sign-out"></bq-icon>
+        <span>Close session</span>
+      </bq-option>
+    </bq-option-list>
+    ```
+
+    ```jsx React icon="react"
+    import { BqIcon, BqOption, BqOptionList } from "@beeq/react";
+
+    <BqOptionList>
+      <BqOption selected value="profile">
+        <BqIcon slot="prefix" name="user" />
+        <span>User profile</span>
+      </BqOption>
+      <BqOption value="password">
+        <BqIcon slot="prefix" name="lock-simple" />
+        <span>Change password</span>
+      </BqOption>
+      <BqOption value="logout">
+        <BqIcon slot="prefix" name="sign-out" />
+        <span>Close session</span>
+      </BqOption>
+    </BqOptionList>
+    ```
+
+    ```html Angular icon="angular"
+    <bq-option-list>
+      <bq-option [selected]="true" value="profile">
+        <bq-icon slot="prefix" name="user"></bq-icon>
+        <span>User profile</span>
+      </bq-option>
+      <bq-option value="password">
+        <bq-icon slot="prefix" name="lock-simple"></bq-icon>
+        <span>Change password</span>
+      </bq-option>
+      <bq-option value="logout">
+        <bq-icon slot="prefix" name="sign-out"></bq-icon>
+        <span>Close session</span>
+      </bq-option>
+    </bq-option-list>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqIcon, BqOption, BqOptionList } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqOptionList>
+        <BqOption :selected="true" value="profile">
+          <BqIcon slot="prefix" name="user" />
+          <span>User profile</span>
+        </BqOption>
+        <BqOption value="password">
+          <BqIcon slot="prefix" name="lock-simple" />
+          <span>Change password</span>
+        </BqOption>
+        <BqOption value="logout">
+          <BqIcon slot="prefix" name="sign-out" />
+          <span>Close session</span>
+        </BqOption>
+      </BqOptionList>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Disabled state
+
+Set `disabled` on individual options to mark them as contextually unavailable. Disabled options remain visible in the list but do not respond to clicks or keyboard events.
+
+<CodeLivePreview code={`
+  <bq-option-list>
+    <bq-option value="profile">
+      <bq-icon slot="prefix" name="user"></bq-icon>
+      <span>User profile</span>
+    </bq-option>
+    <bq-option disabled value="admin">
+      <bq-icon slot="prefix" name="layout"></bq-icon>
+      <span>Admin dashboard</span>
+    </bq-option>
+    <bq-option value="password">
+      <bq-icon slot="prefix" name="lock-simple"></bq-icon>
+      <span>Change password</span>
+    </bq-option>
+    <bq-option value="logout">
+      <bq-icon slot="prefix" name="sign-out"></bq-icon>
+      <span>Close session</span>
+    </bq-option>
+  </bq-option-list>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-option-list>
+      <bq-option value="profile">
+        <bq-icon slot="prefix" name="user"></bq-icon>
+        <span>User profile</span>
+      </bq-option>
+      <bq-option disabled value="admin">
+        <bq-icon slot="prefix" name="layout"></bq-icon>
+        <span>Admin dashboard</span>
+      </bq-option>
+      <bq-option value="password">
+        <bq-icon slot="prefix" name="lock-simple"></bq-icon>
+        <span>Change password</span>
+      </bq-option>
+      <bq-option value="logout">
+        <bq-icon slot="prefix" name="sign-out"></bq-icon>
+        <span>Close session</span>
+      </bq-option>
+    </bq-option-list>
+    ```
+
+    ```jsx React icon="react"
+    import { BqIcon, BqOption, BqOptionList } from "@beeq/react";
+
+    <BqOptionList>
+      <BqOption value="profile">
+        <BqIcon slot="prefix" name="user" />
+        <span>User profile</span>
+      </BqOption>
+      <BqOption disabled value="admin">
+        <BqIcon slot="prefix" name="layout" />
+        <span>Admin dashboard</span>
+      </BqOption>
+      <BqOption value="password">
+        <BqIcon slot="prefix" name="lock-simple" />
+        <span>Change password</span>
+      </BqOption>
+      <BqOption value="logout">
+        <BqIcon slot="prefix" name="sign-out" />
+        <span>Close session</span>
+      </BqOption>
+    </BqOptionList>
+    ```
+
+    ```html Angular icon="angular"
+    <bq-option-list>
+      <bq-option value="profile">
+        <bq-icon slot="prefix" name="user"></bq-icon>
+        <span>User profile</span>
+      </bq-option>
+      <bq-option [disabled]="true" value="admin">
+        <bq-icon slot="prefix" name="layout"></bq-icon>
+        <span>Admin dashboard</span>
+      </bq-option>
+      <bq-option value="password">
+        <bq-icon slot="prefix" name="lock-simple"></bq-icon>
+        <span>Change password</span>
+      </bq-option>
+      <bq-option value="logout">
+        <bq-icon slot="prefix" name="sign-out"></bq-icon>
+        <span>Close session</span>
+      </bq-option>
+    </bq-option-list>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqIcon, BqOption, BqOptionList } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqOptionList>
+        <BqOption value="profile">
+          <BqIcon slot="prefix" name="user" />
+          <span>User profile</span>
+        </BqOption>
+        <BqOption :disabled="true" value="admin">
+          <BqIcon slot="prefix" name="layout" />
+          <span>Admin dashboard</span>
+        </BqOption>
+        <BqOption value="password">
+          <BqIcon slot="prefix" name="lock-simple" />
+          <span>Change password</span>
+        </BqOption>
+        <BqOption value="logout">
+          <BqIcon slot="prefix" name="sign-out" />
+          <span>Close session</span>
+        </BqOption>
+      </BqOptionList>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+<Tip>
+  To organize options into labeled sections, wrap `bq-option` elements in [`bq-option-group`](/components/option-group) and place the groups inside a `bq-option-list`. The [Option Group](/components/option-group) page has full code examples including header prefix and suffix customization.
+</Tip>
+
+## Best practices
+
+<CardGroup cols={2}>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Always provide a `value` attribute on each option so the parent component can identify which item was selected.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Omit the `value` attribute. Without it, the parent `bq-option-list` or select-like component cannot distinguish which option the user chose.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Use `disabled` for options that are temporarily unavailable in the current context — keeping them visible signals that the feature exists.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Use `hidden` as a permanent way to remove an option. If an option is never relevant for the user, remove it from the DOM entirely instead.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Keep option labels short and descriptive — one to four words that clearly identify the action or destination.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Write long sentences as option labels. Long labels break the visual rhythm of the list and make scanning harder.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Use consistent icon placement across all options in the same list — either all with prefix icons or all without.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Mix options with icons and options without icons in the same list — the uneven spacing makes the list look misaligned.
+  </Card>
+</CardGroup>
+
+## Accessibility
+
+`bq-option` sets `role="option"` on its host element automatically. It also manages the following ARIA attributes based on its props:
+
+- `aria-selected="true"` is set when `selected` is `true`, communicating the active choice to screen readers.
+- `aria-disabled` is always present on the host. It is set to `"true"` when `disabled` or `hidden` is `true`, and to `"false"` otherwise, ensuring assistive technologies always have the correct interactive state.
+- `aria-hidden="true"` is set when `hidden` is `true`, removing the item from the accessibility tree entirely.
+
+As a developer, you are responsible for:
+
+- **Placing options inside `bq-option-list`** — the `role="option"` on each item requires a `role="listbox"` ancestor, which `bq-option-list` provides. Rendering options outside this context breaks the ARIA relationship.
+- **Providing meaningful labels** — the text inside the default slot is read by screen readers as the option's accessible name. Avoid icon-only options; always include a visible text label.
+- **Keyboard navigation** — `bq-option` listens for `Enter` keydown and emits `bqEnter`. The parent `bq-option-list` handles `ArrowUp`/`ArrowDown` focus management. Do not intercept these keys in your own handlers unless you are building a custom container.
+
+## API reference
+
+### Properties
+
+| Property | Attribute | Description | Type | Default |
+|---|---|---|---|---|
+| `disabled` | `disabled` | If true, the option is disabled | `boolean` | `false` |
+| `displayValue` | `display-value` | Overrides the default displayed value of the option | `string` | — |
+| `hidden` | `hidden` | If true, the option is hidden | `boolean` | `false` |
+| `selected` | `selected` | If true, the option is selected and active | `boolean` | `false` |
+| `value` | `value` | A string used to identify the option | `string` | — |
+
+### Events
+
+| Event | Description | Type |
+|---|---|---|
+| `bqBlur` | Emitted when the option loses focus | `CustomEvent<HTMLBqOptionElement>` |
+| `bqClick` | Emitted when the option is clicked | `CustomEvent<HTMLBqOptionElement>` |
+| `bqEnter` | Emitted when Enter is pressed while the option is focused | `CustomEvent<HTMLBqOptionElement>` |
+| `bqFocus` | Emitted when the option receives focus | `CustomEvent<HTMLBqOptionElement>` |
+
+### Slots
+
+| Slot | Description |
+|---|---|
+| *(default)* | The label text content of the option |
+| `prefix` | Content rendered before the label — typically a `bq-icon` |
+| `suffix` | Content rendered after the label — typically a `bq-icon` |
+
+### Shadow parts
+
+| Part | Description |
+|---|---|
+| `base` | The internal `<button>` wrapper of the option |
+| `label` | The `<span>` element containing the label text |
+| `prefix` | The `<span>` element wrapping the prefix slot content |
+| `suffix` | The `<span>` element wrapping the suffix slot content |
+
+### CSS custom properties
+
+<Expandable title="CSS variables" defaultOpen={true}>
+  | Variable | Description | Default |
+  |---|---|---|
+  | `--bq-option--background` | Option background color | `var(--bq-ui--primary)` |
+  | `--bq-option--font-size` | Option label font size | `var(--bq-font-size--m)` |
+  | `--bq-option--border-color` | Option border color | `transparent` |
+  | `--bq-option--border-style` | Option border style | `none` |
+  | `--bq-option--border-width` | Option border width | `0` |
+  | `--bq-option--border-radius` | Option border radius | `var(--bq-radius--s)` |
+  | `--bq-option--box-shadow` | Option box shadow | `none` |
+  | `--bq-option--gap-start` | Gap between prefix icon and label | `var(--bq-spacing-s)` |
+  | `--bq-option--gap-end` | Gap between label and suffix icon | `var(--bq-spacing-s)` |
+  | `--bq-option--paddingY` | Vertical padding | `var(--bq-spacing-xs)` |
+  | `--bq-option--padding-start` | Inline-start padding | `var(--bq-spacing-s)` |
+  | `--bq-option--padding-end` | Inline-end padding | `var(--bq-spacing-s)` |
+</Expandable>
+
+<Tip>
+  Learn more about [styling with shadow parts](/theming/styles) and [CSS custom properties](/theming/global-css-variables).
+</Tip>
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card horizontal title="Interactive playground" icon="code" href="https://storybook.beeq.design/?path=/story/components-option--default">
+    Explore option variants and states in Storybook
+  </Card>
+  <Card horizontal title="Source code" icon="github" href="https://github.com/Endava/BEEQ/tree/main/packages/beeq/src/components/option">
+    View the component source on GitHub
+  </Card>
+</CardGroup>

--- a/apps/beeq-docs/components/option.mdx
+++ b/apps/beeq-docs/components/option.mdx
@@ -148,7 +148,7 @@ A simple list of options inside a `bq-option-list`. Each option carries a `value
     </bq-option-list>
     ```
 
-    ```jsx React icon="react"
+    ```tsx React icon="react"
     import { BqOption, BqOptionList } from "@beeq/react";
 
     <BqOptionList>
@@ -240,7 +240,7 @@ Add a `bq-icon` in the `prefix` slot to give each item a visual anchor. Icons ma
     </bq-option-list>
     ```
 
-    ```jsx React icon="react"
+    ```tsx React icon="react"
     import { BqIcon, BqOption, BqOptionList } from "@beeq/react";
 
     <BqOptionList>
@@ -347,7 +347,7 @@ Use the `suffix` slot for a right-aligned secondary indicator. Common uses inclu
     </bq-option-list>
     ```
 
-    ```jsx React icon="react"
+    ```tsx React icon="react"
     import { BqIcon, BqOption, BqOptionList } from "@beeq/react";
 
     <BqOptionList>
@@ -460,7 +460,7 @@ Set `selected` on the option that reflects the current active value. The compone
     </bq-option-list>
     ```
 
-    ```jsx React icon="react"
+    ```tsx React icon="react"
     import { BqIcon, BqOption, BqOptionList } from "@beeq/react";
 
     <BqOptionList>
@@ -567,7 +567,7 @@ Set `disabled` on individual options to mark them as contextually unavailable. D
     </bq-option-list>
     ```
 
-    ```jsx React icon="react"
+    ```tsx React icon="react"
     import { BqIcon, BqOption, BqOptionList } from "@beeq/react";
 
     <BqOptionList>

--- a/apps/beeq-docs/components/option.mdx
+++ b/apps/beeq-docs/components/option.mdx
@@ -186,7 +186,7 @@ A simple list of options inside a `bq-option-list`. Each option carries a `value
         </bq-option-list>
       `,
     })
-    export class AppComponent {}
+    export class DefaultOptionComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -293,7 +293,7 @@ Add a `bq-icon` in the `prefix` slot to give each item a visual anchor. Icons ma
         </bq-option-list>
       `,
     })
-    export class AppComponent {}
+    export class OptionWithPrefixIconComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -419,7 +419,7 @@ Use the `suffix` slot for a right-aligned secondary indicator. Common uses inclu
         </bq-option-list>
       `,
     })
-    export class AppComponent {}
+    export class OptionWithSuffixIconComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -535,7 +535,7 @@ Set `selected` on the option that reflects the current active value. The compone
         </bq-option-list>
       `,
     })
-    export class AppComponent {}
+    export class SelectedOptionComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -661,7 +661,7 @@ Set `disabled` on individual options to mark them as contextually unavailable. D
         </bq-option-list>
       `,
     })
-    export class AppComponent {}
+    export class DisabledOptionComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -676,6 +676,136 @@ Set `disabled` on individual options to mark them as contextually unavailable. D
           <span>User profile</span>
         </BqOption>
         <BqOption :disabled="true" value="admin">
+          <BqIcon slot="prefix" name="layout" />
+          <span>Admin dashboard</span>
+        </BqOption>
+        <BqOption value="password">
+          <BqIcon slot="prefix" name="lock-simple" />
+          <span>Change password</span>
+        </BqOption>
+        <BqOption value="logout">
+          <BqIcon slot="prefix" name="sign-out" />
+          <span>Close session</span>
+        </BqOption>
+      </BqOptionList>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Hidden state
+
+Set `hidden` on an option to remove it from the visible list and the accessibility tree while keeping it in the DOM. Unlike `disabled`, a hidden option is completely invisible — screen readers skip it and it cannot be focused. Use this for options that are programmatically toggled based on application state.
+
+<CodeLivePreview code={`
+  <bq-option-list>
+    <bq-option value="profile">
+      <bq-icon slot="prefix" name="user"></bq-icon>
+      <span>User profile</span>
+    </bq-option>
+    <bq-option hidden value="admin">
+      <bq-icon slot="prefix" name="layout"></bq-icon>
+      <span>Admin dashboard</span>
+    </bq-option>
+    <bq-option value="password">
+      <bq-icon slot="prefix" name="lock-simple"></bq-icon>
+      <span>Change password</span>
+    </bq-option>
+    <bq-option value="logout">
+      <bq-icon slot="prefix" name="sign-out"></bq-icon>
+      <span>Close session</span>
+    </bq-option>
+  </bq-option-list>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-option-list>
+      <bq-option value="profile">
+        <bq-icon slot="prefix" name="user"></bq-icon>
+        <span>User profile</span>
+      </bq-option>
+      <bq-option hidden value="admin">
+        <bq-icon slot="prefix" name="layout"></bq-icon>
+        <span>Admin dashboard</span>
+      </bq-option>
+      <bq-option value="password">
+        <bq-icon slot="prefix" name="lock-simple"></bq-icon>
+        <span>Change password</span>
+      </bq-option>
+      <bq-option value="logout">
+        <bq-icon slot="prefix" name="sign-out"></bq-icon>
+        <span>Close session</span>
+      </bq-option>
+    </bq-option-list>
+    ```
+
+    ```tsx React icon="react"
+    import { BqIcon, BqOption, BqOptionList } from "@beeq/react";
+
+    <BqOptionList>
+      <BqOption value="profile">
+        <BqIcon slot="prefix" name="user" />
+        <span>User profile</span>
+      </BqOption>
+      <BqOption hidden value="admin">
+        <BqIcon slot="prefix" name="layout" />
+        <span>Admin dashboard</span>
+      </BqOption>
+      <BqOption value="password">
+        <BqIcon slot="prefix" name="lock-simple" />
+        <span>Change password</span>
+      </BqOption>
+      <BqOption value="logout">
+        <BqIcon slot="prefix" name="sign-out" />
+        <span>Close session</span>
+      </BqOption>
+    </BqOptionList>
+    ```
+
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqIcon, BqOption, BqOptionList } from "@beeq/angular/standalone";
+
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqIcon, BqOption, BqOptionList],
+      template: `
+        <bq-option-list>
+          <bq-option value="profile">
+            <bq-icon slot="prefix" name="user"></bq-icon>
+            <span>User profile</span>
+          </bq-option>
+          <bq-option [hidden]="true" value="admin">
+            <bq-icon slot="prefix" name="layout"></bq-icon>
+            <span>Admin dashboard</span>
+          </bq-option>
+          <bq-option value="password">
+            <bq-icon slot="prefix" name="lock-simple"></bq-icon>
+            <span>Change password</span>
+          </bq-option>
+          <bq-option value="logout">
+            <bq-icon slot="prefix" name="sign-out"></bq-icon>
+            <span>Close session</span>
+          </bq-option>
+        </bq-option-list>
+      `,
+    })
+    export class HiddenOptionComponent {}
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqIcon, BqOption, BqOptionList } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqOptionList>
+        <BqOption value="profile">
+          <BqIcon slot="prefix" name="user" />
+          <span>User profile</span>
+        </BqOption>
+        <BqOption :hidden="true" value="admin">
           <BqIcon slot="prefix" name="layout" />
           <span>Admin dashboard</span>
         </BqOption>
@@ -837,7 +967,7 @@ As a developer, you are responsible for:
 </Expandable>
 
 <Tip>
-  Learn more about [styling with shadow parts](/theming/styles) and [CSS custom properties](/theming/global-css-variables).
+  Learn more about [styling with shadow parts](/guides/styles) and [CSS custom properties](/theming/global-css-variables).
 </Tip>
 
 ## Resources

--- a/apps/beeq-docs/components/option.mdx
+++ b/apps/beeq-docs/components/option.mdx
@@ -164,20 +164,29 @@ A simple list of options inside a `bq-option-list`. Each option carries a `value
     </BqOptionList>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqOption, BqOptionList } from "@beeq/angular/standalone" -->
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqOption, BqOptionList } from "@beeq/angular/standalone";
 
-    <bq-option-list>
-      <bq-option value="profile">
-        <span>User profile</span>
-      </bq-option>
-      <bq-option value="password">
-        <span>Change password</span>
-      </bq-option>
-      <bq-option value="logout">
-        <span>Close session</span>
-      </bq-option>
-    </bq-option-list>
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqOption, BqOptionList],
+      template: `
+        <bq-option-list>
+          <bq-option value="profile">
+            <span>User profile</span>
+          </bq-option>
+          <bq-option value="password">
+            <span>Change password</span>
+          </bq-option>
+          <bq-option value="logout">
+            <span>Close session</span>
+          </bq-option>
+        </bq-option-list>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -259,21 +268,32 @@ Add a `bq-icon` in the `prefix` slot to give each item a visual anchor. Icons ma
     </BqOptionList>
     ```
 
-    ```html Angular icon="angular"
-    <bq-option-list>
-      <bq-option value="profile">
-        <bq-icon slot="prefix" name="user"></bq-icon>
-        <span>User profile</span>
-      </bq-option>
-      <bq-option value="password">
-        <bq-icon slot="prefix" name="lock-simple"></bq-icon>
-        <span>Change password</span>
-      </bq-option>
-      <bq-option value="logout">
-        <bq-icon slot="prefix" name="sign-out"></bq-icon>
-        <span>Close session</span>
-      </bq-option>
-    </bq-option-list>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqIcon, BqOption, BqOptionList } from "@beeq/angular/standalone";
+
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqIcon, BqOption, BqOptionList],
+      template: `
+        <bq-option-list>
+          <bq-option value="profile">
+            <bq-icon slot="prefix" name="user"></bq-icon>
+            <span>User profile</span>
+          </bq-option>
+          <bq-option value="password">
+            <bq-icon slot="prefix" name="lock-simple"></bq-icon>
+            <span>Change password</span>
+          </bq-option>
+          <bq-option value="logout">
+            <bq-icon slot="prefix" name="sign-out"></bq-icon>
+            <span>Close session</span>
+          </bq-option>
+        </bq-option-list>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -370,25 +390,36 @@ Use the `suffix` slot for a right-aligned secondary indicator. Common uses inclu
     </BqOptionList>
     ```
 
-    ```html Angular icon="angular"
-    <bq-option-list>
-      <bq-option value="profile">
-        <span>User profile</span>
-        <bq-icon slot="suffix" name="user"></bq-icon>
-      </bq-option>
-      <bq-option value="admin">
-        <span>Admin dashboard</span>
-        <bq-icon slot="suffix" name="layout"></bq-icon>
-      </bq-option>
-      <bq-option value="password">
-        <span>Change password</span>
-        <bq-icon slot="suffix" name="lock-simple"></bq-icon>
-      </bq-option>
-      <bq-option value="logout">
-        <span>Close session</span>
-        <bq-icon slot="suffix" name="sign-out"></bq-icon>
-      </bq-option>
-    </bq-option-list>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqIcon, BqOption, BqOptionList } from "@beeq/angular/standalone";
+
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqIcon, BqOption, BqOptionList],
+      template: `
+        <bq-option-list>
+          <bq-option value="profile">
+            <span>User profile</span>
+            <bq-icon slot="suffix" name="user"></bq-icon>
+          </bq-option>
+          <bq-option value="admin">
+            <span>Admin dashboard</span>
+            <bq-icon slot="suffix" name="layout"></bq-icon>
+          </bq-option>
+          <bq-option value="password">
+            <span>Change password</span>
+            <bq-icon slot="suffix" name="lock-simple"></bq-icon>
+          </bq-option>
+          <bq-option value="logout">
+            <span>Close session</span>
+            <bq-icon slot="suffix" name="sign-out"></bq-icon>
+          </bq-option>
+        </bq-option-list>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -479,21 +510,32 @@ Set `selected` on the option that reflects the current active value. The compone
     </BqOptionList>
     ```
 
-    ```html Angular icon="angular"
-    <bq-option-list>
-      <bq-option [selected]="true" value="profile">
-        <bq-icon slot="prefix" name="user"></bq-icon>
-        <span>User profile</span>
-      </bq-option>
-      <bq-option value="password">
-        <bq-icon slot="prefix" name="lock-simple"></bq-icon>
-        <span>Change password</span>
-      </bq-option>
-      <bq-option value="logout">
-        <bq-icon slot="prefix" name="sign-out"></bq-icon>
-        <span>Close session</span>
-      </bq-option>
-    </bq-option-list>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqIcon, BqOption, BqOptionList } from "@beeq/angular/standalone";
+
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqIcon, BqOption, BqOptionList],
+      template: `
+        <bq-option-list>
+          <bq-option [selected]="true" value="profile">
+            <bq-icon slot="prefix" name="user"></bq-icon>
+            <span>User profile</span>
+          </bq-option>
+          <bq-option value="password">
+            <bq-icon slot="prefix" name="lock-simple"></bq-icon>
+            <span>Change password</span>
+          </bq-option>
+          <bq-option value="logout">
+            <bq-icon slot="prefix" name="sign-out"></bq-icon>
+            <span>Close session</span>
+          </bq-option>
+        </bq-option-list>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -590,25 +632,36 @@ Set `disabled` on individual options to mark them as contextually unavailable. D
     </BqOptionList>
     ```
 
-    ```html Angular icon="angular"
-    <bq-option-list>
-      <bq-option value="profile">
-        <bq-icon slot="prefix" name="user"></bq-icon>
-        <span>User profile</span>
-      </bq-option>
-      <bq-option [disabled]="true" value="admin">
-        <bq-icon slot="prefix" name="layout"></bq-icon>
-        <span>Admin dashboard</span>
-      </bq-option>
-      <bq-option value="password">
-        <bq-icon slot="prefix" name="lock-simple"></bq-icon>
-        <span>Change password</span>
-      </bq-option>
-      <bq-option value="logout">
-        <bq-icon slot="prefix" name="sign-out"></bq-icon>
-        <span>Close session</span>
-      </bq-option>
-    </bq-option-list>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqIcon, BqOption, BqOptionList } from "@beeq/angular/standalone";
+
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqIcon, BqOption, BqOptionList],
+      template: `
+        <bq-option-list>
+          <bq-option value="profile">
+            <bq-icon slot="prefix" name="user"></bq-icon>
+            <span>User profile</span>
+          </bq-option>
+          <bq-option [disabled]="true" value="admin">
+            <bq-icon slot="prefix" name="layout"></bq-icon>
+            <span>Admin dashboard</span>
+          </bq-option>
+          <bq-option value="password">
+            <bq-icon slot="prefix" name="lock-simple"></bq-icon>
+            <span>Change password</span>
+          </bq-option>
+          <bq-option value="logout">
+            <bq-icon slot="prefix" name="sign-out"></bq-icon>
+            <span>Close session</span>
+          </bq-option>
+        </bq-option-list>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/select.mdx
+++ b/apps/beeq-docs/components/select.mdx
@@ -413,44 +413,34 @@ The `displayValue` property (`display-value` attribute) on `bq-option` overrides
   <style>
     bq-select::part(panel) { z-index: 12; }
 
-    .flex {
+    .payment-option {
       display: flex;
-    }
-
-    .flex-col {
       flex-direction: column;
-    }
-
-    .items-center {
-      align-items: center;
-    }
-
-    .gap-xs {
-      gap: var(--bq-spacing-xs);
-    }
-
-    .gap-xs2 {
       gap: var(--bq-spacing-xs2);
     }
 
-    .text-secondary {
+    .payment-option__header {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+
+    .payment-option__name {
+      font-weight: 600;
+    }
+
+    .payment-option__meta,
+    .payment-option__owner {
+      padding-inline-start: 28px;
       color: var(--bq-text--secondary);
     }
 
-    .text-s {
+    .payment-option__meta {
       font-size: var(--bq-font-size--s);
     }
 
-    .text-xs {
+    .payment-option__owner {
       font-size: var(--bq-font-size--xs);
-    }
-
-    .option-indent {
-      padding-inline-start: 28px;
-    }
-
-    .font-semibold {
-      font-weight: 600;
     }
   </style>
 
@@ -460,37 +450,69 @@ The `displayValue` property (`display-value` attribute) on `bq-option` overrides
       You will not be charged until you review your order on the next page
     </span>
     <bq-option value="visa-1234" display-value="Visa •••• 1234">
-      <div class="flex flex-col gap-xs2">
-        <div class="flex items-center gap-xs">
+      <div class="payment-option">
+        <div class="payment-option__header">
           <bq-icon name="credit-card" size="20"></bq-icon>
-          <span class="font-semibold">Visa ending in 1234</span>
+          <span class="payment-option__name">Visa ending in 1234</span>
         </div>
-        <span class="text-secondary text-s option-indent">Expires 12/2025</span>
-        <span class="text-secondary text-xs option-indent">John Doe</span>
+        <span class="payment-option__meta">Expires 12/2025</span>
+        <span class="payment-option__owner">John Doe</span>
       </div>
     </bq-option>
     <bq-option value="mastercard-5678" display-value="Mastercard •••• 5678">
-      <div class="flex flex-col gap-xs2">
-        <div class="flex items-center gap-xs">
+      <div class="payment-option">
+        <div class="payment-option__header">
           <bq-icon name="credit-card" size="20"></bq-icon>
-          <span class="font-semibold">Mastercard ending in 5678</span>
+          <span class="payment-option__name">Mastercard ending in 5678</span>
         </div>
-        <span class="text-secondary text-s option-indent">Expires 08/2026</span>
-        <span class="text-secondary text-xs option-indent">Jane Smith</span>
+        <span class="payment-option__meta">Expires 08/2026</span>
+        <span class="payment-option__owner">Jane Smith</span>
       </div>
     </bq-option>
     <bq-option value="paypal" display-value="PayPal">
-      <div class="flex flex-col gap-xs2">
-        <div class="flex items-center gap-xs">
+      <div class="payment-option">
+        <div class="payment-option__header">
           <bq-icon name="paypal-logo" size="20"></bq-icon>
-          <span class="font-semibold">Pay with PayPal</span>
+          <span class="payment-option__name">Pay with PayPal</span>
         </div>
-        <span class="text-secondary text-s option-indent">john.doe@email.com</span>
+        <span class="payment-option__meta">john.doe@email.com</span>
       </div>
     </bq-option>
   </bq-select>
 `}>
   <CodeGroup>
+    ```css payment-option.css icon="css3"
+    .payment-option {
+      display: flex;
+      flex-direction: column;
+      gap: var(--bq-spacing-xs2);
+    }
+
+    .payment-option__header {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+
+    .payment-option__name {
+      font-weight: 600;
+    }
+
+    .payment-option__meta,
+    .payment-option__owner {
+      padding-inline-start: 28px;
+      color: var(--bq-text--secondary);
+    }
+
+    .payment-option__meta {
+      font-size: var(--bq-font-size--s);
+    }
+
+    .payment-option__owner {
+      font-size: var(--bq-font-size--xs);
+    }
+    ```
+
     ```html HTML icon="html5"
     <bq-select placeholder="Payment method..." open>
       <label slot="label">Choose a payment method</label>
@@ -498,32 +520,32 @@ The `displayValue` property (`display-value` attribute) on `bq-option` overrides
         You will not be charged until you review your order on the next page
       </span>
       <bq-option value="visa-1234" display-value="Visa •••• 1234">
-        <div class="flex flex-col gap-xs2">
-          <div class="flex items-center gap-xs">
+        <div class="payment-option">
+          <div class="payment-option__header">
             <bq-icon name="credit-card" size="20"></bq-icon>
-            <span class="font-semibold">Visa ending in 1234</span>
+            <span class="payment-option__name">Visa ending in 1234</span>
           </div>
-          <span class="text-secondary text-s option-indent">Expires 12/2025</span>
-          <span class="text-secondary text-xs option-indent">John Doe</span>
+          <span class="payment-option__meta">Expires 12/2025</span>
+          <span class="payment-option__owner">John Doe</span>
         </div>
       </bq-option>
       <bq-option value="mastercard-5678" display-value="Mastercard •••• 5678">
-        <div class="flex flex-col gap-xs2">
-          <div class="flex items-center gap-xs">
+        <div class="payment-option">
+          <div class="payment-option__header">
             <bq-icon name="credit-card" size="20"></bq-icon>
-            <span class="font-semibold">Mastercard ending in 5678</span>
+            <span class="payment-option__name">Mastercard ending in 5678</span>
           </div>
-          <span class="text-secondary text-s option-indent">Expires 08/2026</span>
-          <span class="text-secondary text-xs option-indent">Jane Smith</span>
+          <span class="payment-option__meta">Expires 08/2026</span>
+          <span class="payment-option__owner">Jane Smith</span>
         </div>
       </bq-option>
       <bq-option value="paypal" display-value="PayPal">
-        <div class="flex flex-col gap-xs2">
-          <div class="flex items-center gap-xs">
+        <div class="payment-option">
+          <div class="payment-option__header">
             <bq-icon name="paypal-logo" size="20"></bq-icon>
-            <span class="font-semibold">Pay with PayPal</span>
+            <span class="payment-option__name">Pay with PayPal</span>
           </div>
-          <span class="text-secondary text-s option-indent">john.doe@email.com</span>
+          <span class="payment-option__meta">john.doe@email.com</span>
         </div>
       </bq-option>
     </bq-select>
@@ -531,6 +553,7 @@ The `displayValue` property (`display-value` attribute) on `bq-option` overrides
 
     ```jsx React icon="react"
     import { BqIcon, BqOption, BqSelect } from "@beeq/react";
+    import "./payment-option.css";
 
     <BqSelect placeholder="Payment method..." open>
       <label slot="label">Choose a payment method</label>
@@ -538,32 +561,32 @@ The `displayValue` property (`display-value` attribute) on `bq-option` overrides
         You will not be charged until you review your order on the next page
       </span>
       <BqOption value="visa-1234" displayValue="Visa •••• 1234">
-        <div className="flex flex-col gap-xs2">
-          <div className="flex items-center gap-xs">
+        <div className="payment-option">
+          <div className="payment-option__header">
             <BqIcon name="credit-card" size="20" />
-            <span className="font-semibold">Visa ending in 1234</span>
+            <span className="payment-option__name">Visa ending in 1234</span>
           </div>
-          <span className="text-secondary text-s option-indent">Expires 12/2025</span>
-          <span className="text-secondary text-xs option-indent">John Doe</span>
+          <span className="payment-option__meta">Expires 12/2025</span>
+          <span className="payment-option__owner">John Doe</span>
         </div>
       </BqOption>
       <BqOption value="mastercard-5678" displayValue="Mastercard •••• 5678">
-        <div className="flex flex-col gap-xs2">
-          <div className="flex items-center gap-xs">
+        <div className="payment-option">
+          <div className="payment-option__header">
             <BqIcon name="credit-card" size="20" />
-            <span className="font-semibold">Mastercard ending in 5678</span>
+            <span className="payment-option__name">Mastercard ending in 5678</span>
           </div>
-          <span className="text-secondary text-s option-indent">Expires 08/2026</span>
-          <span className="text-secondary text-xs option-indent">Jane Smith</span>
+          <span className="payment-option__meta">Expires 08/2026</span>
+          <span className="payment-option__owner">Jane Smith</span>
         </div>
       </BqOption>
       <BqOption value="paypal" displayValue="PayPal">
-        <div className="flex flex-col gap-xs2">
-          <div className="flex items-center gap-xs">
+        <div className="payment-option">
+          <div className="payment-option__header">
             <BqIcon name="paypal-logo" size="20" />
-            <span className="font-semibold">Pay with PayPal</span>
+            <span className="payment-option__name">Pay with PayPal</span>
           </div>
-          <span className="text-secondary text-s option-indent">john.doe@email.com</span>
+          <span className="payment-option__meta">john.doe@email.com</span>
         </div>
       </BqOption>
     </BqSelect>
@@ -583,41 +606,78 @@ The `displayValue` property (`display-value` attribute) on `bq-option` overrides
             You will not be charged until you review your order on the next page
           </span>
           <bq-option value="visa-1234" display-value="Visa •••• 1234">
-            <div class="flex flex-col gap-xs2">
-              <div class="flex items-center gap-xs">
+            <div class="payment-option">
+              <div class="payment-option__header">
                 <bq-icon name="credit-card" size="20"></bq-icon>
-                <span class="font-semibold">Visa ending in 1234</span>
+                <span class="payment-option__name">Visa ending in 1234</span>
               </div>
-              <span class="text-secondary text-s option-indent">Expires 12/2025</span>
-              <span class="text-secondary text-xs option-indent">John Doe</span>
+              <span class="payment-option__meta">Expires 12/2025</span>
+              <span class="payment-option__owner">John Doe</span>
             </div>
           </bq-option>
           <bq-option value="mastercard-5678" display-value="Mastercard •••• 5678">
-            <div class="flex flex-col gap-xs2">
-              <div class="flex items-center gap-xs">
+            <div class="payment-option">
+              <div class="payment-option__header">
                 <bq-icon name="credit-card" size="20"></bq-icon>
-                <span class="font-semibold">Mastercard ending in 5678</span>
+                <span class="payment-option__name">Mastercard ending in 5678</span>
               </div>
-              <span class="text-secondary text-s option-indent">Expires 08/2026</span>
-              <span class="text-secondary text-xs option-indent">Jane Smith</span>
+              <span class="payment-option__meta">Expires 08/2026</span>
+              <span class="payment-option__owner">Jane Smith</span>
             </div>
           </bq-option>
           <bq-option value="paypal" display-value="PayPal">
-            <div class="flex flex-col gap-xs2">
-              <div class="flex items-center gap-xs">
+            <div class="payment-option">
+              <div class="payment-option__header">
                 <bq-icon name="paypal-logo" size="20"></bq-icon>
-                <span class="font-semibold">Pay with PayPal</span>
+                <span class="payment-option__name">Pay with PayPal</span>
               </div>
-              <span class="text-secondary text-s option-indent">john.doe@email.com</span>
+              <span class="payment-option__meta">john.doe@email.com</span>
             </div>
           </bq-option>
         </bq-select>
-      `
+      `,
+      styles: [
+        `
+          .payment-option {
+            display: flex;
+            flex-direction: column;
+            gap: var(--bq-spacing-xs2);
+          }
+
+          .payment-option__header {
+            display: flex;
+            align-items: center;
+            gap: var(--bq-spacing-xs);
+          }
+
+          .payment-option__name {
+            font-weight: 600;
+          }
+
+          .payment-option__meta,
+          .payment-option__owner {
+            padding-inline-start: 28px;
+            color: var(--bq-text--secondary);
+          }
+
+          .payment-option__meta {
+            font-size: var(--bq-font-size--s);
+          }
+
+          .payment-option__owner {
+            font-size: var(--bq-font-size--xs);
+          }
+        `
+      ],
     })
     export class DisplayValueSelectComponent {}
     ```
 
     ```vue Vue icon="vuejs"
+    <script setup>
+    import { BqIcon, BqOption, BqSelect } from "@beeq/vue";
+    </script>
+
     <template>
       <BqSelect placeholder="Payment method..." open>
         <label slot="label">Choose a payment method</label>
@@ -625,40 +685,68 @@ The `displayValue` property (`display-value` attribute) on `bq-option` overrides
           You will not be charged until you review your order on the next page
         </span>
         <BqOption value="visa-1234" displayValue="Visa •••• 1234">
-          <div class="flex flex-col gap-xs2">
-            <div class="flex items-center gap-xs">
+          <div class="payment-option">
+            <div class="payment-option__header">
               <BqIcon name="credit-card" size="20" />
-              <span class="font-semibold">Visa ending in 1234</span>
+              <span class="payment-option__name">Visa ending in 1234</span>
             </div>
-            <span class="text-secondary text-s option-indent">Expires 12/2025</span>
-            <span class="text-secondary text-xs option-indent">John Doe</span>
+            <span class="payment-option__meta">Expires 12/2025</span>
+            <span class="payment-option__owner">John Doe</span>
           </div>
         </BqOption>
         <BqOption value="mastercard-5678" displayValue="Mastercard •••• 5678">
-          <div class="flex flex-col gap-xs2">
-            <div class="flex items-center gap-xs">
+          <div class="payment-option">
+            <div class="payment-option__header">
               <BqIcon name="credit-card" size="20" />
-              <span class="font-semibold">Mastercard ending in 5678</span>
+              <span class="payment-option__name">Mastercard ending in 5678</span>
             </div>
-            <span class="text-secondary text-s option-indent">Expires 08/2026</span>
-            <span class="text-secondary text-xs option-indent">Jane Smith</span>
+            <span class="payment-option__meta">Expires 08/2026</span>
+            <span class="payment-option__owner">Jane Smith</span>
           </div>
         </BqOption>
         <BqOption value="paypal" displayValue="PayPal">
-          <div class="flex flex-col gap-xs2">
-            <div class="flex items-center gap-xs">
+          <div class="payment-option">
+            <div class="payment-option__header">
               <BqIcon name="paypal-logo" size="20" />
-              <span class="font-semibold">Pay with PayPal</span>
+              <span class="payment-option__name">Pay with PayPal</span>
             </div>
-            <span class="text-secondary text-s option-indent">john.doe@email.com</span>
+            <span class="payment-option__meta">john.doe@email.com</span>
           </div>
         </BqOption>
       </BqSelect>
     </template>
 
-    <script setup>
-    import { BqIcon, BqOption, BqSelect } from "@beeq/vue";
-    </script>
+    <style>
+    .payment-option {
+      display: flex;
+      flex-direction: column;
+      gap: var(--bq-spacing-xs2);
+    }
+
+    .payment-option__header {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+
+    .payment-option__name {
+      font-weight: 600;
+    }
+
+    .payment-option__meta,
+    .payment-option__owner {
+      padding-inline-start: 28px;
+      color: var(--bq-text--secondary);
+    }
+
+    .payment-option__meta {
+      font-size: var(--bq-font-size--s);
+    }
+
+    .payment-option__owner {
+      font-size: var(--bq-font-size--xs);
+    }
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -2240,145 +2328,244 @@ Call `preventDefault()` on the `bqInput` event to take full control of option fi
 </Tip>
 
 <CodeLivePreview code={`
-  <style>
-    bq-select::part(panel) { z-index: 12; }
-  </style>
-
   <bq-select id="custom-select" placeholder="Search options..." debounce-time="300">
     <label slot="label">Custom filtering</label>
+    <bq-option value="running" display-value="Running" data-label="Running" data-icon="sneaker-move">
+      <bq-icon slot="prefix" name="sneaker-move"></bq-icon> Running
+    </bq-option>
+    <bq-option value="hiking" display-value="Hiking" data-label="Hiking" data-icon="boot">
+      <bq-icon slot="prefix" name="boot"></bq-icon> Hiking
+    </bq-option>
+    <bq-option value="biking" display-value="Biking" data-label="Biking" data-icon="person-simple-bike">
+      <bq-icon slot="prefix" name="person-simple-bike"></bq-icon> Biking
+    </bq-option>
+    <bq-option value="swimming" display-value="Swimming" data-label="Swimming" data-icon="swimming-pool">
+      <bq-icon slot="prefix" name="swimming-pool"></bq-icon> Swimming
+    </bq-option>
+    <bq-option value="pizza" display-value="Pizza" data-label="Pizza" data-icon="pizza">
+      <bq-icon slot="prefix" name="pizza"></bq-icon> Pizza
+    </bq-option>
+    <bq-option value="hamburger" display-value="Hamburger" data-label="Hamburger" data-icon="hamburger">
+      <bq-icon slot="prefix" name="hamburger"></bq-icon> Hamburger
+    </bq-option>
+    <bq-option value="cookie" display-value="Cookie" data-label="Cookie" data-icon="cookie">
+      <bq-icon slot="prefix" name="cookie"></bq-icon> Cookie
+    </bq-option>
+    <bq-option value="ice-cream" display-value="Ice-cream" data-label="Ice-cream" data-icon="ice-cream">
+      <bq-icon slot="prefix" name="ice-cream"></bq-icon> Ice-cream
+    </bq-option>
   </bq-select>
 
   <script>
     (() => {
-      const ALL_OPTIONS = [
-        { label: 'Running', value: 'running', icon: 'sneaker-move' },
-        { label: 'Hiking', value: 'hiking', icon: 'boot' },
-        { label: 'Biking', value: 'biking', icon: 'person-simple-bike' },
-        { label: 'Swimming', value: 'swimming', icon: 'swimming-pool' },
-        { label: 'Pizza', value: 'pizza', icon: 'pizza' },
-        { label: 'Hamburger', value: 'hamburger', icon: 'hamburger' },
-        { label: 'Cookie', value: 'cookie', icon: 'cookie' },
-        { label: 'Ice-cream', value: 'ice-cream', icon: 'ice-cream' },
-      ];
-
       const select = previewRoot.querySelector('#custom-select');
+      const staticOpts = Array.from(select.querySelectorAll('bq-option'));
 
       function highlight(text, query) {
-        return text.replace(new RegExp('(' + query + ')', 'gi'), '<b>$1</b>');
+        const escaped = query.replace(/[.*+?^{}()|[\]\\$]/g, '\\$&');
+        return text.replace(new RegExp('(' + escaped + ')', 'gi'), '<b>$1</b>');
       }
 
-      function renderOptions(items, query) {
-        select.querySelectorAll('bq-option').forEach(function(el) { el.remove(); });
+      function removeTempOpts() {
+        select.querySelectorAll('bq-option[data-temp]').forEach(function(opt) { opt.remove(); });
+      }
 
-        if (items.length === 0) {
-          const opt = document.createElement('bq-option');
-          opt.setAttribute('disabled', '');
-          opt.innerHTML = '<bq-icon slot="prefix" name="x-circle"></bq-icon> No results found';
-          select.appendChild(opt);
-          return;
-        }
+      function insertTempOption(icon, message) {
+        select.insertAdjacentHTML('beforeend',
+          '<bq-option disabled data-temp="">' +
+          '<bq-icon slot="prefix" name="' + icon + '"></bq-icon> ' + message +
+          '</bq-option>'
+        );
+      }
 
-        items.forEach(function(item) {
-          const opt = document.createElement('bq-option');
-          opt.value = item.value;
-          const labelHtml = query ? highlight(item.label, query) : item.label;
-          opt.innerHTML = '<bq-icon slot="prefix" name="' + item.icon + '"></bq-icon><span>' + labelHtml + '</span>';
-          select.appendChild(opt);
+      function showAllOptions() {
+        staticOpts.forEach(function(opt) {
+          opt.hidden = false;
+          opt.innerHTML =
+            '<bq-icon slot="prefix" name="' + opt.getAttribute('data-icon') + '"></bq-icon> ' +
+            opt.getAttribute('data-label');
         });
       }
 
-      renderOptions(ALL_OPTIONS);
+      async function fetchFilteredOptions(query) {
+        await new Promise(function(resolve) { setTimeout(resolve, 500); });
+        const q = query.toLowerCase();
+        return staticOpts.filter(function(opt) {
+          return opt.getAttribute('data-label').toLowerCase().includes(q);
+        });
+      }
 
-      select.addEventListener('bqInput', function(ev) {
+      select.addEventListener('bqInput', async function(ev) {
         ev.preventDefault();
         const query = ev.detail.value;
-        if (!query) { renderOptions(ALL_OPTIONS); return; }
-        const q = query.toLowerCase();
-        renderOptions(
-          ALL_OPTIONS.filter(function(o) { return o.label.toLowerCase().includes(q); }),
-          query
+
+        removeTempOpts();
+
+        if (!query) {
+          showAllOptions();
+          return;
+        }
+
+        staticOpts.forEach(function(opt) { opt.hidden = true; });
+        select.insertAdjacentHTML('beforeend',
+          '<bq-option disabled data-temp="">' +
+          '<bq-spinner slot="prefix" animation size="small" text-position="right"></bq-spinner>' +
+          ' Loading...' +
+          '</bq-option>'
         );
+
+        try {
+          const matches = await fetchFilteredOptions(query);
+          removeTempOpts();
+
+          if (matches.length === 0) {
+            insertTempOption('x-circle', 'No results found');
+          } else {
+            matches.forEach(function(opt) {
+              opt.hidden = false;
+              opt.innerHTML =
+                '<bq-icon slot="prefix" name="' + opt.getAttribute('data-icon') + '"></bq-icon>' +
+                '<span>' + highlight(opt.getAttribute('data-label'), query) + '</span>';
+            });
+          }
+        } catch (_) {
+          removeTempOpts();
+          insertTempOption('warning', 'Error loading options');
+        }
       });
 
       select.addEventListener('bqSelect', function() {
-        renderOptions(ALL_OPTIONS);
+        removeTempOpts();
+        showAllOptions();
       });
     })();
   </script>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-select id="custom-select" placeholder="Search options..." debounce-time="300">
       <label slot="label">Custom filtering</label>
+      <bq-option value="running" display-value="Running" data-label="Running" data-icon="sneaker-move">
+        <bq-icon slot="prefix" name="sneaker-move"></bq-icon> Running
+      </bq-option>
+      <bq-option value="hiking" display-value="Hiking" data-label="Hiking" data-icon="boot">
+        <bq-icon slot="prefix" name="boot"></bq-icon> Hiking
+      </bq-option>
+      <bq-option value="biking" display-value="Biking" data-label="Biking" data-icon="person-simple-bike">
+        <bq-icon slot="prefix" name="person-simple-bike"></bq-icon> Biking
+      </bq-option>
+      <bq-option value="swimming" display-value="Swimming" data-label="Swimming" data-icon="swimming-pool">
+        <bq-icon slot="prefix" name="swimming-pool"></bq-icon> Swimming
+      </bq-option>
+      <bq-option value="pizza" display-value="Pizza" data-label="Pizza" data-icon="pizza">
+        <bq-icon slot="prefix" name="pizza"></bq-icon> Pizza
+      </bq-option>
+      <bq-option value="hamburger" display-value="Hamburger" data-label="Hamburger" data-icon="hamburger">
+        <bq-icon slot="prefix" name="hamburger"></bq-icon> Hamburger
+      </bq-option>
+      <bq-option value="cookie" display-value="Cookie" data-label="Cookie" data-icon="cookie">
+        <bq-icon slot="prefix" name="cookie"></bq-icon> Cookie
+      </bq-option>
+      <bq-option value="ice-cream" display-value="Ice-cream" data-label="Ice-cream" data-icon="ice-cream">
+        <bq-icon slot="prefix" name="ice-cream"></bq-icon> Ice-cream
+      </bq-option>
     </bq-select>
-    ```
 
-    ```js JS icon="square-js"
-    const ALL_OPTIONS = [
-      { label: 'Running', value: 'running', icon: 'sneaker-move' },
-      { label: 'Hiking', value: 'hiking', icon: 'boot' },
-      { label: 'Biking', value: 'biking', icon: 'person-simple-bike' },
-      { label: 'Swimming', value: 'swimming', icon: 'swimming-pool' },
-      { label: 'Pizza', value: 'pizza', icon: 'pizza' },
-      { label: 'Hamburger', value: 'hamburger', icon: 'hamburger' },
-      { label: 'Cookie', value: 'cookie', icon: 'cookie' },
-      { label: 'Ice-cream', value: 'ice-cream', icon: 'ice-cream' },
-    ];
+    <script>
+      const select = document.querySelector('#custom-select');
+      const staticOpts = Array.from(select.querySelectorAll('bq-option'));
 
-    const select = document.querySelector('#custom-select');
-
-    function highlight(text, query) {
-      const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      return text.replace(new RegExp(`(${escaped})`, 'gi'), '<b>$1</b>');
-    }
-
-    function renderOptions(items, query = '') {
-      select.querySelectorAll('bq-option').forEach((el) => el.remove());
-
-      if (items.length === 0) {
-        const opt = document.createElement('bq-option');
-        opt.setAttribute('disabled', '');
-        opt.innerHTML = `<bq-icon slot="prefix" name="x-circle"></bq-icon> No results found`;
-        select.appendChild(opt);
-        return;
+      function highlight(text, query) {
+        const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        return text.replace(new RegExp(`(${escaped})`, 'gi'), '<b>$1</b>');
       }
 
-      items.forEach(({ label, value, icon }) => {
-        const opt = document.createElement('bq-option');
-        opt.value = value;
-        const labelHtml = query ? highlight(label, query) : label;
-        opt.innerHTML = `<bq-icon slot="prefix" name="${icon}"></bq-icon><span>${labelHtml}</span>`;
-        select.appendChild(opt);
+      function removeTempOpts() {
+        select.querySelectorAll('bq-option[data-temp]').forEach((opt) => opt.remove());
+      }
+
+      function insertTempOption(icon, message) {
+        select.insertAdjacentHTML('beforeend',
+          `<bq-option disabled data-temp="">` +
+          `<bq-icon slot="prefix" name="${icon}"></bq-icon> ${message}` +
+          `</bq-option>`
+        );
+      }
+
+      function showAllOptions() {
+        staticOpts.forEach((opt) => {
+          opt.hidden = false;
+          opt.innerHTML =
+            `<bq-icon slot="prefix" name="${opt.getAttribute('data-icon')}"></bq-icon> ` +
+            opt.getAttribute('data-label');
+        });
+      }
+
+      async function fetchFilteredOptions(query) {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        const q = query.toLowerCase();
+        return staticOpts.filter((opt) => opt.getAttribute('data-label').toLowerCase().includes(q));
+      }
+
+      select.addEventListener('bqInput', async (ev) => {
+        ev.preventDefault();
+        const query = ev.detail.value;
+
+        removeTempOpts();
+
+        if (!query) {
+          showAllOptions();
+          return;
+        }
+
+        staticOpts.forEach((opt) => (opt.hidden = true));
+        select.insertAdjacentHTML('beforeend',
+          `<bq-option disabled data-temp="">` +
+          `<bq-spinner slot="prefix" animation size="small" text-position="right"></bq-spinner>` +
+          ` Loading...</bq-option>`
+        );
+
+        try {
+          const matches = await fetchFilteredOptions(query);
+          removeTempOpts();
+
+          if (matches.length === 0) {
+            insertTempOption('x-circle', 'No results found');
+          } else {
+            matches.forEach((opt) => {
+              opt.hidden = false;
+              opt.innerHTML =
+                `<bq-icon slot="prefix" name="${opt.getAttribute('data-icon')}"></bq-icon>` +
+                `<span>${highlight(opt.getAttribute('data-label'), query)}</span>`;
+            });
+          }
+        } catch (_) {
+          removeTempOpts();
+          insertTempOption('warning', 'Error loading options');
+        }
       });
-    }
 
-    renderOptions(ALL_OPTIONS);
-
-    select.addEventListener('bqInput', (ev) => {
-      ev.preventDefault();
-      const query = ev.detail.value;
-      if (!query) { renderOptions(ALL_OPTIONS); return; }
-      const q = query.toLowerCase();
-      renderOptions(ALL_OPTIONS.filter((o) => o.label.toLowerCase().includes(q)), query);
-    });
-
-    select.addEventListener('bqSelect', () => renderOptions(ALL_OPTIONS));
+      select.addEventListener('bqSelect', () => {
+        removeTempOpts();
+        showAllOptions();
+      });
+    </script>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { useState } from 'react';
     import type { BqSelectCustomEvent } from '@beeq/core';
     import { BqIcon, BqOption, BqSelect, BqSpinner } from '@beeq/react';
 
     const ALL_OPTIONS = [
-      { label: 'Running', value: 'running', icon: 'sneaker-move' },
-      { label: 'Hiking', value: 'hiking', icon: 'boot' },
-      { label: 'Biking', value: 'biking', icon: 'person-simple-bike' },
-      { label: 'Swimming', value: 'swimming', icon: 'swimming-pool' },
-      { label: 'Pizza', value: 'pizza', icon: 'pizza' },
-      { label: 'Hamburger', value: 'hamburger', icon: 'hamburger' },
-      { label: 'Cookie', value: 'cookie', icon: 'cookie' },
-      { label: 'Ice-cream', value: 'ice-cream', icon: 'ice-cream' },
+      { label: 'Running', value: 'running', icon: 'sneaker-move', displayValue: 'Running' },
+      { label: 'Hiking', value: 'hiking', icon: 'boot', displayValue: 'Hiking' },
+      { label: 'Biking', value: 'biking', icon: 'person-simple-bike', displayValue: 'Biking' },
+      { label: 'Swimming', value: 'swimming', icon: 'swimming-pool', displayValue: 'Swimming' },
+      { label: 'Pizza', value: 'pizza', icon: 'pizza', displayValue: 'Pizza' },
+      { label: 'Hamburger', value: 'hamburger', icon: 'hamburger', displayValue: 'Hamburger' },
+      { label: 'Cookie', value: 'cookie', icon: 'cookie', displayValue: 'Cookie' },
+      { label: 'Ice-cream', value: 'ice-cream', icon: 'ice-cream', displayValue: 'Ice-cream' },
     ];
 
     function highlight(text: string, query: string) {
@@ -2449,7 +2636,7 @@ Call `preventDefault()` on the `bqInput` event to take full control of option fi
             </BqOption>
           ) : (
             visibleOptions.map((option) => (
-              <BqOption key={option.value} value={option.value}>
+              <BqOption key={option.value} value={option.value} displayValue={option.displayValue}>
                 <BqIcon slot="prefix" name={option.icon} />
                 <span dangerouslySetInnerHTML={{ __html: option.label }} />
               </BqOption>
@@ -2460,20 +2647,20 @@ Call `preventDefault()` on the `bqInput` event to take full control of option fi
     }
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqOption, BqSelect, BqSpinner } from "@beeq/angular/standalone";
     import type { BqSelectCustomEvent } from "@beeq/core";
 
     const ALL_OPTIONS = [
-      { label: 'Running', value: 'running', icon: 'sneaker-move' },
-      { label: 'Hiking', value: 'hiking', icon: 'boot' },
-      { label: 'Biking', value: 'biking', icon: 'person-simple-bike' },
-      { label: 'Swimming', value: 'swimming', icon: 'swimming-pool' },
-      { label: 'Pizza', value: 'pizza', icon: 'pizza' },
-      { label: 'Hamburger', value: 'hamburger', icon: 'hamburger' },
-      { label: 'Cookie', value: 'cookie', icon: 'cookie' },
-      { label: 'Ice-cream', value: 'ice-cream', icon: 'ice-cream' },
+      { label: 'Running', value: 'running', icon: 'sneaker-move', displayValue: 'Running' },
+      { label: 'Hiking', value: 'hiking', icon: 'boot', displayValue: 'Hiking' },
+      { label: 'Biking', value: 'biking', icon: 'person-simple-bike', displayValue: 'Biking' },
+      { label: 'Swimming', value: 'swimming', icon: 'swimming-pool', displayValue: 'Swimming' },
+      { label: 'Pizza', value: 'pizza', icon: 'pizza', displayValue: 'Pizza' },
+      { label: 'Hamburger', value: 'hamburger', icon: 'hamburger', displayValue: 'Hamburger' },
+      { label: 'Cookie', value: 'cookie', icon: 'cookie', displayValue: 'Cookie' },
+      { label: 'Ice-cream', value: 'ice-cream', icon: 'ice-cream', displayValue: 'Ice-cream' },
     ];
 
     @Component({
@@ -2500,7 +2687,7 @@ Call `preventDefault()` on the `bqInput` event to take full control of option fi
               </bq-option>
             }
             @for (option of visibleOptions; track option.value) {
-              <bq-option [value]="option.value">
+              <bq-option [value]="option.value" [attr.display-value]="option.displayValue">
                 <bq-icon slot="prefix" [name]="option.icon"></bq-icon>
                 <span [innerHTML]="option.label"></span>
               </bq-option>
@@ -2542,7 +2729,7 @@ Call `preventDefault()` on the `bqInput` event to take full control of option fi
     }
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <template>
       <BqSelect
         placeholder="Search options..."
@@ -2560,7 +2747,7 @@ Call `preventDefault()` on the `bqInput` event to take full control of option fi
             <BqIcon slot="prefix" name="x-circle" />
             No results found
           </BqOption>
-          <BqOption v-for="option in visibleOptions" :key="option.value" :value="option.value">
+          <BqOption v-for="option in visibleOptions" :key="option.value" :value="option.value" :displayValue="option.displayValue">
             <BqIcon slot="prefix" :name="option.icon" />
             <span v-html="option.label" />
           </BqOption>
@@ -2573,14 +2760,14 @@ Call `preventDefault()` on the `bqInput` event to take full control of option fi
     import { BqIcon, BqOption, BqSelect, BqSpinner } from '@beeq/vue';
 
     const ALL_OPTIONS = [
-      { label: 'Running', value: 'running', icon: 'sneaker-move' },
-      { label: 'Hiking', value: 'hiking', icon: 'boot' },
-      { label: 'Biking', value: 'biking', icon: 'person-simple-bike' },
-      { label: 'Swimming', value: 'swimming', icon: 'swimming-pool' },
-      { label: 'Pizza', value: 'pizza', icon: 'pizza' },
-      { label: 'Hamburger', value: 'hamburger', icon: 'hamburger' },
-      { label: 'Cookie', value: 'cookie', icon: 'cookie' },
-      { label: 'Ice-cream', value: 'ice-cream', icon: 'ice-cream' },
+      { label: 'Running', value: 'running', icon: 'sneaker-move', displayValue: 'Running' },
+      { label: 'Hiking', value: 'hiking', icon: 'boot', displayValue: 'Hiking' },
+      { label: 'Biking', value: 'biking', icon: 'person-simple-bike', displayValue: 'Biking' },
+      { label: 'Swimming', value: 'swimming', icon: 'swimming-pool', displayValue: 'Swimming' },
+      { label: 'Pizza', value: 'pizza', icon: 'pizza', displayValue: 'Pizza' },
+      { label: 'Hamburger', value: 'hamburger', icon: 'hamburger', displayValue: 'Hamburger' },
+      { label: 'Cookie', value: 'cookie', icon: 'cookie', displayValue: 'Cookie' },
+      { label: 'Ice-cream', value: 'ice-cream', icon: 'ice-cream', displayValue: 'Ice-cream' },
     ];
 
     const visibleOptions = ref([...ALL_OPTIONS]);

--- a/apps/beeq-docs/docs.json
+++ b/apps/beeq-docs/docs.json
@@ -143,6 +143,14 @@
             ]
           },
           {
+            "group": "Options",
+            "pages": [
+              "components/option",
+              "components/option-group",
+              "components/option-list"
+            ]
+          },
+          {
             "group": "Layout",
             "pages": [
               "components/card",

--- a/apps/beeq-docs/docs.json
+++ b/apps/beeq-docs/docs.json
@@ -135,19 +135,14 @@
               "components/checkbox",
               "components/date-picker",
               "components/input",
+              "components/option",
+              "components/option-group",
+              "components/option-list",
               "components/radio",
               "components/select",
               "components/slider",
               "components/switch",
               "components/textarea"
-            ]
-          },
-          {
-            "group": "Options",
-            "pages": [
-              "components/option",
-              "components/option-group",
-              "components/option-list"
             ]
           },
           {


### PR DESCRIPTION
## Description

This PR expands the Mintlify documentation site with a new batch of migrated component pages for the Option component family, aligning them with the documentation structure established by earlier migrations.

Included in this PR:
- migrate `Option` docs to Mintlify
- migrate `Option Group` docs to Mintlify
- migrate `Option List` docs to Mintlify
- add **Options** navigation group to `docs.json` under the Components tab

All pages follow the consistent structure:
- overview frame (light + dark)
- when to use / when not to use
- patterns
- anatomy + parts table
- design guidelines
- usage examples with live previews (HTML / React / Angular / Vue tabs)
- options variants
- best practices (Do / Don't pairs)
- accessibility guidance (built-in + developer responsibilities)
- API reference (properties, events, slots, shadow parts, CSS custom properties)
- related components (cross-navigation between the three sibling pages)
- resources (Storybook + GitHub)

Notable additions in this batch:
- **Option**: covers default, prefix icon, suffix icon, selected state, disabled state, and hidden state variants; documents all 12 CSS custom properties
- **Option Group**: covers basic grouping, prefix icon on the group header, and suffix badge on the group header; documents the 9 CSS custom properties and the no-props API pattern
- **Option List**: covers flat list usage, custom accessible label, and the `bqSelect` event payload; cross-references grouped list usage to the Option Group page to avoid redundancy

## Documentation

This PR is documentation-only.

Pages added:
- `apps/beeq-docs/components/option.mdx`
- `apps/beeq-docs/components/option-group.mdx`
- `apps/beeq-docs/components/option-list.mdx`

Navigation updated:
- `apps/beeq-docs/docs.json` — added **Options** group under the Components tab

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [ ] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes

- ❌ SVG assets (overview, anatomy, design guideline images) are still pending for all three pages — placeholder `<Frame>` image paths are in place and will be replaced once assets are delivered.