### PR TITLE
docs(Side-Menu, Steps): migrate component

### DIFF
--- a/apps/beeq-docs/components/side-menu.mdx
+++ b/apps/beeq-docs/components/side-menu.mdx
@@ -1,0 +1,896 @@
+---
+title: Side Menu
+description: "Side menus provide persistent vertical navigation for applications with multiple sections, features, or hierarchy levels."
+---
+
+import { CardTile } from '/snippets/CardTile.jsx';
+import { CodeLivePreview } from "/snippets/CodeLivePreview.jsx";
+
+<Frame className="px-4 py-4" caption="Side Menu overview">
+  <img src="https://placeholdit.com/600x400" alt="Placeholder for the Side Menu overview image" />
+</Frame>
+
+The side menu is a vertical navigation element that sits alongside a page or application layout. It acts as a central hub for accessing sections, features, and functionality.
+
+<Note>
+  Use `bq-side-menu-item` inside `bq-side-menu`; side menu items rely on the parent menu to manage collapsed and selected states.
+</Note>
+
+## When to use
+
+<CardGroup cols={2}>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="thumbs-up" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Use side menus when
+    </span>
+    - A website or application has extensive content or multiple hierarchical levels
+    - A compact and organized navigation system is necessary
+    - Users need persistent access to primary sections while they work
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="thumbs-down" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Do not use side menus when
+    </span>
+    - The menu reduces the visibility of primary content
+    - The interface is focused on reading or content consumption
+    - The layout is too narrow to support persistent navigation
+  </Card>
+</CardGroup>
+
+## Patterns
+
+<CardGroup cols={2}>
+  <Card title="Default view">
+    Navigation items remain visible while users scroll. This gives people a persistent representation of the product structure.
+  </Card>
+  <Card title="Collapsible view">
+    The collapsible view reduces the menu to a compact rail. Use it when space is constrained or when users need more room for content.
+  </Card>
+</CardGroup>
+
+<Tip>
+  For grid sizes M to XS, applicable to viewports of 768 pixels and below, display the side menu in collapsed mode.
+</Tip>
+
+## Anatomy
+
+<Frame className="px-4 py-4" caption="Side Menu anatomy">
+  <img src="https://placeholdit.com/1000x420" alt="Placeholder for the Side Menu anatomy image" />
+</Frame>
+
+A side menu is composed of a container, selected item state, navigation items, and an expand/collapse control.
+
+| Part | Element | Description |
+|---|---|---|
+| **1** | Container | The root `<aside>` surface that holds the side menu |
+| **2** | Selected | The active item that represents the current location |
+| **3** | Navigation item | A selectable `bq-side-menu-item` with optional prefix and suffix content |
+| **4** | Expand/collapse button | The control used to toggle between expanded and collapsed views |
+
+## Design guidelines
+
+<CardGroup cols={2}>
+  <CardTile
+    title="Keep navigation available"
+    imageLightSrc="https://placeholdit.com/480x320"
+    imageDarkSrc="https://placeholdit.com/480x320"
+  >
+    The side menu can scroll separately from the main content. This keeps navigation available when the page content is long.
+  </CardTile>
+  <CardTile
+    title="Write clear labels"
+    imageLightSrc="https://placeholdit.com/480x320"
+    imageDarkSrc="https://placeholdit.com/480x320"
+  >
+    Use short, unique labels in sentence case. The link text should explain the destination without extra context.
+  </CardTile>
+</CardGroup>
+
+## Usage
+
+### Default
+
+The default side menu is a versatile container for organizing and displaying navigation elements. Use it as the foundation for structured and intuitive navigation layouts.
+
+<CodeLivePreview code={`<style>
+  :host {
+    align-items: stretch !important;
+    justify-content: flex-start !important;
+    min-height: 22rem !important;
+    overflow: hidden !important;
+    padding: 0 !important;
+    position: relative !important;
+  }
+
+  bq-side-menu {
+    display: block;
+    inline-size: var(--bq-side-menu--width);
+    min-height: 22rem;
+    position: relative;
+  }
+
+  bq-side-menu::part(base) {
+    block-size: 100% !important;
+    inset: 0 auto 0 0 !important;
+    min-block-size: 0 !important;
+    position: absolute !important;
+  }
+
+  .side-menu-demo__logo {
+    display: flex;
+    align-items: center;
+    gap: var(--bq-spacing-s);
+    padding: var(--bq-spacing-m);
+  }
+
+  .side-menu-demo__title {
+    margin: 0;
+    font-size: var(--bq-font-size--xl);
+    white-space: nowrap;
+  }
+</style>
+
+<bq-side-menu>
+  <div class="side-menu-demo__logo" slot="logo">
+    <bq-icon name="hexagon" size="32"></bq-icon>
+    <h1 class="side-menu-demo__title">BEEQ</h1>
+  </div>
+  <bq-side-menu-item active>
+    <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+    Dashboard
+  </bq-side-menu-item>
+  <bq-side-menu-item>
+    <bq-icon name="package" slot="prefix"></bq-icon>
+    Products
+    <bq-badge slot="suffix">5</bq-badge>
+  </bq-side-menu-item>
+  <bq-side-menu-item disabled>
+    <bq-icon name="gauge" slot="prefix"></bq-icon>
+    Performance
+  </bq-side-menu-item>
+</bq-side-menu>
+
+<script>
+  (() => {
+    const bodyClasses = ['bq-body--side-menu', 'bq-body--side-menu__expand', 'bq-body--side-menu__collapse'];
+    const previewDocument = previewRoot.host?.ownerDocument ?? document;
+    const resetBodyClasses = () => previewDocument.body.classList.remove(...bodyClasses);
+
+    const scheduleReset = () => requestAnimationFrame(() => requestAnimationFrame(resetBodyClasses));
+
+    // The production side menu reserves layout space on <body>; the docs preview
+    // keeps the demo contained, so remove those global layout classes after mount.
+    resetBodyClasses();
+    customElements.whenDefined('bq-side-menu').then(scheduleReset);
+  })();
+</script>`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-side-menu>
+      <div slot="logo">
+        <bq-icon name="hexagon" size="32"></bq-icon>
+        <h1>BEEQ</h1>
+      </div>
+
+      <bq-side-menu-item active>
+        <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+        Dashboard
+      </bq-side-menu-item>
+
+      <bq-side-menu-item>
+        <bq-icon name="package" slot="prefix"></bq-icon>
+        Products
+        <bq-badge slot="suffix">5</bq-badge>
+      </bq-side-menu-item>
+
+      <bq-side-menu-item disabled>
+        <bq-icon name="gauge" slot="prefix"></bq-icon>
+        Performance
+      </bq-side-menu-item>
+    </bq-side-menu>
+    ```
+    ```jsx React icon="react"
+    import { BqBadge, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/react";
+
+    <BqSideMenu>
+      <div slot="logo">
+        <BqIcon name="hexagon" size="32" />
+        <h1>BEEQ</h1>
+      </div>
+
+      <BqSideMenuItem active>
+        <BqIcon name="diamonds-four" slot="prefix" />
+        Dashboard
+      </BqSideMenuItem>
+
+      <BqSideMenuItem>
+        <BqIcon name="package" slot="prefix" />
+        Products
+        <BqBadge slot="suffix">5</BqBadge>
+      </BqSideMenuItem>
+
+      <BqSideMenuItem disabled>
+        <BqIcon name="gauge" slot="prefix" />
+        Performance
+      </BqSideMenuItem>
+    </BqSideMenu>
+    ```
+    ```html Angular icon="angular"
+    <bq-side-menu>
+      <div slot="logo">
+        <bq-icon name="hexagon" size="32"></bq-icon>
+        <h1>BEEQ</h1>
+      </div>
+
+      <bq-side-menu-item active>
+        <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+        Dashboard
+      </bq-side-menu-item>
+
+      <bq-side-menu-item>
+        <bq-icon name="package" slot="prefix"></bq-icon>
+        Products
+        <bq-badge slot="suffix">5</bq-badge>
+      </bq-side-menu-item>
+
+      <bq-side-menu-item disabled>
+        <bq-icon name="gauge" slot="prefix"></bq-icon>
+        Performance
+      </bq-side-menu-item>
+    </bq-side-menu>
+    ```
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqBadge, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSideMenu>
+        <div slot="logo">
+          <BqIcon name="hexagon" size="32" />
+          <h1>BEEQ</h1>
+        </div>
+
+        <BqSideMenuItem active>
+          <BqIcon name="diamonds-four" slot="prefix" />
+          Dashboard
+        </BqSideMenuItem>
+
+        <BqSideMenuItem>
+          <BqIcon name="package" slot="prefix" />
+          Products
+          <BqBadge slot="suffix">5</BqBadge>
+        </BqSideMenuItem>
+
+        <BqSideMenuItem disabled>
+          <BqIcon name="gauge" slot="prefix" />
+          Performance
+        </BqSideMenuItem>
+      </BqSideMenu>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+## Options
+
+### Item states
+
+Side menu items support default, active, hover, focus, disabled, and with-counter states.
+
+<CodeLivePreview code={`<style>
+  :host {
+    align-items: stretch !important;
+  }
+
+  .side-menu-states {
+    display: grid;
+    gap: var(--bq-spacing-xs);
+    inline-size: min(100%, 16rem);
+  }
+</style>
+
+<div class="side-menu-states">
+  <bq-side-menu-item>
+    <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+    Default
+  </bq-side-menu-item>
+  <bq-side-menu-item active>
+    <bq-icon name="package" slot="prefix"></bq-icon>
+    Active
+  </bq-side-menu-item>
+  <bq-side-menu-item disabled>
+    <bq-icon name="gauge" slot="prefix"></bq-icon>
+    Disabled
+  </bq-side-menu-item>
+  <bq-side-menu-item>
+    <bq-icon name="bell" slot="prefix"></bq-icon>
+    With counter
+    <bq-badge slot="suffix">5</bq-badge>
+  </bq-side-menu-item>
+</div>`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-side-menu-item>
+      <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+      Default
+    </bq-side-menu-item>
+
+    <bq-side-menu-item active>
+      <bq-icon name="package" slot="prefix"></bq-icon>
+      Active
+    </bq-side-menu-item>
+
+    <bq-side-menu-item disabled>
+      <bq-icon name="gauge" slot="prefix"></bq-icon>
+      Disabled
+    </bq-side-menu-item>
+
+    <bq-side-menu-item>
+      <bq-icon name="bell" slot="prefix"></bq-icon>
+      With counter
+      <bq-badge slot="suffix">5</bq-badge>
+    </bq-side-menu-item>
+    ```
+    ```jsx React icon="react"
+    import { BqBadge, BqIcon, BqSideMenuItem } from "@beeq/react";
+
+    <>
+      <BqSideMenuItem>
+        <BqIcon name="diamonds-four" slot="prefix" />
+        Default
+      </BqSideMenuItem>
+      <BqSideMenuItem active>
+        <BqIcon name="package" slot="prefix" />
+        Active
+      </BqSideMenuItem>
+      <BqSideMenuItem disabled>
+        <BqIcon name="gauge" slot="prefix" />
+        Disabled
+      </BqSideMenuItem>
+      <BqSideMenuItem>
+        <BqIcon name="bell" slot="prefix" />
+        With counter
+        <BqBadge slot="suffix">5</BqBadge>
+      </BqSideMenuItem>
+    </>
+    ```
+    ```html Angular icon="angular"
+    <bq-side-menu-item>
+      <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+      Default
+    </bq-side-menu-item>
+
+    <bq-side-menu-item active>
+      <bq-icon name="package" slot="prefix"></bq-icon>
+      Active
+    </bq-side-menu-item>
+
+    <bq-side-menu-item disabled>
+      <bq-icon name="gauge" slot="prefix"></bq-icon>
+      Disabled
+    </bq-side-menu-item>
+
+    <bq-side-menu-item>
+      <bq-icon name="bell" slot="prefix"></bq-icon>
+      With counter
+      <bq-badge slot="suffix">5</bq-badge>
+    </bq-side-menu-item>
+    ```
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqBadge, BqIcon, BqSideMenuItem } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSideMenuItem>
+        <BqIcon name="diamonds-four" slot="prefix" />
+        Default
+      </BqSideMenuItem>
+      <BqSideMenuItem active>
+        <BqIcon name="package" slot="prefix" />
+        Active
+      </BqSideMenuItem>
+      <BqSideMenuItem disabled>
+        <BqIcon name="gauge" slot="prefix" />
+        Disabled
+      </BqSideMenuItem>
+      <BqSideMenuItem>
+        <BqIcon name="bell" slot="prefix" />
+        With counter
+        <BqBadge slot="suffix">5</BqBadge>
+      </BqSideMenuItem>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Appearance
+
+Use the `appearance` attribute to align the side menu with your application's visual language.
+
+<CodeLivePreview code={`<style>
+  :host {
+    align-items: stretch !important;
+    gap: var(--bq-spacing-m) !important;
+  }
+
+  .side-menu-appearance {
+    display: grid;
+    gap: var(--bq-spacing-s);
+    grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+    inline-size: min(100%, 44rem);
+  }
+
+  bq-side-menu {
+    block-size: 18rem;
+    display: block;
+    inline-size: 100%;
+    position: relative;
+  }
+
+  bq-side-menu::part(base) {
+    block-size: 100% !important;
+    inset: 0 auto 0 0 !important;
+    min-block-size: 0 !important;
+    position: absolute !important;
+  }
+</style>
+
+<div class="side-menu-appearance">
+  <bq-side-menu appearance="default">
+    <bq-side-menu-item active>Dashboard</bq-side-menu-item>
+    <bq-side-menu-item>Reports</bq-side-menu-item>
+  </bq-side-menu>
+  <bq-side-menu appearance="brand">
+    <bq-side-menu-item active>Dashboard</bq-side-menu-item>
+    <bq-side-menu-item>Reports</bq-side-menu-item>
+  </bq-side-menu>
+  <bq-side-menu appearance="inverse">
+    <bq-side-menu-item active>Dashboard</bq-side-menu-item>
+    <bq-side-menu-item>Reports</bq-side-menu-item>
+  </bq-side-menu>
+</div>
+
+<script>
+  (() => {
+    const bodyClasses = ['bq-body--side-menu', 'bq-body--side-menu__expand', 'bq-body--side-menu__collapse'];
+    const previewDocument = previewRoot.host?.ownerDocument ?? document;
+    const resetBodyClasses = () => previewDocument.body.classList.remove(...bodyClasses);
+    const scheduleReset = () => requestAnimationFrame(() => requestAnimationFrame(resetBodyClasses));
+
+    resetBodyClasses();
+    customElements.whenDefined('bq-side-menu').then(scheduleReset);
+  })();
+</script>`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-side-menu appearance="brand">
+      <bq-side-menu-item active>Dashboard</bq-side-menu-item>
+      <bq-side-menu-item>Reports</bq-side-menu-item>
+    </bq-side-menu>
+    ```
+    ```jsx React icon="react"
+    import { BqSideMenu, BqSideMenuItem } from "@beeq/react";
+
+    <BqSideMenu appearance="brand">
+      <BqSideMenuItem active>Dashboard</BqSideMenuItem>
+      <BqSideMenuItem>Reports</BqSideMenuItem>
+    </BqSideMenu>
+    ```
+    ```html Angular icon="angular"
+    <bq-side-menu appearance="brand">
+      <bq-side-menu-item active>Dashboard</bq-side-menu-item>
+      <bq-side-menu-item>Reports</bq-side-menu-item>
+    </bq-side-menu>
+    ```
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqSideMenu, BqSideMenuItem } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSideMenu appearance="brand">
+        <BqSideMenuItem active>Dashboard</BqSideMenuItem>
+        <BqSideMenuItem>Reports</BqSideMenuItem>
+      </BqSideMenu>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Collapse and size
+
+Use `collapse` to create a compact side menu. Use `size="small"` when space is constrained and labels remain readable.
+
+<CodeLivePreview code={`<style>
+  :host {
+    align-items: stretch !important;
+    justify-content: flex-start !important;
+    min-height: 18rem !important;
+    overflow: hidden !important;
+    padding: 0 !important;
+    position: relative !important;
+  }
+
+  bq-side-menu {
+    display: block;
+    inline-size: var(--bq-side-menu--width-collapse);
+    min-height: 18rem;
+    position: relative;
+  }
+
+  bq-side-menu::part(base) {
+    block-size: 100% !important;
+    inset: 0 auto 0 0 !important;
+    min-block-size: 0 !important;
+    position: absolute !important;
+  }
+</style>
+
+<bq-side-menu collapse size="small">
+  <bq-side-menu-item active>
+    <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+    Dashboard
+  </bq-side-menu-item>
+  <bq-side-menu-item>
+    <bq-icon name="package" slot="prefix"></bq-icon>
+    Products
+  </bq-side-menu-item>
+</bq-side-menu>
+
+<script>
+  (() => {
+    const bodyClasses = ['bq-body--side-menu', 'bq-body--side-menu__expand', 'bq-body--side-menu__collapse'];
+    const previewDocument = previewRoot.host?.ownerDocument ?? document;
+    const resetBodyClasses = () => previewDocument.body.classList.remove(...bodyClasses);
+    const scheduleReset = () => requestAnimationFrame(() => requestAnimationFrame(resetBodyClasses));
+
+    resetBodyClasses();
+    customElements.whenDefined('bq-side-menu').then(scheduleReset);
+  })();
+</script>`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-side-menu collapse size="small">
+      <bq-side-menu-item active>
+        <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+        Dashboard
+      </bq-side-menu-item>
+      <bq-side-menu-item>
+        <bq-icon name="package" slot="prefix"></bq-icon>
+        Products
+      </bq-side-menu-item>
+    </bq-side-menu>
+    ```
+    ```jsx React icon="react"
+    import { BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/react";
+
+    <BqSideMenu collapse size="small">
+      <BqSideMenuItem active>
+        <BqIcon name="diamonds-four" slot="prefix" />
+        Dashboard
+      </BqSideMenuItem>
+      <BqSideMenuItem>
+        <BqIcon name="package" slot="prefix" />
+        Products
+      </BqSideMenuItem>
+    </BqSideMenu>
+    ```
+    ```html Angular icon="angular"
+    <bq-side-menu collapse size="small">
+      <bq-side-menu-item active>
+        <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+        Dashboard
+      </bq-side-menu-item>
+      <bq-side-menu-item>
+        <bq-icon name="package" slot="prefix"></bq-icon>
+        Products
+      </bq-side-menu-item>
+    </bq-side-menu>
+    ```
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSideMenu collapse size="small">
+        <BqSideMenuItem active>
+          <BqIcon name="diamonds-four" slot="prefix" />
+          Dashboard
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="package" slot="prefix" />
+          Products
+        </BqSideMenuItem>
+      </BqSideMenu>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### With footer
+
+Use the footer slot for supplementary actions, links, or information at the bottom of the menu.
+
+<CodeLivePreview code={`<style>
+  :host {
+    align-items: stretch !important;
+    justify-content: flex-start !important;
+    min-height: 22rem !important;
+    overflow: hidden !important;
+    padding: 0 !important;
+    position: relative !important;
+  }
+
+  bq-side-menu {
+    display: block;
+    inline-size: var(--bq-side-menu--width);
+    min-height: 22rem;
+    position: relative;
+  }
+
+  bq-side-menu::part(base) {
+    block-size: 100% !important;
+    inset: 0 auto 0 0 !important;
+    min-block-size: 0 !important;
+    position: absolute !important;
+  }
+</style>
+
+<bq-side-menu>
+  <bq-side-menu-item active>Dashboard</bq-side-menu-item>
+  <bq-side-menu-item>Reports</bq-side-menu-item>
+  <bq-button slot="footer" appearance="link" size="small">
+    Settings
+  </bq-button>
+</bq-side-menu>
+
+<script>
+  (() => {
+    const bodyClasses = ['bq-body--side-menu', 'bq-body--side-menu__expand', 'bq-body--side-menu__collapse'];
+    const previewDocument = previewRoot.host?.ownerDocument ?? document;
+    const resetBodyClasses = () => previewDocument.body.classList.remove(...bodyClasses);
+    const scheduleReset = () => requestAnimationFrame(() => requestAnimationFrame(resetBodyClasses));
+
+    resetBodyClasses();
+    customElements.whenDefined('bq-side-menu').then(scheduleReset);
+  })();
+</script>`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-side-menu>
+      <bq-side-menu-item active>Dashboard</bq-side-menu-item>
+      <bq-side-menu-item>Reports</bq-side-menu-item>
+      <bq-button slot="footer" appearance="link" size="small">
+        Settings
+      </bq-button>
+    </bq-side-menu>
+    ```
+    ```jsx React icon="react"
+    import { BqButton, BqSideMenu, BqSideMenuItem } from "@beeq/react";
+
+    <BqSideMenu>
+      <BqSideMenuItem active>Dashboard</BqSideMenuItem>
+      <BqSideMenuItem>Reports</BqSideMenuItem>
+      <BqButton slot="footer" appearance="link" size="small">
+        Settings
+      </BqButton>
+    </BqSideMenu>
+    ```
+    ```html Angular icon="angular"
+    <bq-side-menu>
+      <bq-side-menu-item active>Dashboard</bq-side-menu-item>
+      <bq-side-menu-item>Reports</bq-side-menu-item>
+      <bq-button slot="footer" appearance="link" size="small">
+        Settings
+      </bq-button>
+    </bq-side-menu>
+    ```
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqButton, BqSideMenu, BqSideMenuItem } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSideMenu>
+        <BqSideMenuItem active>Dashboard</BqSideMenuItem>
+        <BqSideMenuItem>Reports</BqSideMenuItem>
+        <BqButton slot="footer" appearance="link" size="small">
+          Settings
+        </BqButton>
+      </BqSideMenu>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+## Best practices
+
+<CardGroup cols={2}>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Choose navigation titles that clearly communicate where each item leads.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Avoid arbitrary titles that hide the destination or force people to guess.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Keep navigation labels concise by removing words that do not add meaning.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Avoid long labels that wrap, truncate poorly, or reduce scanability.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Use sentence case for navigation items so labels read naturally.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Avoid title case or all caps when they make navigation harder to scan.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Validate icon meaning with users when icons are needed for collapsed navigation.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Do not rely on icons alone unless the destination remains understandable.
+  </Card>
+</CardGroup>
+
+## Accessibility
+
+The side menu renders the root navigation surface as an `<aside>`. Each `bq-side-menu-item` renders as a focusable button with `role="menuitem"`. The `disabled` property maps to `aria-disabled="true"` and removes the item from the tab order with `tabindex="-1"`.
+
+- **Landmark context** - include semantic heading text in the logo slot to communicate the menu purpose and where its content begins.
+- **Collapsed state** - communicate the expanded or collapsed state through your surrounding layout controls when you expose a custom toggle.
+- **Icons** - validate icon meaning with people who use assistive technology or who may need additional visual clarity.
+- **Labels** - use unique labels that make sense without additional context. The side menu item text feeds the collapsed tooltip content.
+- **Keyboard navigation** - side menu items support focus, click, <kbd>Enter</kbd>, and <kbd>Space</kbd> interaction through the underlying button.
+
+## API reference
+
+### Properties
+
+#### `bq-side-menu`
+
+| Property | Attribute | Description | Type | Default |
+|---|---|---|---|---|
+| `appearance` | `appearance` | Sets a predefined appearance of the side menu | `'brand'` \| `'default'` \| `'inverse'` | `'default'` |
+| `collapse` | `collapse` | If `true`, the container will reduce its width | `boolean` | `false` |
+| `size` | `size` | Sets the size of the navigation menu items | `'medium'` \| `'small'` | `'medium'` |
+
+#### `bq-side-menu-item`
+
+| Property | Attribute | Description | Type | Default |
+|---|---|---|---|---|
+| `active` | `active` | If `true`, the menu item will be shown as active or selected | `boolean` | `false` |
+| `collapse` | `collapse` | If `true`, the item label and suffix will be hidden and the width will be reduced according to its parent | `boolean` | `false` |
+| `disabled` | `disabled` | If `true`, the menu item will be disabled and no interaction is allowed | `boolean` | `false` |
+
+### Slots
+
+#### `bq-side-menu`
+
+| Slot | Description |
+|---|---|
+| *(default)* | The main section that holds all menu items |
+| `footer` | The section for adding footer content to the side menu |
+| `logo` | The section for displaying the logo or brand in the side menu |
+
+#### `bq-side-menu-item`
+
+| Slot | Description |
+|---|---|
+| *(default)* | The content of the menu item |
+| `prefix` | The prefix part of the menu item |
+| `suffix` | The suffix part of the menu item |
+
+### Shadow parts
+
+#### `bq-side-menu`
+
+| Part | Description |
+|---|---|
+| `base` | HTML `<aside>` root container |
+| `footer` | HTML `<div>` element that holds the footer |
+| `logo` | HTML `<div>` element that holds the logo |
+| `nav` | HTML `<nav>` element that holds the navigation items |
+
+#### `bq-side-menu-item`
+
+| Part | Description |
+|---|---|
+| `base` | The component wrapper container inside the shadow DOM |
+| `label` | The label slot |
+| `panel` | The `<div>` container that holds the tooltip content when the side menu is collapsed |
+| `prefix` | The prefix slot |
+| `suffix` | The suffix slot |
+| `trigger` | The `<div>` container that holds the element that displays the tooltip on hover when the side menu is collapsed |
+
+### CSS custom properties
+
+<Expandable title="CSS variables" defaultOpen={true}>
+  | Variable | Description | Default |
+  |---|---|---|
+  | `--bq-side-menu--bg-color` | Side menu background color | `var(--bq-background--primary)` |
+  | `--bq-side-menu--brand-color` | Side menu logo color | `var(--bq-background--brand)` |
+  | `--bq-side-menu--border-color` | Side menu border color | `var(--bq-stroke--primary)` |
+  | `--bq-side-menu--footer-box-shadow` | Side menu footer box shadow | `0 -10px 12px -12px var(--bq-background--tertiary)` |
+  | `--bq-side-menu-item--bg-default` | Side menu item default background color | `transparent` |
+  | `--bq-side-menu-item--bg-active` | Side menu item active background color | `var(--bq-ui--brand-alt)` |
+  | `--bq-side-menu-item--text-default` | Side menu item default text color | `var(--bq-text--primary)` |
+  | `--bq-side-menu-item--text-active` | Side menu item active text color | `var(--bq-text--brand)` |
+  | `--bq-side-menu-item--paddingX` | Side menu item horizontal padding | `var(--bq-spacing-l)` |
+  | `--bq-side-menu-item--paddingY` | Side menu item vertical padding | `var(--bq-spacing-m)` |
+  | `--bq-side-menu--width` | Side menu width, added to the global `:root` scope | `16rem` |
+  | `--bq-side-menu--width-collapse` | Side menu width when collapsed, added to the global `:root` scope | `4.5rem` |
+</Expandable>
+
+<Tip>
+  Learn more about [styling with shadow parts](/theming/styles) and [CSS custom properties](/theming/global-css-variables).
+</Tip>
+
+### Events
+
+| Component | Event | Description | Type |
+|---|---|---|---|
+| `bq-side-menu` | `bqCollapse` | Fires when the side menu changes its width from expanded to collapsed and vice versa | `CustomEvent<{ collapse: boolean; }>` |
+| `bq-side-menu` | `bqSelect` | Fires when the active or selected menu item changes | `CustomEvent<HTMLBqSideMenuItemElement>` |
+| `bq-side-menu-item` | `bqBlur` | Fires when the menu item loses focus | `CustomEvent<HTMLBqSideMenuItemElement>` |
+| `bq-side-menu-item` | `bqClick` | Fires when the menu item is clicked | `CustomEvent<HTMLBqSideMenuItemElement>` |
+| `bq-side-menu-item` | `bqFocus` | Fires when the menu item receives focus | `CustomEvent<HTMLBqSideMenuItemElement>` |
+
+<Note>
+  - In React, prefix events with `on`: `onBqSelect`, `onBqCollapse`, `onBqClick`.
+  - In Angular, use event binding syntax: `(bqSelect)`, `(bqCollapse)`, `(bqClick)`.
+  - In Vue, use the `@` shorthand: `@bqSelect`, `@bqCollapse`, `@bqClick`.
+</Note>
+
+### Methods
+
+| Method | Description | Returns |
+|---|---|---|
+| `toggleCollapse()` | Toggles the collapse state of the side menu | `Promise<void>` |
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card horizontal title="Interactive playground" icon="code" href="https://storybook.beeq.design/?path=/story/components-side-menu--default">
+    Explore all side menu configurations in Storybook
+  </Card>
+  <Card horizontal title="Source code" icon="github" href="https://github.com/Endava/BEEQ/tree/main/packages/beeq/src/components/side-menu">
+    View the component source on GitHub
+  </Card>
+</CardGroup>

--- a/apps/beeq-docs/components/side-menu.mdx
+++ b/apps/beeq-docs/components/side-menu.mdx
@@ -96,130 +96,341 @@ A side menu is composed of a container, selected item state, navigation items, a
 
 The default side menu is a versatile container for organizing and displaying navigation elements. Use it as the foundation for structured and intuitive navigation layouts.
 
-<CodeLivePreview code={`<style>
-  :host {
-    align-items: stretch !important;
-    justify-content: flex-start !important;
-    min-height: 22rem !important;
-    overflow: hidden !important;
-    padding: 0 !important;
-    position: relative !important;
-  }
+<CodeLivePreview mode="iframe" height="30rem" removePadding code={`
+  <style>
+    .app-logo {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-s);
+      padding-inline: var(--bq-spacing-m);
+      padding-block-start: var(--bq-spacing-m);
+    }
 
-  bq-side-menu {
-    display: block;
-    inline-size: var(--bq-side-menu--width);
-    min-height: 22rem;
-    position: relative;
-  }
+    .app-logo svg {
+      height: 2.5rem;
+      width: 2.5rem;
+    }
 
-  bq-side-menu::part(base) {
-    block-size: 100% !important;
-    inset: 0 auto 0 0 !important;
-    min-block-size: 0 !important;
-    position: absolute !important;
-  }
+    .app-logo h1 {
+      font-size: var(--bq-font-size--xl);
+      white-space: nowrap;
+    }
+  </style>
 
-  .side-menu-demo__logo {
-    display: flex;
-    align-items: center;
-    gap: var(--bq-spacing-s);
-    padding: var(--bq-spacing-m);
-  }
-
-  .side-menu-demo__title {
-    margin: 0;
-    font-size: var(--bq-font-size--xl);
-    white-space: nowrap;
-  }
-</style>
-
-<bq-side-menu>
-  <div class="side-menu-demo__logo" slot="logo">
-    <bq-icon name="hexagon" size="32"></bq-icon>
-    <h1 class="side-menu-demo__title">BEEQ</h1>
-  </div>
-  <bq-side-menu-item active>
-    <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
-    Dashboard
-  </bq-side-menu-item>
-  <bq-side-menu-item>
-    <bq-icon name="package" slot="prefix"></bq-icon>
-    Products
-    <bq-badge slot="suffix">5</bq-badge>
-  </bq-side-menu-item>
-  <bq-side-menu-item disabled>
-    <bq-icon name="gauge" slot="prefix"></bq-icon>
-    Performance
-  </bq-side-menu-item>
-</bq-side-menu>
-
-<script>
-  (() => {
-    const bodyClasses = ['bq-body--side-menu', 'bq-body--side-menu__expand', 'bq-body--side-menu__collapse'];
-    const previewDocument = previewRoot.host?.ownerDocument ?? document;
-    const resetBodyClasses = () => previewDocument.body.classList.remove(...bodyClasses);
-
-    const scheduleReset = () => requestAnimationFrame(() => requestAnimationFrame(resetBodyClasses));
-
-    // The production side menu reserves layout space on <body>; the docs preview
-    // keeps the demo contained, so remove those global layout classes after mount.
-    resetBodyClasses();
-    customElements.whenDefined('bq-side-menu').then(scheduleReset);
-  })();
-</script>`}>
+  <bq-side-menu>
+    <div class="app-logo" slot="logo">
+      <bq-icon name="square-logo" size="40"></bq-icon>
+      <h1>App Name</h1>
+    </div>
+    <bq-divider></bq-divider>
+    <bq-side-menu-item active>
+      <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+      Dashboard
+    </bq-side-menu-item>
+    <bq-side-menu-item>
+      <bq-icon name="package" slot="prefix"></bq-icon>
+      Products
+      <bq-badge slot="suffix">5</bq-badge>
+    </bq-side-menu-item>
+    <bq-side-menu-item disabled>
+      <bq-icon name="gauge" slot="prefix"></bq-icon>
+      Performance
+    </bq-side-menu-item>
+    <bq-side-menu-item>
+      <bq-icon name="truck" slot="prefix" ></bq-icon>
+      Deliver
+    </bq-side-menu-item>
+    <bq-side-menu-item>
+      <bq-icon name="files" slot="prefix" ></bq-icon>
+      Documents
+    </bq-side-menu-item>
+  </bq-side-menu>
+`}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```css styles.css icon="css3" expandable
+    .app-logo {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-s);
+      padding-inline: var(--bq-spacing-m);
+      padding-block-start: var(--bq-spacing-m);
+    }
+
+    .app-logo svg {
+      height: 2.5rem;
+      width: 2.5rem;
+    }
+
+    .app-logo h1 {
+      font-size: var(--bq-font-size--xl);
+      white-space: nowrap;
+    }
+    ```
+
+    ```html HTML icon="html5" expandable
     <bq-side-menu>
       <div slot="logo">
-        <bq-icon name="hexagon" size="32"></bq-icon>
-        <h1>BEEQ</h1>
+        <bq-icon name="square-logo" size="40"></bq-icon>
+        <h1>App Name</h1>
       </div>
-
+      <bq-divider></bq-divider>
       <bq-side-menu-item active>
         <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
         Dashboard
       </bq-side-menu-item>
-
       <bq-side-menu-item>
         <bq-icon name="package" slot="prefix"></bq-icon>
         Products
         <bq-badge slot="suffix">5</bq-badge>
       </bq-side-menu-item>
-
       <bq-side-menu-item disabled>
         <bq-icon name="gauge" slot="prefix"></bq-icon>
         Performance
       </bq-side-menu-item>
+      <bq-side-menu-item>
+        <bq-icon name="truck" slot="prefix" ></bq-icon>
+        Deliver
+      </bq-side-menu-item>
+      <bq-side-menu-item>
+        <bq-icon name="files" slot="prefix" ></bq-icon>
+        Documents
+      </bq-side-menu-item>
     </bq-side-menu>
     ```
-    ```jsx React icon="react"
-    import { BqBadge, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/react";
+
+    ```jsx React icon="react" expandable
+    import { BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/react";
+    import "./styles.css";
 
     <BqSideMenu>
       <div slot="logo">
-        <BqIcon name="hexagon" size="32" />
-        <h1>BEEQ</h1>
+        <BqIcon name="square-logo" size="40" />
+        <h1>App Name</h1>
       </div>
-
+      <BqDivider />
       <BqSideMenuItem active>
         <BqIcon name="diamonds-four" slot="prefix" />
         Dashboard
       </BqSideMenuItem>
-
       <BqSideMenuItem>
         <BqIcon name="package" slot="prefix" />
         Products
         <BqBadge slot="suffix">5</BqBadge>
       </BqSideMenuItem>
-
       <BqSideMenuItem disabled>
         <BqIcon name="gauge" slot="prefix" />
         Performance
       </BqSideMenuItem>
+      <BqSideMenuItem>
+        <BqIcon name="truck" slot="prefix" />
+        Deliver
+      </BqSideMenuItem>
+      <BqSideMenuItem>
+        <BqIcon name="files" slot="prefix" />
+        Documents
+      </BqSideMenuItem>
     </BqSideMenu>
     ```
-    ```ts Angular icon="angular"
+
+    ```ts Angular icon="angular" expandable
+    import { Component } from "@angular/core";
+    import { BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/angular/standalone";
+
+    @Component({
+      standalone: true,
+      imports: [BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem],
+      template: `
+        <bq-side-menu>
+          <div slot="logo">
+            <bq-icon name="square-logo" size="40"></bq-icon>
+            <h1>App Name</h1>
+          </div>
+          <bq-divider></bq-divider>
+          <bq-side-menu-item active>
+            <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+            Dashboard
+          </bq-side-menu-item>
+          <bq-side-menu-item>
+            <bq-icon name="package" slot="prefix"></bq-icon>
+            Products
+            <bq-badge slot="suffix">5</bq-badge>
+          </bq-side-menu-item>
+          <bq-side-menu-item disabled>
+            <bq-icon name="gauge" slot="prefix"></bq-icon>
+            Performance
+          </bq-side-menu-item>
+          <bq-side-menu-item>
+            <bq-icon name="truck" slot="prefix" ></bq-icon>
+            Deliver
+          </bq-side-menu-item>
+          <bq-side-menu-item>
+            <bq-icon name="files" slot="prefix" ></bq-icon>
+            Documents
+          </bq-side-menu-item>
+        </bq-side-menu>
+      `,
+      styles: `
+        .app-logo {
+          display: flex;
+          align-items: center;
+          gap: var(--bq-spacing-s);
+          padding-inline: var(--bq-spacing-m);
+          padding-block-start: var(--bq-spacing-m);
+        }
+
+        .app-logo svg {
+          height: 2.5rem;
+          width: 2.5rem;
+        }
+
+        .app-logo h1 {
+          font-size: var(--bq-font-size--xl);
+          white-space: nowrap;
+        }
+      `
+    })
+    export class DefaultSideMenuComponent {}
+    ```
+
+    ```vue Vue icon="vuejs" expandable
+    <script setup lang="ts">
+    import { BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSideMenu>
+        <div slot="logo">
+          <BqIcon name="square-logo" size="40" />
+          <h1>App Name</h1>
+        </div>
+        <BqDivider />
+        <BqSideMenuItem active>
+          <BqIcon name="diamonds-four" slot="prefix" />
+          Dashboard
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="package" slot="prefix" />
+          Products
+          <BqBadge slot="suffix">5</BqBadge>
+        </BqSideMenuItem>
+        <BqSideMenuItem disabled>
+          <BqIcon name="gauge" slot="prefix" />
+          Performance
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="truck" slot="prefix" />
+          Deliver
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="files" slot="prefix" />
+          Documents
+        </BqSideMenuItem>
+      </BqSideMenu>
+    </template>
+
+    <style>
+    .app-logo {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-s);
+      padding-inline: var(--bq-spacing-m);
+      padding-block-start: var(--bq-spacing-m);
+    }
+
+    .app-logo svg {
+      height: 2.5rem;
+      width: 2.5rem;
+    }
+
+    .app-logo h1 {
+      font-size: var(--bq-font-size--xl);
+      white-space: nowrap;
+    }
+    </style>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+## Side menu item behavior
+
+### Side menu item states
+
+`bq-side-menu-item` is a child component, not a standalone navigation pattern. Use it only inside `bq-side-menu`.
+
+Within a side menu, items support default, active, hover, focus, disabled, and with-counter states.
+
+<CodeLivePreview mode="iframe" height="30rem" removePadding code={`
+  <bq-side-menu>
+    <bq-side-menu-item>
+      <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+      Default
+    </bq-side-menu-item>
+    <bq-side-menu-item active>
+      <bq-icon name="package" slot="prefix"></bq-icon>
+      Active
+    </bq-side-menu-item>
+    <bq-side-menu-item disabled>
+      <bq-icon name="gauge" slot="prefix"></bq-icon>
+      Disabled
+    </bq-side-menu-item>
+    <bq-side-menu-item>
+      <bq-icon name="bell" slot="prefix"></bq-icon>
+      With counter
+      <bq-badge slot="suffix">5</bq-badge>
+    </bq-side-menu-item>
+  </bq-side-menu>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5" expandable
+    <bq-side-menu>
+      <bq-side-menu-item>
+        <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+        Default
+      </bq-side-menu-item>
+
+      <bq-side-menu-item active>
+        <bq-icon name="package" slot="prefix"></bq-icon>
+        Active
+      </bq-side-menu-item>
+
+      <bq-side-menu-item disabled>
+        <bq-icon name="gauge" slot="prefix"></bq-icon>
+        Disabled
+      </bq-side-menu-item>
+
+      <bq-side-menu-item>
+        <bq-icon name="bell" slot="prefix"></bq-icon>
+        With counter
+        <bq-badge slot="suffix">5</bq-badge>
+      </bq-side-menu-item>
+    </bq-side-menu>
+    ```
+
+    ```jsx React icon="react" expandable
+    import { BqBadge, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/react";
+
+    <BqSideMenu>
+      <BqSideMenuItem>
+        <BqIcon name="diamonds-four" slot="prefix" />
+        Default
+      </BqSideMenuItem>
+      <BqSideMenuItem active>
+        <BqIcon name="package" slot="prefix" />
+        Active
+      </BqSideMenuItem>
+      <BqSideMenuItem disabled>
+        <BqIcon name="gauge" slot="prefix" />
+        Disabled
+      </BqSideMenuItem>
+      <BqSideMenuItem>
+        <BqIcon name="bell" slot="prefix" />
+        With counter
+        <BqBadge slot="suffix">5</BqBadge>
+      </BqSideMenuItem>
+    </BqSideMenu>
+    ```
+
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqBadge, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/angular/standalone";
 
@@ -228,57 +439,55 @@ The default side menu is a versatile container for organizing and displaying nav
       imports: [BqBadge, BqIcon, BqSideMenu, BqSideMenuItem],
       template: `
         <bq-side-menu>
-          <div slot="logo">
-            <bq-icon name="hexagon" size="32"></bq-icon>
-            <h1>BEEQ</h1>
-          </div>
-
-          <bq-side-menu-item [active]="true">
+          <bq-side-menu-item>
             <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
-            Dashboard
+            Default
+          </bq-side-menu-item>
+
+          <bq-side-menu-item active>
+            <bq-icon name="package" slot="prefix"></bq-icon>
+            Active
+          </bq-side-menu-item>
+
+          <bq-side-menu-item disabled>
+            <bq-icon name="gauge" slot="prefix"></bq-icon>
+            Disabled
           </bq-side-menu-item>
 
           <bq-side-menu-item>
-            <bq-icon name="package" slot="prefix"></bq-icon>
-            Products
+            <bq-icon name="bell" slot="prefix"></bq-icon>
+            With counter
             <bq-badge slot="suffix">5</bq-badge>
-          </bq-side-menu-item>
-
-          <bq-side-menu-item [disabled]="true">
-            <bq-icon name="gauge" slot="prefix"></bq-icon>
-            Performance
           </bq-side-menu-item>
         </bq-side-menu>
       `
     })
-    export class DefaultSideMenuComponent {}
+    export class SideMenuItemStatesComponent {}
     ```
-    ```vue Vue icon="vuejs"
+
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqBadge, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/vue";
     </script>
 
     <template>
       <BqSideMenu>
-        <div slot="logo">
-          <BqIcon name="hexagon" size="32" />
-          <h1>BEEQ</h1>
-        </div>
-
-        <BqSideMenuItem active>
-          <BqIcon name="diamonds-four" slot="prefix" />
-          Dashboard
-        </BqSideMenuItem>
-
         <BqSideMenuItem>
-          <BqIcon name="package" slot="prefix" />
-          Products
-          <BqBadge slot="suffix">5</BqBadge>
+          <BqIcon name="diamonds-four" slot="prefix" />
+          Default
         </BqSideMenuItem>
-
+        <BqSideMenuItem active>
+          <BqIcon name="package" slot="prefix" />
+          Active
+        </BqSideMenuItem>
         <BqSideMenuItem disabled>
           <BqIcon name="gauge" slot="prefix" />
-          Performance
+          Disabled
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="bell" slot="prefix" />
+          With counter
+          <BqBadge slot="suffix">5</BqBadge>
         </BqSideMenuItem>
       </BqSideMenu>
     </template>
@@ -288,305 +497,69 @@ The default side menu is a versatile container for organizing and displaying nav
 
 ## Options
 
-### Item states
-
-Side menu items support default, active, hover, focus, disabled, and with-counter states.
-
-<CodeLivePreview code={`<style>
-  :host {
-    align-items: stretch !important;
-  }
-
-  .side-menu-states {
-    display: grid;
-    gap: var(--bq-spacing-xs);
-    inline-size: min(100%, 16rem);
-  }
-</style>
-
-<div class="side-menu-states">
-  <bq-side-menu-item>
-    <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
-    Default
-  </bq-side-menu-item>
-  <bq-side-menu-item active>
-    <bq-icon name="package" slot="prefix"></bq-icon>
-    Active
-  </bq-side-menu-item>
-  <bq-side-menu-item disabled>
-    <bq-icon name="gauge" slot="prefix"></bq-icon>
-    Disabled
-  </bq-side-menu-item>
-  <bq-side-menu-item>
-    <bq-icon name="bell" slot="prefix"></bq-icon>
-    With counter
-    <bq-badge slot="suffix">5</bq-badge>
-  </bq-side-menu-item>
-</div>`}>
-  <CodeGroup>
-    ```html HTML icon="html5"
-    <bq-side-menu-item>
-      <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
-      Default
-    </bq-side-menu-item>
-
-    <bq-side-menu-item active>
-      <bq-icon name="package" slot="prefix"></bq-icon>
-      Active
-    </bq-side-menu-item>
-
-    <bq-side-menu-item disabled>
-      <bq-icon name="gauge" slot="prefix"></bq-icon>
-      Disabled
-    </bq-side-menu-item>
-
-    <bq-side-menu-item>
-      <bq-icon name="bell" slot="prefix"></bq-icon>
-      With counter
-      <bq-badge slot="suffix">5</bq-badge>
-    </bq-side-menu-item>
-    ```
-    ```jsx React icon="react"
-    import { BqBadge, BqIcon, BqSideMenuItem } from "@beeq/react";
-
-    <>
-      <BqSideMenuItem>
-        <BqIcon name="diamonds-four" slot="prefix" />
-        Default
-      </BqSideMenuItem>
-      <BqSideMenuItem active>
-        <BqIcon name="package" slot="prefix" />
-        Active
-      </BqSideMenuItem>
-      <BqSideMenuItem disabled>
-        <BqIcon name="gauge" slot="prefix" />
-        Disabled
-      </BqSideMenuItem>
-      <BqSideMenuItem>
-        <BqIcon name="bell" slot="prefix" />
-        With counter
-        <BqBadge slot="suffix">5</BqBadge>
-      </BqSideMenuItem>
-    </>
-    ```
-    ```ts Angular icon="angular"
-    import { Component } from "@angular/core";
-    import { BqBadge, BqIcon, BqSideMenuItem } from "@beeq/angular/standalone";
-
-    @Component({
-      standalone: true,
-      imports: [BqBadge, BqIcon, BqSideMenuItem],
-      template: `
-        <bq-side-menu-item>
-          <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
-          Default
-        </bq-side-menu-item>
-
-        <bq-side-menu-item [active]="true">
-          <bq-icon name="package" slot="prefix"></bq-icon>
-          Active
-        </bq-side-menu-item>
-
-        <bq-side-menu-item [disabled]="true">
-          <bq-icon name="gauge" slot="prefix"></bq-icon>
-          Disabled
-        </bq-side-menu-item>
-
-        <bq-side-menu-item>
-          <bq-icon name="bell" slot="prefix"></bq-icon>
-          With counter
-          <bq-badge slot="suffix">5</bq-badge>
-        </bq-side-menu-item>
-      `
-    })
-    export class SideMenuItemStatesComponent {}
-    ```
-    ```vue Vue icon="vuejs"
-    <script setup lang="ts">
-    import { BqBadge, BqIcon, BqSideMenuItem } from "@beeq/vue";
-    </script>
-
-    <template>
-      <BqSideMenuItem>
-        <BqIcon name="diamonds-four" slot="prefix" />
-        Default
-      </BqSideMenuItem>
-      <BqSideMenuItem active>
-        <BqIcon name="package" slot="prefix" />
-        Active
-      </BqSideMenuItem>
-      <BqSideMenuItem disabled>
-        <BqIcon name="gauge" slot="prefix" />
-        Disabled
-      </BqSideMenuItem>
-      <BqSideMenuItem>
-        <BqIcon name="bell" slot="prefix" />
-        With counter
-        <BqBadge slot="suffix">5</BqBadge>
-      </BqSideMenuItem>
-    </template>
-    ```
-  </CodeGroup>
-</CodeLivePreview>
-
 ### Appearance
 
 Use the `appearance` attribute to align the side menu with your application's visual language.
 
-<CodeLivePreview code={`<style>
-  :host {
-    align-items: stretch !important;
-    gap: var(--bq-spacing-m) !important;
-  }
+#### Default
 
-  .side-menu-appearance {
-    display: grid;
-    gap: var(--bq-spacing-s);
-    grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
-    inline-size: min(100%, 44rem);
-  }
+The default appearance is a neutral style that works well in most contexts.
+It pairs with a light or dark background and uses color accents for active and hover states.
 
-  bq-side-menu {
-    block-size: 18rem;
-    display: block;
-    inline-size: 100%;
-    position: relative;
-  }
+<CodeLivePreview mode="iframe" height="30rem" removePadding code={`
+  <style>
+    .app-logo {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-s);
+      padding-inline: var(--bq-spacing-m);
+      padding-block-start: var(--bq-spacing-m);
+    }
 
-  bq-side-menu::part(base) {
-    block-size: 100% !important;
-    inset: 0 auto 0 0 !important;
-    min-block-size: 0 !important;
-    position: absolute !important;
-  }
-</style>
+    .app-logo svg {
+      height: 2.5rem;
+      width: 2.5rem;
+    }
 
-<div class="side-menu-appearance">
-  <bq-side-menu appearance="default">
-    <bq-side-menu-item active>Dashboard</bq-side-menu-item>
-    <bq-side-menu-item>Reports</bq-side-menu-item>
+    .app-logo h1 {
+      font-size: var(--bq-font-size--xl);
+      white-space: nowrap;
+    }
+  </style>
+
+  <bq-side-menu>
+    <div class="app-logo" slot="logo">
+      <bq-icon name="square-logo" size="40"></bq-icon>
+      <h1>App Name</h1>
+    </div>
+    <bq-divider></bq-divider>
+    <bq-side-menu-item active>
+      <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+      Dashboard
+    </bq-side-menu-item>
+    <bq-side-menu-item>
+      <bq-icon name="package" slot="prefix"></bq-icon>
+      Products
+      <bq-badge slot="suffix">5</bq-badge>
+    </bq-side-menu-item>
+    <bq-side-menu-item>
+      <bq-icon name="truck" slot="prefix" ></bq-icon>
+      Deliver
+    </bq-side-menu-item>
+    <bq-side-menu-item>
+      <bq-icon name="files" slot="prefix" ></bq-icon>
+      Documents
+    </bq-side-menu-item>
   </bq-side-menu>
-  <bq-side-menu appearance="brand">
-    <bq-side-menu-item active>Dashboard</bq-side-menu-item>
-    <bq-side-menu-item>Reports</bq-side-menu-item>
-  </bq-side-menu>
-  <bq-side-menu appearance="inverse">
-    <bq-side-menu-item active>Dashboard</bq-side-menu-item>
-    <bq-side-menu-item>Reports</bq-side-menu-item>
-  </bq-side-menu>
-</div>
-
-<script>
-  (() => {
-    const bodyClasses = ['bq-body--side-menu', 'bq-body--side-menu__expand', 'bq-body--side-menu__collapse'];
-    const previewDocument = previewRoot.host?.ownerDocument ?? document;
-    const resetBodyClasses = () => previewDocument.body.classList.remove(...bodyClasses);
-    const scheduleReset = () => requestAnimationFrame(() => requestAnimationFrame(resetBodyClasses));
-
-    resetBodyClasses();
-    customElements.whenDefined('bq-side-menu').then(scheduleReset);
-  })();
-</script>`}>
+`}>
   <CodeGroup>
-    ```html HTML icon="html5"
-    <bq-side-menu appearance="brand">
-      <bq-side-menu-item active>Dashboard</bq-side-menu-item>
-      <bq-side-menu-item>Reports</bq-side-menu-item>
-    </bq-side-menu>
-    ```
-    ```jsx React icon="react"
-    import { BqSideMenu, BqSideMenuItem } from "@beeq/react";
-
-    <BqSideMenu appearance="brand">
-      <BqSideMenuItem active>Dashboard</BqSideMenuItem>
-      <BqSideMenuItem>Reports</BqSideMenuItem>
-    </BqSideMenu>
-    ```
-    ```ts Angular icon="angular"
-    import { Component } from "@angular/core";
-    import { BqSideMenu, BqSideMenuItem } from "@beeq/angular/standalone";
-
-    @Component({
-      standalone: true,
-      imports: [BqSideMenu, BqSideMenuItem],
-      template: `
-        <bq-side-menu appearance="brand">
-          <bq-side-menu-item [active]="true">Dashboard</bq-side-menu-item>
-          <bq-side-menu-item>Reports</bq-side-menu-item>
-        </bq-side-menu>
-      `
-    })
-    export class BrandSideMenuComponent {}
-    ```
-    ```vue Vue icon="vuejs"
-    <script setup lang="ts">
-    import { BqSideMenu, BqSideMenuItem } from "@beeq/vue";
-    </script>
-
-    <template>
-      <BqSideMenu appearance="brand">
-        <BqSideMenuItem active>Dashboard</BqSideMenuItem>
-        <BqSideMenuItem>Reports</BqSideMenuItem>
-      </BqSideMenu>
-    </template>
-    ```
-  </CodeGroup>
-</CodeLivePreview>
-
-### Collapse and size
-
-Use `collapse` to create a compact side menu. Use `size="small"` when space is constrained and labels remain readable.
-
-<CodeLivePreview code={`<style>
-  :host {
-    align-items: stretch !important;
-    justify-content: flex-start !important;
-    min-height: 18rem !important;
-    overflow: hidden !important;
-    padding: 0 !important;
-    position: relative !important;
-  }
-
-  bq-side-menu {
-    display: block;
-    inline-size: var(--bq-side-menu--width-collapse);
-    min-height: 18rem;
-    position: relative;
-  }
-
-  bq-side-menu::part(base) {
-    block-size: 100% !important;
-    inset: 0 auto 0 0 !important;
-    min-block-size: 0 !important;
-    position: absolute !important;
-  }
-</style>
-
-<bq-side-menu collapse size="small">
-  <bq-side-menu-item active>
-    <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
-    Dashboard
-  </bq-side-menu-item>
-  <bq-side-menu-item>
-    <bq-icon name="package" slot="prefix"></bq-icon>
-    Products
-  </bq-side-menu-item>
-</bq-side-menu>
-
-<script>
-  (() => {
-    const bodyClasses = ['bq-body--side-menu', 'bq-body--side-menu__expand', 'bq-body--side-menu__collapse'];
-    const previewDocument = previewRoot.host?.ownerDocument ?? document;
-    const resetBodyClasses = () => previewDocument.body.classList.remove(...bodyClasses);
-    const scheduleReset = () => requestAnimationFrame(() => requestAnimationFrame(resetBodyClasses));
-
-    resetBodyClasses();
-    customElements.whenDefined('bq-side-menu').then(scheduleReset);
-  })();
-</script>`}>
-  <CodeGroup>
-    ```html HTML icon="html5"
-    <bq-side-menu collapse size="small">
+    ```html HTML icon="html5" expandable
+    <bq-side-menu>
+      <div class="app-logo" slot="logo">
+        <bq-icon name="square-logo" size="40"></bq-icon>
+        <h1>App Name</h1>
+      </div>
+      <bq-divider></bq-divider>
       <bq-side-menu-item active>
         <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
         Dashboard
@@ -594,13 +567,27 @@ Use `collapse` to create a compact side menu. Use `size="small"` when space is c
       <bq-side-menu-item>
         <bq-icon name="package" slot="prefix"></bq-icon>
         Products
+        <bq-badge slot="suffix">5</bq-badge>
       </bq-side-menu-item>
-    </bq-side-menu>
+      <bq-side-menu-item>
+        <bq-icon name="truck" slot="prefix" ></bq-icon>
+        Deliver
+      </bq-side-menu-item>
+      <bq-side-menu-item>
+        <bq-icon name="files" slot="prefix" ></bq-icon>
+        Documents
+      </bq-side-menu-item>
     ```
-    ```jsx React icon="react"
-    import { BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/react";
 
-    <BqSideMenu collapse size="small">
+    ```jsx React icon="react" expandable
+    import { BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/react";
+
+    <BqSideMenu>
+      <div class="app-logo" slot="logo">
+        <BqIcon name="square-logo" size="40" />
+        <h1>App Name</h1>
+      </div>
+      <BqDivider />
       <BqSideMenuItem active>
         <BqIcon name="diamonds-four" slot="prefix" />
         Dashboard
@@ -608,38 +595,67 @@ Use `collapse` to create a compact side menu. Use `size="small"` when space is c
       <BqSideMenuItem>
         <BqIcon name="package" slot="prefix" />
         Products
+        <BqBadge slot="suffix">5</BqBadge>
+      </BqSideMenuItem>
+      <BqSideMenuItem>
+        <BqIcon name="truck" slot="prefix" />
+        Deliver
+      </BqSideMenuItem>
+      <BqSideMenuItem>
+        <BqIcon name="files" slot="prefix" />
+        Documents
       </BqSideMenuItem>
     </BqSideMenu>
     ```
-    ```ts Angular icon="angular"
+
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
-    import { BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/angular/standalone";
+    import { BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/angular/standalone";
 
     @Component({
       standalone: true,
-      imports: [BqIcon, BqSideMenu, BqSideMenuItem],
+      imports: [BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem],
       template: `
-        <bq-side-menu [collapse]="true" size="small">
-          <bq-side-menu-item [active]="true">
+        <bq-side-menu>
+          <div class="app-logo" slot="logo">
+            <bq-icon name="square-logo" size="40"></bq-icon>
+            <h1>App Name</h1>
+          </div>
+          <bq-side-menu-item active>
             <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
             Dashboard
           </bq-side-menu-item>
           <bq-side-menu-item>
             <bq-icon name="package" slot="prefix"></bq-icon>
             Products
+            <bq-badge slot="suffix">5</bq-badge>
+          </bq-side-menu-item>
+          <bq-side-menu-item>
+            <bq-icon name="truck" slot="prefix" ></bq-icon>
+            Deliver
+          </bq-side-menu-item>
+          <bq-side-menu-item>
+            <bq-icon name="files" slot="prefix" ></bq-icon>
+            Documents
           </bq-side-menu-item>
         </bq-side-menu>
       `
     })
-    export class CollapsedSideMenuComponent {}
+    export class BrandSideMenuComponent {}
     ```
-    ```vue Vue icon="vuejs"
+
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
-    import { BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/vue";
+    import { BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/vue";
     </script>
 
     <template>
-      <BqSideMenu collapse size="small">
+      <BqSideMenu>
+        <div class="app-logo" slot="logo">
+          <BqIcon name="square-logo" size="40" />
+          <h1>App Name</h1>
+        </div>
+        <BqDivider />
         <BqSideMenuItem active>
           <BqIcon name="diamonds-four" slot="prefix" />
           Dashboard
@@ -647,6 +663,558 @@ Use `collapse` to create a compact side menu. Use `size="small"` when space is c
         <BqSideMenuItem>
           <BqIcon name="package" slot="prefix" />
           Products
+          <BqBadge slot="suffix">5</BqBadge>
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="truck" slot="prefix" />
+          Deliver
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="files" slot="prefix" />
+          Documents
+        </BqSideMenuItem>
+      </BqSideMenu>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+#### Brand
+
+The brand appearance highlight the brand color as the background of the side menu.
+This creates a strong visual presence and reinforces brand identity.
+
+<CodeLivePreview mode="iframe" height="30rem" removePadding code={`
+  <style>
+    .app-logo {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-s);
+      padding-inline: var(--bq-spacing-m);
+      padding-block-start: var(--bq-spacing-m);
+    }
+
+    .app-logo svg {
+      height: 2.5rem;
+      width: 2.5rem;
+    }
+
+    .app-logo h1 {
+      font-size: var(--bq-font-size--xl);
+      white-space: nowrap;
+    }
+  </style>
+
+  <bq-side-menu appearance="brand">
+    <div class="app-logo" slot="logo">
+      <bq-icon name="square-logo" size="40"></bq-icon>
+      <h1>App Name</h1>
+    </div>
+    <bq-divider></bq-divider>
+    <bq-side-menu-item active>
+      <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+      Dashboard
+    </bq-side-menu-item>
+    <bq-side-menu-item>
+      <bq-icon name="package" slot="prefix"></bq-icon>
+      Products
+      <bq-badge slot="suffix">5</bq-badge>
+    </bq-side-menu-item>
+    <bq-side-menu-item>
+      <bq-icon name="truck" slot="prefix" ></bq-icon>
+      Deliver
+    </bq-side-menu-item>
+    <bq-side-menu-item>
+      <bq-icon name="files" slot="prefix" ></bq-icon>
+      Documents
+    </bq-side-menu-item>
+  </bq-side-menu>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5" expandable
+    <bq-side-menu>
+      <div class="app-logo" slot="logo">
+        <bq-icon name="square-logo" size="40"></bq-icon>
+        <h1>App Name</h1>
+      </div>
+      <bq-divider></bq-divider>
+      <bq-side-menu-item active>
+        <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+        Dashboard
+      </bq-side-menu-item>
+      <bq-side-menu-item>
+        <bq-icon name="package" slot="prefix"></bq-icon>
+        Products
+        <bq-badge slot="suffix">5</bq-badge>
+      </bq-side-menu-item>
+      <bq-side-menu-item>
+        <bq-icon name="truck" slot="prefix" ></bq-icon>
+        Deliver
+      </bq-side-menu-item>
+      <bq-side-menu-item>
+        <bq-icon name="files" slot="prefix" ></bq-icon>
+        Documents
+      </bq-side-menu-item>
+    ```
+
+    ```jsx React icon="react" expandable
+    import { BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/react";
+
+    <BqSideMenu>
+      <div class="app-logo" slot="logo">
+        <BqIcon name="square-logo" size="40" />
+        <h1>App Name</h1>
+      </div>
+      <BqDivider />
+      <BqSideMenuItem active>
+        <BqIcon name="diamonds-four" slot="prefix" />
+        Dashboard
+      </BqSideMenuItem>
+      <BqSideMenuItem>
+        <BqIcon name="package" slot="prefix" />
+        Products
+        <BqBadge slot="suffix">5</BqBadge>
+      </BqSideMenuItem>
+      <BqSideMenuItem>
+        <BqIcon name="truck" slot="prefix" />
+        Deliver
+      </BqSideMenuItem>
+      <BqSideMenuItem>
+        <BqIcon name="files" slot="prefix" />
+        Documents
+      </BqSideMenuItem>
+    </BqSideMenu>
+    ```
+
+    ```ts Angular icon="angular" expandable
+    import { Component } from "@angular/core";
+    import { BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/angular/standalone";
+
+    @Component({
+      standalone: true,
+      imports: [BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem],
+      template: `
+        <bq-side-menu>
+          <div class="app-logo" slot="logo">
+            <bq-icon name="square-logo" size="40"></bq-icon>
+            <h1>App Name</h1>
+          </div>
+          <bq-divider></bq-divider>
+          <bq-side-menu-item active>
+            <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+            Dashboard
+          </bq-side-menu-item>
+          <bq-side-menu-item>
+            <bq-icon name="package" slot="prefix"></bq-icon>
+            Products
+            <bq-badge slot="suffix">5</bq-badge>
+          </bq-side-menu-item>
+          <bq-side-menu-item>
+            <bq-icon name="truck" slot="prefix" ></bq-icon>
+            Deliver
+          </bq-side-menu-item>
+          <bq-side-menu-item>
+            <bq-icon name="files" slot="prefix" ></bq-icon>
+            Documents
+          </bq-side-menu-item>
+        </bq-side-menu>
+      `
+    })
+    export class BrandSideMenuComponent {}
+    ```
+
+    ```vue Vue icon="vuejs" expandable
+    <script setup lang="ts">
+    import { BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSideMenu>
+        <div class="app-logo" slot="logo">
+          <BqIcon name="square-logo" size="40" />
+          <h1>App Name</h1>
+        </div>
+        <BqDivider />
+        <BqSideMenuItem active>
+          <BqIcon name="diamonds-four" slot="prefix" />
+          Dashboard
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="package" slot="prefix" />
+          Products
+          <BqBadge slot="suffix">5</BqBadge>
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="truck" slot="prefix" />
+          Deliver
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="files" slot="prefix" />
+          Documents
+        </BqSideMenuItem>
+      </BqSideMenu>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+#### Inverse
+
+The inverse appearance is designed for use as the opposite of the BEEQ mode of the application.
+For example, if your app uses `bq-mode="light"`, the inverse side menu will use the dark appearance, and vice versa.
+
+<CodeLivePreview mode="iframe" height="30rem" removePadding code={`
+  <style>
+    .app-logo {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-s);
+      padding-inline: var(--bq-spacing-m);
+      padding-block-start: var(--bq-spacing-m);
+    }
+
+    .app-logo svg {
+      height: 2.5rem;
+      width: 2.5rem;
+    }
+
+    .app-logo h1 {
+      font-size: var(--bq-font-size--xl);
+      white-space: nowrap;
+    }
+  </style>
+
+  <bq-side-menu appearance="inverse">
+    <div class="app-logo" slot="logo">
+      <bq-icon name="square-logo" size="40"></bq-icon>
+      <h1>App Name</h1>
+    </div>
+    <bq-divider></bq-divider>
+    <bq-side-menu-item active>
+      <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+      Dashboard
+    </bq-side-menu-item>
+    <bq-side-menu-item>
+      <bq-icon name="package" slot="prefix"></bq-icon>
+      Products
+      <bq-badge slot="suffix">5</bq-badge>
+    </bq-side-menu-item>
+    <bq-side-menu-item>
+      <bq-icon name="truck" slot="prefix" ></bq-icon>
+      Deliver
+    </bq-side-menu-item>
+    <bq-side-menu-item>
+      <bq-icon name="files" slot="prefix" ></bq-icon>
+      Documents
+    </bq-side-menu-item>
+  </bq-side-menu>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5" expandable
+    <bq-side-menu>
+      <div class="app-logo" slot="logo">
+        <bq-icon name="square-logo" size="40"></bq-icon>
+        <h1>App Name</h1>
+      </div>
+      <bq-divider></bq-divider>
+      <bq-side-menu-item active>
+        <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+        Dashboard
+      </bq-side-menu-item>
+      <bq-side-menu-item>
+        <bq-icon name="package" slot="prefix"></bq-icon>
+        Products
+        <bq-badge slot="suffix">5</bq-badge>
+      </bq-side-menu-item>
+      <bq-side-menu-item>
+        <bq-icon name="truck" slot="prefix" ></bq-icon>
+        Deliver
+      </bq-side-menu-item>
+      <bq-side-menu-item>
+        <bq-icon name="files" slot="prefix" ></bq-icon>
+        Documents
+      </bq-side-menu-item>
+    ```
+
+    ```jsx React icon="react" expandable
+    import { BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/react";
+
+    <BqSideMenu>
+      <div className="app-logo" slot="logo">
+        <BqIcon name="square-logo" size="40" />
+        <h1>App Name</h1>
+      </div>
+      <BqDivider />
+      <BqSideMenuItem active>
+        <BqIcon name="diamonds-four" slot="prefix" />
+        Dashboard
+      </BqSideMenuItem>
+      <BqSideMenuItem>
+        <BqIcon name="package" slot="prefix" />
+        Products
+        <BqBadge slot="suffix">5</BqBadge>
+      </BqSideMenuItem>
+      <BqSideMenuItem>
+        <BqIcon name="truck" slot="prefix" />
+        Deliver
+      </BqSideMenuItem>
+      <BqSideMenuItem>
+        <BqIcon name="files" slot="prefix" />
+        Documents
+      </BqSideMenuItem>
+    </BqSideMenu>
+    ```
+
+    ```ts Angular icon="angular" expandable
+    import { Component } from "@angular/core";
+    import { BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/angular/standalone";
+
+    @Component({
+      standalone: true,
+      imports: [BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem],
+      template: `
+        <bq-side-menu>
+          <div class="app-logo" slot="logo">
+            <bq-icon name="square-logo" size="40"></bq-icon>
+            <h1>App Name</h1>
+          </div>
+          <bq-divider></bq-divider>
+          <bq-side-menu-item active>
+            <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+            Dashboard
+          </bq-side-menu-item>
+          <bq-side-menu-item>
+            <bq-icon name="package" slot="prefix"></bq-icon>
+            Products
+            <bq-badge slot="suffix">5</bq-badge>
+          </bq-side-menu-item>
+          <bq-side-menu-item>
+            <bq-icon name="truck" slot="prefix" ></bq-icon>
+            Deliver
+          </bq-side-menu-item>
+          <bq-side-menu-item>
+            <bq-icon name="files" slot="prefix" ></bq-icon>
+            Documents
+          </bq-side-menu-item>
+        </bq-side-menu>
+      `
+    })
+    export class BrandSideMenuComponent {}
+    ```
+
+    ```vue Vue icon="vuejs" expandable
+    <script setup lang="ts">
+    import { BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSideMenu>
+        <div class="app-logo" slot="logo">
+          <BqIcon name="square-logo" size="40" />
+          <h1>App Name</h1>
+        </div>
+        <BqDivider />
+        <BqSideMenuItem active>
+          <BqIcon name="diamonds-four" slot="prefix" />
+          Dashboard
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="package" slot="prefix" />
+          Products
+          <BqBadge slot="suffix">5</BqBadge>
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="truck" slot="prefix" />
+          Deliver
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="files" slot="prefix" />
+          Documents
+        </BqSideMenuItem>
+      </BqSideMenu>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Size
+
+The side menu supports two sizes: medium (default) and small.
+The small size is a version of the side menu that shows only icons, hiding the text labels.
+Use the `size` attribute/property to switch between the two sizes.
+
+<Tip>
+  When using the medium size, there's no need to specify the `size` attribute, as it is the default.
+  Default values are not required to be set explicitly, but you can add `size="medium"` for clarity if desired.
+</Tip>
+
+<CodeLivePreview mode="iframe" height="30rem" removePadding code={`
+  <style>
+    .app-logo {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-s);
+      padding-inline: var(--bq-spacing-m);
+      padding-block-start: var(--bq-spacing-s);
+    }
+
+    .app-logo svg {
+      height: 2rem;
+      width: 2rem;
+    }
+
+    .app-logo h1 {
+      font-size: var(--bq-font-size--l);
+      white-space: nowrap;
+    }
+  </style>
+
+  <bq-side-menu size="small">
+    <div class="app-logo" slot="logo">
+      <bq-icon name="square-logo" size="32"></bq-icon>
+      <h1>App Name</h1>
+    </div>
+    <bq-divider></bq-divider>
+    <bq-side-menu-item active>
+      <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+      Dashboard
+    </bq-side-menu-item>
+    <bq-side-menu-item>
+      <bq-icon name="package" slot="prefix"></bq-icon>
+      Products
+      <bq-badge slot="suffix">5</bq-badge>
+    </bq-side-menu-item>
+    <bq-side-menu-item>
+      <bq-icon name="truck" slot="prefix" ></bq-icon>
+      Deliver
+    </bq-side-menu-item>
+    <bq-side-menu-item>
+      <bq-icon name="files" slot="prefix" ></bq-icon>
+      Documents
+    </bq-side-menu-item>
+  </bq-side-menu>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5" expandable
+    <bq-side-menu size="small">
+      <div class="app-logo" slot="logo">
+        <bq-icon name="square-logo" size="40"></bq-icon>
+        <h1>App Name</h1>
+      </div>
+      <bq-divider></bq-divider>
+      <bq-side-menu-item active>
+        <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+        Dashboard
+      </bq-side-menu-item>
+      <bq-side-menu-item>
+        <bq-icon name="package" slot="prefix"></bq-icon>
+        Products
+        <bq-badge slot="suffix">5</bq-badge>
+      </bq-side-menu-item>
+      <bq-side-menu-item>
+        <bq-icon name="truck" slot="prefix" ></bq-icon>
+        Deliver
+      </bq-side-menu-item>
+      <bq-side-menu-item>
+        <bq-icon name="files" slot="prefix" ></bq-icon>
+        Documents
+      </bq-side-menu-item>
+    ```
+
+    ```jsx React icon="react" expandable
+    import { BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/react";
+
+    <BqSideMenu size="small">
+      <div class="app-logo" slot="logo">
+        <BqIcon name="square-logo" size="40" />
+        <h1>App Name</h1>
+      </div>
+      <BqDivider />
+      <BqSideMenuItem active>
+        <BqIcon name="diamonds-four" slot="prefix" />
+        Dashboard
+      </BqSideMenuItem>
+      <BqSideMenuItem>
+        <BqIcon name="package" slot="prefix" />
+        Products
+        <BqBadge slot="suffix">5</BqBadge>
+      </BqSideMenuItem>
+      <BqSideMenuItem>
+        <BqIcon name="truck" slot="prefix" />
+        Deliver
+      </BqSideMenuItem>
+      <BqSideMenuItem>
+        <BqIcon name="files" slot="prefix" />
+        Documents
+      </BqSideMenuItem>
+    </BqSideMenu>
+    ```
+
+    ```ts Angular icon="angular" expandable
+    import { Component } from "@angular/core";
+    import { BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/angular/standalone";
+
+    @Component({
+      standalone: true,
+      imports: [BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem],
+      template: `
+        <bq-side-menu size="small">
+          <div class="app-logo" slot="logo">
+            <bq-icon name="square-logo" size="40"></bq-icon>
+            <h1>App Name</h1>
+          </div>
+          <bq-divider></bq-divider>
+          <bq-side-menu-item active>
+            <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+            Dashboard
+          </bq-side-menu-item>
+          <bq-side-menu-item>
+            <bq-icon name="package" slot="prefix"></bq-icon>
+            Products
+            <bq-badge slot="suffix">5</bq-badge>
+          </bq-side-menu-item>
+          <bq-side-menu-item>
+            <bq-icon name="truck" slot="prefix" ></bq-icon>
+            Deliver
+          </bq-side-menu-item>
+          <bq-side-menu-item>
+            <bq-icon name="files" slot="prefix" ></bq-icon>
+            Documents
+          </bq-side-menu-item>
+        </bq-side-menu>
+      `,
+    })
+    export class BrandSideMenuComponent {}
+    ```
+
+    ```vue Vue icon="vuejs" expandable
+    <script setup lang="ts">
+    import { BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSideMenu size="small">
+        <div class="app-logo" slot="logo">
+          <BqIcon name="square-logo" size="40" />
+          <h1>App Name</h1>
+        </div>
+        <BqDivider />
+        <BqSideMenuItem active>
+          <BqIcon name="diamonds-four" slot="prefix" />
+          Dashboard
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="package" slot="prefix" />
+          Products
+          <BqBadge slot="suffix">5</BqBadge>
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="truck" slot="prefix" />
+          Deliver
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="files" slot="prefix" />
+          Documents
         </BqSideMenuItem>
       </BqSideMenu>
     </template>
@@ -658,104 +1226,761 @@ Use `collapse` to create a compact side menu. Use `size="small"` when space is c
 
 Use the footer slot for supplementary actions, links, or information at the bottom of the menu.
 
-<CodeLivePreview code={`<style>
-  :host {
-    align-items: stretch !important;
-    justify-content: flex-start !important;
-    min-height: 22rem !important;
-    overflow: hidden !important;
-    padding: 0 !important;
-    position: relative !important;
-  }
+<CodeLivePreview mode="iframe" height="30rem" removePadding code={`
+  <style>
+    .app-logo {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-s);
+      padding-inline: var(--bq-spacing-m);
+      padding-block-start: var(--bq-spacing-m);
+    }
 
-  bq-side-menu {
-    display: block;
-    inline-size: var(--bq-side-menu--width);
-    min-height: 22rem;
-    position: relative;
-  }
+    .app-logo svg {
+      height: 2.5rem;
+      width: 2.5rem;
+    }
 
-  bq-side-menu::part(base) {
-    block-size: 100% !important;
-    inset: 0 auto 0 0 !important;
-    min-block-size: 0 !important;
-    position: absolute !important;
-  }
-</style>
+    .app-logo h1 {
+      font-size: var(--bq-font-size--xl);
+      white-space: nowrap;
+    }
+  </style>
 
-<bq-side-menu>
-  <bq-side-menu-item active>Dashboard</bq-side-menu-item>
-  <bq-side-menu-item>Reports</bq-side-menu-item>
-  <bq-button slot="footer" appearance="link" size="small">
-    Settings
-  </bq-button>
-</bq-side-menu>
+  <bq-side-menu>
+    <div class="app-logo" slot="logo">
+      <bq-icon name="square-logo" size="40"></bq-icon>
+      <h1>App Name</h1>
+    </div>
+    <bq-divider></bq-divider>
+    <bq-side-menu-item active>
+      <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+      Dashboard
+    </bq-side-menu-item>
+    <bq-side-menu-item>
+      <bq-icon name="package" slot="prefix"></bq-icon>
+      Products
+      <bq-badge slot="suffix">5</bq-badge>
+    </bq-side-menu-item>
+    <bq-side-menu-item disabled>
+      <bq-icon name="gauge" slot="prefix"></bq-icon>
+      Performance
+    </bq-side-menu-item>
+    <bq-side-menu-item>
+      <bq-icon name="truck" slot="prefix" ></bq-icon>
+      Deliver
+    </bq-side-menu-item>
+    <bq-side-menu-item>
+      <bq-icon name="files" slot="prefix" ></bq-icon>
+      Documents
+    </bq-side-menu-item>
 
-<script>
-  (() => {
-    const bodyClasses = ['bq-body--side-menu', 'bq-body--side-menu__expand', 'bq-body--side-menu__collapse'];
-    const previewDocument = previewRoot.host?.ownerDocument ?? document;
-    const resetBodyClasses = () => previewDocument.body.classList.remove(...bodyClasses);
-    const scheduleReset = () => requestAnimationFrame(() => requestAnimationFrame(resetBodyClasses));
-
-    resetBodyClasses();
-    customElements.whenDefined('bq-side-menu').then(scheduleReset);
-  })();
-</script>`}>
-  <CodeGroup>
-    ```html HTML icon="html5"
-    <bq-side-menu>
-      <bq-side-menu-item active>Dashboard</bq-side-menu-item>
-      <bq-side-menu-item>Reports</bq-side-menu-item>
-      <bq-button slot="footer" appearance="link" size="small">
-        Settings
+    <div slot="footer">
+      <bq-button appearance="text" only-icon>
+        <bq-icon name="bell"></bq-icon>
       </bq-button>
+      <bq-button appearance="text" only-icon>
+        <bq-icon name="chats-circle"></bq-icon>
+      </bq-button>
+      <bq-button appearance="text" only-icon>
+        <bq-icon name="sliders"></bq-icon>
+      </bq-button>
+    </div>
+  </bq-side-menu>
+`}>
+  <CodeGroup>
+    ```css styles.css icon="css3" expandable
+    app-logo {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-s);
+      padding-inline: var(--bq-spacing-m);
+      padding-block-start: var(--bq-spacing-m);
+    }
+
+    app-logo svg {
+      height: 2.5rem;
+      width: 2.5rem;
+    }
+
+    app-logo h1 {
+      font-size: var(--bq-font-size--l);
+      white-space: nowrap;
+    }
+    ```
+
+    ```html HTML icon="html5" expandable
+    <bq-side-menu>
+      <div class="app-logo" slot="logo">
+        <bq-icon name="square-logo" size="40"></bq-icon>
+        <h1>App Name</h1>
+      </div>
+      <bq-divider></bq-divider>
+      <bq-side-menu-item active>
+        <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+        Dashboard
+      </bq-side-menu-item>
+      <bq-side-menu-item>
+        <bq-icon name="package" slot="prefix"></bq-icon>
+        Products
+        <bq-badge slot="suffix">5</bq-badge>
+      </bq-side-menu-item>
+      <bq-side-menu-item disabled>
+        <bq-icon name="gauge" slot="prefix"></bq-icon>
+        Performance
+      </bq-side-menu-item>
+      <bq-side-menu-item>
+        <bq-icon name="truck" slot="prefix" ></bq-icon>
+        Deliver
+      </bq-side-menu-item>
+      <bq-side-menu-item>
+        <bq-icon name="files" slot="prefix" ></bq-icon>
+        Documents
+      </bq-side-menu-item>
+
+      <div slot="footer">
+        <bq-button appearance="text" only-icon>
+          <bq-icon name="bell"></bq-icon>
+        </bq-button>
+        <bq-button appearance="text" only-icon>
+          <bq-icon name="chats-circle"></bq-icon>
+        </bq-button>
+        <bq-button appearance="text" only-icon>
+          <bq-icon name="sliders"></bq-icon>
+        </bq-button>
+      </div>
     </bq-side-menu>
     ```
-    ```jsx React icon="react"
-    import { BqButton, BqSideMenu, BqSideMenuItem } from "@beeq/react";
+
+    ```jsx React icon="react" expandable
+    import { BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/react";
+    import "./styles.css";
 
     <BqSideMenu>
-      <BqSideMenuItem active>Dashboard</BqSideMenuItem>
-      <BqSideMenuItem>Reports</BqSideMenuItem>
-      <BqButton slot="footer" appearance="link" size="small">
-        Settings
-      </BqButton>
+      <div className="app-logo" slot="logo">
+        <BqIcon name="square-logo" size="40" />
+        <h1>App Name</h1>
+      </div>
+      <BqDivider />
+      <BqSideMenuItem active>
+        <BqIcon name="diamonds-four" slot="prefix" />
+        Dashboard
+      </BqSideMenuItem>
+      <BqSideMenuItem>
+        <BqIcon name="package" slot="prefix" />
+        Products
+        <BqBadge slot="suffix">5</BqBadge>
+      </BqSideMenuItem>
+      <BqSideMenuItem disabled>
+        <BqIcon name="gauge" slot="prefix" />
+        Performance
+      </BqSideMenuItem>
+      <BqSideMenuItem>
+        <BqIcon name="truck" slot="prefix" />
+        Deliver
+      </BqSideMenuItem>
+      <BqSideMenuItem>
+        <BqIcon name="files" slot="prefix" />
+        Documents
+      </BqSideMenuItem>
+
+      <div slot="footer">
+        <BqButton appearance="text" only-icon>
+          <BqIcon name="bell"></BqIcon>
+        </BqButton>
+        <BqButton appearance="text" only-icon>
+          <BqIcon name="chats-circle"></BqIcon>
+        </BqButton>
+        <BqButton appearance="text" only-icon>
+          <BqIcon name="sliders"></BqIcon>
+        </BqButton>
+      </div>
     </BqSideMenu>
     ```
-    ```ts Angular icon="angular"
+
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
-    import { BqButton, BqSideMenu, BqSideMenuItem } from "@beeq/angular/standalone";
+    import { BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/angular/standalone";
 
     @Component({
       standalone: true,
-      imports: [BqButton, BqSideMenu, BqSideMenuItem],
+      imports: [BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem],
       template: `
         <bq-side-menu>
-          <bq-side-menu-item [active]="true">Dashboard</bq-side-menu-item>
-          <bq-side-menu-item>Reports</bq-side-menu-item>
-          <bq-button slot="footer" appearance="link" size="small">
-            Settings
-          </bq-button>
+          <div class="app-logo" slot="logo">
+            <bq-icon name="square-logo" size="40"></bq-icon>
+            <h1>App Name</h1>
+          </div>
+          <bq-divider></bq-divider>
+          <bq-side-menu-item active>
+            <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+            Dashboard
+          </bq-side-menu-item>
+          <bq-side-menu-item>
+            <bq-icon name="package" slot="prefix"></bq-icon>
+            Products
+            <bq-badge slot="suffix">5</bq-badge>
+          </bq-side-menu-item>
+          <bq-side-menu-item disabled>
+            <bq-icon name="gauge" slot="prefix"></bq-icon>
+            Performance
+          </bq-side-menu-item>
+          <bq-side-menu-item>
+            <bq-icon name="truck" slot="prefix" ></bq-icon>
+            Deliver
+          </bq-side-menu-item>
+          <bq-side-menu-item>
+            <bq-icon name="files" slot="prefix" ></bq-icon>
+            Documents
+          </bq-side-menu-item>
+
+          <div slot="footer">
+            <bq-button appearance="text" only-icon>
+              <bq-icon name="bell"></bq-icon>
+            </bq-button>
+            <bq-button appearance="text" only-icon>
+              <bq-icon name="chats-circle"></bq-icon>
+            </bq-button>
+            <bq-button appearance="text" only-icon>
+              <bq-icon name="sliders"></bq-icon>
+            </bq-button>
+          </div>
         </bq-side-menu>
+      `,
+      styles: `
+        .app-logo {
+          display: flex;
+          align-items: center;
+          gap: var(--bq-spacing-s);
+          padding-block: var(--bq-spacing-m);
+          padding-inline: var(--bq-spacing-l);
+        }
+
+        .app-logo svg {
+          height: 2.5rem;
+          width: 2.5rem;
+        }
+
+        .app-logo h1 {
+          font-size: var(--bq-font-size--xl);
+          white-space: nowrap;
+        }
       `
     })
-    export class SideMenuFooterComponent {}
+    export class DefaultSideMenuComponent {}
     ```
-    ```vue Vue icon="vuejs"
+
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
-    import { BqButton, BqSideMenu, BqSideMenuItem } from "@beeq/vue";
+    import { BqBadge, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/vue";
     </script>
 
     <template>
       <BqSideMenu>
-        <BqSideMenuItem active>Dashboard</BqSideMenuItem>
-        <BqSideMenuItem>Reports</BqSideMenuItem>
-        <BqButton slot="footer" appearance="link" size="small">
-          Settings
-        </BqButton>
+        <div class="app-logo" slot="logo">
+          <BqIcon name="square-logo" size="40" />
+          <h1>App Name</h1>
+        </div>
+        <BqDivider />
+        <BqSideMenuItem active>
+          <BqIcon name="diamonds-four" slot="prefix" />
+          Dashboard
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="package" slot="prefix" />
+          Products
+          <BqBadge slot="suffix">5</BqBadge>
+        </BqSideMenuItem>
+        <BqSideMenuItem disabled>
+          <BqIcon name="gauge" slot="prefix" />
+          Performance
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="truck" slot="prefix" />
+          Deliver
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="files" slot="prefix" />
+          Documents
+        </BqSideMenuItem>
       </BqSideMenu>
+
+      <div slot="footer">
+        <BqButton appearance="text" only-icon>
+          <BqIcon name="bell"></bq-icon>
+        </BqButton>
+        <BqButton appearance="text" only-icon>
+          <BqIcon name="chats-circle"></bq-icon>
+        </BqButton>
+        <BqButton appearance="text" only-icon>
+          <BqIcon name="sliders"></bq-icon>
+        </BqButton>
+      </div>
     </template>
+
+    <style>
+    .app-logo {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-s);
+      padding: var(--bq-spacing-m);
+    }
+
+    .app-logo svg {
+      height: 2.5rem;
+      width: 2.5rem;
+    }
+
+    .app-logo h1 {
+      font-size: var(--bq-font-size--xl);
+      white-space: nowrap;
+    }
+    </style>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Collapse
+
+Use `collapse` to create a compact side menu. Collapsed menus show icons and hide labels, but the logo can be customized to show or hide based on the collapsed state.
+The menu items will display their label content in a tooltip on hover when the menu is collapsed.
+
+<CodeLivePreview mode="iframe" height="30rem" removePadding code={`
+  <style>
+    .app-menu[collapse] [slot="logo"] {
+      padding-inline: var(--bq-spacing-xs);
+    }
+
+    .app-menu[collapse] [slot="logo"] h1 {
+      display: none;
+    }
+
+    .app-menu[collapse] [slot="footer"] bq-icon[name="arrow-line-left"] {
+      transform: rotate(180deg);
+    }
+
+    .app-menu .app-logo {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-s);
+      padding-inline: var(--bq-spacing-m);
+      padding-block-start: var(--bq-spacing-m);
+    }
+
+    .app-menu .app-logo svg {
+      block-size: 2.5rem;
+      inline-size: 2.5rem;
+    }
+
+    .app-menu .app-logo h1 {
+      font-size: var(--bq-font-size--xl);
+      white-space: nowrap;
+    }
+
+    .app-menu bq-icon[name="arrow-line-left"] {
+      transition: transform 0.3s ease;
+    }
+
+    .app-content {
+      padding: var(--bq-spacing-m);
+    }
+
+    .app-content h1 {
+      margin-block-end: var(--bq-spacing-l);
+    }
+
+    .app-surface {
+      block-size: 20rem;
+      inline-size: 100%;
+      border: 2px dashed var(--bq-color-primary);
+      background-color: var(--bq-ui--alt);
+    }
+  </style>
+
+  <bq-side-menu class="app-menu" collapse>
+    <div class="app-logo" slot="logo">
+      <bq-icon name="square-logo" size="40"></bq-icon>
+      <h1>App Name</h1>
+    </div>
+    <bq-divider></bq-divider>
+    <bq-side-menu-item active>
+      <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+      Dashboard
+    </bq-side-menu-item>
+    <bq-side-menu-item>
+      <bq-icon name="package" slot="prefix"></bq-icon>
+      Products
+      <bq-badge slot="suffix">5</bq-badge>
+    </bq-side-menu-item>
+    <bq-side-menu-item>
+      <bq-icon name="truck" slot="prefix" ></bq-icon>
+      Deliver
+    </bq-side-menu-item>
+    <bq-side-menu-item>
+      <bq-icon name="files" slot="prefix" ></bq-icon>
+      Documents
+    </bq-side-menu-item>
+
+    <div slot="footer">
+      <bq-button appearance="text" data-action="collapse" only-icon>
+        <bq-icon name="arrow-line-left"></bq-icon>
+      </bq-button>
+    </div>
+  </bq-side-menu>
+
+  <main class="app-content">
+    <h1>Dashboard</h1>
+    <div class="app-surface">
+      <!-- Your content -->
+    </div>
+  </main>
+
+  <script>
+    (() => {
+      const sideMenu = previewRoot.querySelector('bq-side-menu');
+      const collapseButton = previewRoot.querySelector('bq-button[data-action="collapse"]');
+      if (!sideMenu || !collapseButton) return;
+
+      // Keep initial a11y label in sync with current state.
+      const syncButtonState = () => {
+        const isCollapsed = sideMenu.hasAttribute('collapse');
+        collapseButton.toggleAttribute('only-icon', isCollapsed);
+        collapseButton.setAttribute('aria-label', isCollapsed ? 'Expand side menu' : 'Collapse side menu');
+      };
+
+      syncButtonState();
+
+      collapseButton.addEventListener('bqClick', () => {
+        const nextCollapsed = !sideMenu.hasAttribute('collapse');
+        sideMenu.toggleAttribute('collapse', nextCollapsed);
+        syncButtonState();
+      });
+    })();
+  </script>
+`}>
+  <CodeGroup>
+    ```css styles.css icon="css" expandable
+    .app-menu[collapse] [slot="logo"] {
+      padding-inline: var(--bq-spacing-xs);
+    }
+
+    .app-menu[collapse] [slot="logo"] h1 {
+      display: none;
+    }
+
+    .app-menu[collapse] [slot="footer"] bq-icon[name="arrow-line-left"] {
+      transform: rotate(180deg);
+    }
+
+    .app-menu .app-logo {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-s);
+      padding: var(--bq-spacing-m);
+    }
+
+    .app-menu .app-logo svg {
+      block-size: 2.5rem;
+      inline-size: 2.5rem;
+    }
+
+    .app-menu .app-logo h1 {
+      font-size: var(--bq-font-size--xl);
+      white-space: nowrap;
+    }
+
+    .app-menu bq-icon[name="arrow-line-left"] {
+      transition: transform 0.3s ease;
+    }
+
+    .app-content {
+      padding: var(--bq-spacing-m);
+    }
+
+    .app-content h1 {
+      margin-block-end: var(--bq-spacing-l);
+    }
+
+    .app-surface {
+      block-size: 20rem;
+      inline-size: 100%;
+      border: 2px dashed var(--bq-color-primary);
+      background-color: var(--bq-ui--alt);
+    }
+    ```
+
+    ```html HTML icon="html5" expandable
+    <bq-side-menu>
+      <div class="app-logo" slot="logo">
+        <bq-icon name="square-logo" size="40"></bq-icon>
+        <h1>App Name</h1>
+      </div>
+      <bq-divider></bq-divider>
+      <bq-side-menu-item active>
+        <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+        Dashboard
+      </bq-side-menu-item>
+      <bq-side-menu-item>
+        <bq-icon name="package" slot="prefix"></bq-icon>
+        Products
+        <bq-badge slot="suffix">5</bq-badge>
+      </bq-side-menu-item>
+      <bq-side-menu-item>
+        <bq-icon name="truck" slot="prefix" ></bq-icon>
+        Deliver
+      </bq-side-menu-item>
+      <bq-side-menu-item>
+        <bq-icon name="files" slot="prefix" ></bq-icon>
+        Documents
+      </bq-side-menu-item>
+
+      <div slot="footer">
+        <bq-button appearance="text" data-action="collapse" only-icon>
+          <bq-icon name="arrow-line-left"></bq-icon>
+        </bq-button>
+      </div>
+    </bq-side-menu>
+
+    <main class="app-content">
+      <h1>Dashboard</h1>
+      <div class="app-surface">
+        <!-- Your content -->
+      </div>
+    </main>
+    ```
+
+    ```jsx React icon="react" expandable
+    import { BqBadge, BqButton, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/react";
+    import "./styles.css";
+
+    <>
+      <BqSideMenu>
+        <div class="app-logo" slot="logo">
+          <BqIcon name="square-logo" size="40" />
+          <h1>App Name</h1>
+        </div>
+        <BqDivider />
+        <BqSideMenuItem active>
+          <BqIcon name="diamonds-four" slot="prefix" />
+          Dashboard
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="package" slot="prefix" />
+          Products
+          <BqBadge slot="suffix">5</BqBadge>
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="truck" slot="prefix" />
+          Deliver
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="files" slot="prefix" />
+          Documents
+        </BqSideMenuItem>
+
+        <div slot="footer">
+          <BqButton appearance="text" data-action="collapse" only-icon>
+            <BqIcon name="arrow-line-left"></BqIcon>
+          </BqButton>
+        </div>
+      </BqSideMenu>
+
+      <main className="app-content">
+        <h1>Dashboard</h1>
+        <div className="app-surface">
+          {/* Your content */}
+        </div>
+      </main>
+    </>
+    ```
+
+    ```ts Angular icon="angular" expandable
+    import { Component } from "@angular/core";
+    import { BqBadge, BqButton, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/angular/standalone";
+
+    @Component({
+      standalone: true,
+      imports: [BqBadge, BqButton, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem],
+      template: `
+        <bq-side-menu>
+          <div class="app-logo" slot="logo">
+            <bq-icon name="square-logo" size="40"></bq-icon>
+            <h1>App Name</h1>
+          </div>
+          <bq-divider></bq-divider>
+          <bq-side-menu-item active>
+            <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+            Dashboard
+          </bq-side-menu-item>
+          <bq-side-menu-item>
+            <bq-icon name="package" slot="prefix"></bq-icon>
+            Products
+            <bq-badge slot="suffix">5</bq-badge>
+          </bq-side-menu-item>
+          <bq-side-menu-item>
+            <bq-icon name="truck" slot="prefix" ></bq-icon>
+            Deliver
+          </bq-side-menu-item>
+          <bq-side-menu-item>
+            <bq-icon name="files" slot="prefix" ></bq-icon>
+            Documents
+          </bq-side-menu-item>
+        </bq-side-menu>
+
+        <main class="app-content">
+          <h1>Dashboard</h1>
+          <div class="app-surface">
+            <!-- Your content -->
+          </div>
+        </main>
+      `,
+      styles: `
+        .app-menu[collapse] [slot="logo"] {
+          padding-inline: var(--bq-spacing-xs);
+        }
+
+        .app-menu[collapse] [slot="logo"] h1 {
+          display: none;
+        }
+
+        .app-menu[collapse] [slot="footer"] bq-icon[name="arrow-line-left"] {
+          transform: rotate(180deg);
+        }
+
+        .app-menu .app-logo {
+          display: flex;
+          align-items: center;
+          gap: var(--bq-spacing-s);
+          padding: var(--bq-spacing-m);
+        }
+
+        .app-menu .app-logo svg {
+          block-size: 2.5rem;
+          inline-size: 2.5rem;
+        }
+
+        .app-menu .app-logo h1 {
+          font-size: var(--bq-font-size--xl);
+          white-space: nowrap;
+        }
+
+        .app-menu bq-icon[name="arrow-line-left"] {
+          transition: transform 0.3s ease;
+        }
+
+        .app-content {
+          padding: var(--bq-spacing-m);
+        }
+
+        .app-content h1 {
+          margin-block-end: var(--bq-spacing-l);
+        }
+
+        .app-surface {
+          block-size: 20rem;
+          inline-size: 100%;
+          border: 2px dashed var(--bq-color-primary);
+          background-color: var(--bq-ui--alt);
+        }
+      `
+    })
+    export class BrandSideMenuComponent {}
+    ```
+
+    ```vue Vue icon="vuejs" expandable
+    <script setup lang="ts">
+    import { BqBadge, BqButton, BqDivider, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSideMenu>
+        <div class="app-logo" slot="logo">
+          <BqIcon name="square-logo" size="40" />
+          <h1>App Name</h1>
+        </div>
+        <BqDivider />
+        <BqSideMenuItem active>
+          <BqIcon name="diamonds-four" slot="prefix" />
+          Dashboard
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="package" slot="prefix" />
+          Products
+          <BqBadge slot="suffix">5</BqBadge>
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="truck" slot="prefix" />
+          Deliver
+        </BqSideMenuItem>
+        <BqSideMenuItem>
+          <BqIcon name="files" slot="prefix" />
+          Documents
+        </BqSideMenuItem>
+
+        <div slot="footer">
+          <BqButton appearance="text" data-action="collapse" only-icon>
+            <BqIcon name="arrow-line-left"></BqIcon>
+          </BqButton>
+        </div>
+      </BqSideMenu>
+
+      <main class="app-content">
+        <h1>Dashboard</h1>
+        <div class="app-surface">
+          <!-- Your content -->
+        </div>
+      </main>
+    </template>
+
+    <style>
+      .app-menu[collapse] [slot="logo"] {
+        padding-inline: var(--bq-spacing-xs);
+      }
+
+      .app-menu[collapse] [slot="logo"] h1 {
+        display: none;
+      }
+
+      .app-menu[collapse] [slot="footer"] bq-icon[name="arrow-line-left"] {
+        transform: rotate(180deg);
+      }
+
+      .app-menu .app-logo {
+        display: flex;
+        align-items: center;
+        gap: var(--bq-spacing-s);
+        padding: var(--bq-spacing-m);
+      }
+
+      .app-menu .app-logo svg {
+        block-size: 2.5rem;
+        inline-size: 2.5rem;
+      }
+
+      .app-menu .app-logo h1 {
+        font-size: var(--bq-font-size--xl);
+        white-space: nowrap;
+      }
+
+      .app-menu bq-icon[name="arrow-line-left"] {
+        transition: transform 0.3s ease;
+      }
+
+      .app-content {
+        padding: var(--bq-spacing-m);
+      }
+
+      .app-content h1 {
+        margin-block-end: var(--bq-spacing-l);
+      }
+
+      .app-surface {
+        block-size: 20rem;
+        inline-size: 100%;
+        border: 2px dashed var(--bq-color-primary);
+        background-color: var(--bq-ui--alt);
+      }
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -893,13 +2118,20 @@ The side menu renders its root surface as an `<aside>` and places menu items ins
 
 ### Events
 
-| Component | Event | Description | Type |
-|---|---|---|---|
-| `bq-side-menu` | `bqCollapse` | Fires when the side menu changes its width from expanded to collapsed and vice versa | `CustomEvent<{ collapse: boolean; }>` |
-| `bq-side-menu` | `bqSelect` | Fires when the active or selected menu item changes | `CustomEvent<HTMLBqSideMenuItemElement>` |
-| `bq-side-menu-item` | `bqBlur` | Fires when the menu item loses focus | `CustomEvent<HTMLBqSideMenuItemElement>` |
-| `bq-side-menu-item` | `bqClick` | Fires when the menu item is clicked | `CustomEvent<HTMLBqSideMenuItemElement>` |
-| `bq-side-menu-item` | `bqFocus` | Fires when the menu item receives focus | `CustomEvent<HTMLBqSideMenuItemElement>` |
+#### `bq-side-menu`
+
+| Event | Description | Type |
+|---|---|---|
+| `bqCollapse` | Fires when the side menu changes its width from expanded to collapsed and vice versa | `CustomEvent<{ collapse: boolean; }>` |
+| `bqSelect` | Fires when the active or selected menu item changes | `CustomEvent<HTMLBqSideMenuItemElement>` |
+
+#### `bq-side-menu-item`
+
+| Event | Description | Type |
+|---|---|---|
+| `bqBlur` | Fires when the menu item loses focus | `CustomEvent<HTMLBqSideMenuItemElement>` |
+| `bqClick` | Fires when the menu item is clicked | `CustomEvent<HTMLBqSideMenuItemElement>` |
+| `bqFocus` | Fires when the menu item receives focus | `CustomEvent<HTMLBqSideMenuItemElement>` |
 
 <Note>
   - In React, prefix events with `on`: `onBqSelect`, `onBqCollapse`, `onBqClick`.
@@ -915,25 +2147,28 @@ The side menu renders its root surface as an `<aside>` and places menu items ins
 
 ### CSS custom properties
 
-<Expandable title="CSS variables" defaultOpen={true}>
-  | Variable | Description | Default |
-  |---|---|---|
-  | `--bq-side-menu--bg-color` | Side menu background color | `var(--bq-background--primary)` |
-  | `--bq-side-menu--brand-color` | Side menu logo color | `var(--bq-background--brand)` |
-  | `--bq-side-menu--border-color` | Side menu border color | `var(--bq-stroke--primary)` |
-  | `--bq-side-menu--footer-box-shadow` | Side menu footer box shadow | `0 -10px 12px -12px var(--bq-background--tertiary)` |
-  | `--bq-side-menu-item--bg-default` | Side menu item default background color | `transparent` |
-  | `--bq-side-menu-item--bg-active` | Side menu item active background color | `var(--bq-ui--brand-alt)` |
-  | `--bq-side-menu-item--text-default` | Side menu item default text color | `var(--bq-text--primary)` |
-  | `--bq-side-menu-item--text-active` | Side menu item active text color | `var(--bq-text--brand)` |
-  | `--bq-side-menu-item--paddingX` | Side menu item horizontal padding | `var(--bq-spacing-l)` |
-  | `--bq-side-menu-item--paddingY` | Side menu item vertical padding | `var(--bq-spacing-m)` |
-  | `--bq-side-menu--width` | Side menu width, added to the global `:root` scope | `16rem` |
-  | `--bq-side-menu--width-collapse` | Side menu width when collapsed, added to the global `:root` scope | `4.5rem` |
-</Expandable>
+#### `bq-side-menu`
+
+| Variable | Description | Default |
+|---|---|---|
+| `--bq-side-menu--bg-color` | Side menu background color | `var(--bq-background--primary)` |
+| `--bq-side-menu--brand-color` | Side menu logo color | `var(--bq-background--brand)` |
+| `--bq-side-menu--border-color` | Side menu border color | `var(--bq-stroke--primary)` |
+| `--bq-side-menu--footer-box-shadow` | Side menu footer box shadow | `0 -10px 12px -12px var(--bq-background--tertiary)` |
+
+#### `bq-side-menu-item`
+
+| Variable | Description | Default |
+|---|---|---|
+| `--bq-side-menu-item--bg-default` | Side menu item default background color | `transparent` |
+| `--bq-side-menu-item--bg-active` | Side menu item active background color | `var(--bq-ui--brand-alt)` |
+| `--bq-side-menu-item--text-default` | Side menu item default text color | `var(--bq-text--primary)` |
+| `--bq-side-menu-item--text-active` | Side menu item active text color | `var(--bq-text--brand)` |
+| `--bq-side-menu-item--paddingX` | Side menu item horizontal padding | `var(--bq-spacing-l)` |
+| `--bq-side-menu-item--paddingY` | Side menu item vertical padding | `var(--bq-spacing-m)` |
 
 <Tip>
-  Learn more about [styling with shadow parts](/theming/styles) and [CSS custom properties](/theming/global-css-variables).
+  Learn more about [styling with shadow parts](/guides/styles) and [CSS custom properties](/theming/component-css-variables).
 </Tip>
 
 ## Resources

--- a/apps/beeq-docs/components/side-menu.mdx
+++ b/apps/beeq-docs/components/side-menu.mdx
@@ -7,7 +7,8 @@ import { CardTile } from '/snippets/CardTile.jsx';
 import { CodeLivePreview } from "/snippets/CodeLivePreview.jsx";
 
 <Frame className="px-4 py-4" caption="Side Menu overview">
-  <img src="https://placeholdit.com/600x400" alt="Placeholder for the Side Menu overview image" />
+  <img className="block dark:hidden" src="/components/images/side-menu/side-menu-overview-light.svg" alt="BEEQ Side Menu component overview" />
+  <img className="hidden dark:block" src="/components/images/side-menu/side-menu-overview-dark.svg" alt="BEEQ Side Menu component overview" />
 </Frame>
 
 The side menu is a vertical navigation element that sits alongside a page or application layout. It acts as a central hub for accessing sections, features, and functionality.
@@ -57,32 +58,33 @@ The side menu is a vertical navigation element that sits alongside a page or app
 ## Anatomy
 
 <Frame className="px-4 py-4" caption="Side Menu anatomy">
-  <img src="https://placeholdit.com/1000x420" alt="Placeholder for the Side Menu anatomy image" />
+  <img className="block dark:hidden" src="/components/images/side-menu/side-menu-anatomy-light.svg" alt="BEEQ Side Menu component anatomy" />
+  <img className="hidden dark:block" src="/components/images/side-menu/side-menu-anatomy-dark.svg" alt="BEEQ Side Menu component anatomy" />
 </Frame>
 
-A side menu is composed of a container, selected item state, navigation items, and an expand/collapse control.
+A side menu is composed of a container, selected item state, navigation items, and optional logo and footer areas.
 
 | Part | Element | Description |
 |---|---|---|
 | **1** | Container | The root `<aside>` surface that holds the side menu |
 | **2** | Selected | The active item that represents the current location |
 | **3** | Navigation item | A selectable `bq-side-menu-item` with optional prefix and suffix content |
-| **4** | Expand/collapse button | The control used to toggle between expanded and collapsed views |
+| **4** | Logo and footer slots | Optional areas for brand content and supplementary actions |
 
 ## Design guidelines
 
 <CardGroup cols={2}>
   <CardTile
     title="Keep navigation available"
-    imageLightSrc="https://placeholdit.com/480x320"
-    imageDarkSrc="https://placeholdit.com/480x320"
+    imageLightSrc="/components/images/side-menu/side-menu-keep-navigation-light.svg"
+    imageDarkSrc="/components/images/side-menu/side-menu-keep-navigation-dark.svg"
   >
     The side menu can scroll separately from the main content. This keeps navigation available when the page content is long.
   </CardTile>
   <CardTile
     title="Write clear labels"
-    imageLightSrc="https://placeholdit.com/480x320"
-    imageDarkSrc="https://placeholdit.com/480x320"
+    imageLightSrc="/components/images/side-menu/side-menu-clear-labels-light.svg"
+    imageDarkSrc="/components/images/side-menu/side-menu-clear-labels-dark.svg"
   >
     Use short, unique labels in sentence case. The link text should explain the destination without extra context.
   </CardTile>
@@ -217,29 +219,39 @@ The default side menu is a versatile container for organizing and displaying nav
       </BqSideMenuItem>
     </BqSideMenu>
     ```
-    ```html Angular icon="angular"
-    <bq-side-menu>
-      <div slot="logo">
-        <bq-icon name="hexagon" size="32"></bq-icon>
-        <h1>BEEQ</h1>
-      </div>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqBadge, BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/angular/standalone";
 
-      <bq-side-menu-item active>
-        <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
-        Dashboard
-      </bq-side-menu-item>
+    @Component({
+      standalone: true,
+      imports: [BqBadge, BqIcon, BqSideMenu, BqSideMenuItem],
+      template: `
+        <bq-side-menu>
+          <div slot="logo">
+            <bq-icon name="hexagon" size="32"></bq-icon>
+            <h1>BEEQ</h1>
+          </div>
 
-      <bq-side-menu-item>
-        <bq-icon name="package" slot="prefix"></bq-icon>
-        Products
-        <bq-badge slot="suffix">5</bq-badge>
-      </bq-side-menu-item>
+          <bq-side-menu-item [active]="true">
+            <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+            Dashboard
+          </bq-side-menu-item>
 
-      <bq-side-menu-item disabled>
-        <bq-icon name="gauge" slot="prefix"></bq-icon>
-        Performance
-      </bq-side-menu-item>
-    </bq-side-menu>
+          <bq-side-menu-item>
+            <bq-icon name="package" slot="prefix"></bq-icon>
+            Products
+            <bq-badge slot="suffix">5</bq-badge>
+          </bq-side-menu-item>
+
+          <bq-side-menu-item [disabled]="true">
+            <bq-icon name="gauge" slot="prefix"></bq-icon>
+            Performance
+          </bq-side-menu-item>
+        </bq-side-menu>
+      `
+    })
+    export class DefaultSideMenuComponent {}
     ```
     ```vue Vue icon="vuejs"
     <script setup lang="ts">
@@ -357,27 +369,37 @@ Side menu items support default, active, hover, focus, disabled, and with-counte
       </BqSideMenuItem>
     </>
     ```
-    ```html Angular icon="angular"
-    <bq-side-menu-item>
-      <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
-      Default
-    </bq-side-menu-item>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqBadge, BqIcon, BqSideMenuItem } from "@beeq/angular/standalone";
 
-    <bq-side-menu-item active>
-      <bq-icon name="package" slot="prefix"></bq-icon>
-      Active
-    </bq-side-menu-item>
+    @Component({
+      standalone: true,
+      imports: [BqBadge, BqIcon, BqSideMenuItem],
+      template: `
+        <bq-side-menu-item>
+          <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+          Default
+        </bq-side-menu-item>
 
-    <bq-side-menu-item disabled>
-      <bq-icon name="gauge" slot="prefix"></bq-icon>
-      Disabled
-    </bq-side-menu-item>
+        <bq-side-menu-item [active]="true">
+          <bq-icon name="package" slot="prefix"></bq-icon>
+          Active
+        </bq-side-menu-item>
 
-    <bq-side-menu-item>
-      <bq-icon name="bell" slot="prefix"></bq-icon>
-      With counter
-      <bq-badge slot="suffix">5</bq-badge>
-    </bq-side-menu-item>
+        <bq-side-menu-item [disabled]="true">
+          <bq-icon name="gauge" slot="prefix"></bq-icon>
+          Disabled
+        </bq-side-menu-item>
+
+        <bq-side-menu-item>
+          <bq-icon name="bell" slot="prefix"></bq-icon>
+          With counter
+          <bq-badge slot="suffix">5</bq-badge>
+        </bq-side-menu-item>
+      `
+    })
+    export class SideMenuItemStatesComponent {}
     ```
     ```vue Vue icon="vuejs"
     <script setup lang="ts">
@@ -480,11 +502,21 @@ Use the `appearance` attribute to align the side menu with your application's vi
       <BqSideMenuItem>Reports</BqSideMenuItem>
     </BqSideMenu>
     ```
-    ```html Angular icon="angular"
-    <bq-side-menu appearance="brand">
-      <bq-side-menu-item active>Dashboard</bq-side-menu-item>
-      <bq-side-menu-item>Reports</bq-side-menu-item>
-    </bq-side-menu>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqSideMenu, BqSideMenuItem } from "@beeq/angular/standalone";
+
+    @Component({
+      standalone: true,
+      imports: [BqSideMenu, BqSideMenuItem],
+      template: `
+        <bq-side-menu appearance="brand">
+          <bq-side-menu-item [active]="true">Dashboard</bq-side-menu-item>
+          <bq-side-menu-item>Reports</bq-side-menu-item>
+        </bq-side-menu>
+      `
+    })
+    export class BrandSideMenuComponent {}
     ```
     ```vue Vue icon="vuejs"
     <script setup lang="ts">
@@ -579,17 +611,27 @@ Use `collapse` to create a compact side menu. Use `size="small"` when space is c
       </BqSideMenuItem>
     </BqSideMenu>
     ```
-    ```html Angular icon="angular"
-    <bq-side-menu collapse size="small">
-      <bq-side-menu-item active>
-        <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
-        Dashboard
-      </bq-side-menu-item>
-      <bq-side-menu-item>
-        <bq-icon name="package" slot="prefix"></bq-icon>
-        Products
-      </bq-side-menu-item>
-    </bq-side-menu>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqIcon, BqSideMenu, BqSideMenuItem } from "@beeq/angular/standalone";
+
+    @Component({
+      standalone: true,
+      imports: [BqIcon, BqSideMenu, BqSideMenuItem],
+      template: `
+        <bq-side-menu [collapse]="true" size="small">
+          <bq-side-menu-item [active]="true">
+            <bq-icon name="diamonds-four" slot="prefix"></bq-icon>
+            Dashboard
+          </bq-side-menu-item>
+          <bq-side-menu-item>
+            <bq-icon name="package" slot="prefix"></bq-icon>
+            Products
+          </bq-side-menu-item>
+        </bq-side-menu>
+      `
+    })
+    export class CollapsedSideMenuComponent {}
     ```
     ```vue Vue icon="vuejs"
     <script setup lang="ts">
@@ -681,14 +723,24 @@ Use the footer slot for supplementary actions, links, or information at the bott
       </BqButton>
     </BqSideMenu>
     ```
-    ```html Angular icon="angular"
-    <bq-side-menu>
-      <bq-side-menu-item active>Dashboard</bq-side-menu-item>
-      <bq-side-menu-item>Reports</bq-side-menu-item>
-      <bq-button slot="footer" appearance="link" size="small">
-        Settings
-      </bq-button>
-    </bq-side-menu>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqButton, BqSideMenu, BqSideMenuItem } from "@beeq/angular/standalone";
+
+    @Component({
+      standalone: true,
+      imports: [BqButton, BqSideMenu, BqSideMenuItem],
+      template: `
+        <bq-side-menu>
+          <bq-side-menu-item [active]="true">Dashboard</bq-side-menu-item>
+          <bq-side-menu-item>Reports</bq-side-menu-item>
+          <bq-button slot="footer" appearance="link" size="small">
+            Settings
+          </bq-button>
+        </bq-side-menu>
+      `
+    })
+    export class SideMenuFooterComponent {}
     ```
     ```vue Vue icon="vuejs"
     <script setup lang="ts">
@@ -771,12 +823,12 @@ Use the footer slot for supplementary actions, links, or information at the bott
 
 ## Accessibility
 
-The side menu renders the root navigation surface as an `<aside>`. Each `bq-side-menu-item` renders as a focusable button with `role="menuitem"`. The `disabled` property maps to `aria-disabled="true"` and removes the item from the tab order with `tabindex="-1"`.
+The side menu renders its root surface as an `<aside>` and places menu items inside a `<nav>`. Each `bq-side-menu-item` renders as a focusable button with `role="menuitem"`, and the `disabled` property maps to `aria-disabled="true"` and `tabindex="-1"`.
 
 - **Landmark context** - include semantic heading text in the logo slot to communicate the menu purpose and where its content begins.
-- **Collapsed state** - communicate the expanded or collapsed state through your surrounding layout controls when you expose a custom toggle.
-- **Icons** - validate icon meaning with people who use assistive technology or who may need additional visual clarity.
-- **Labels** - use unique labels that make sense without additional context. The side menu item text feeds the collapsed tooltip content.
+- **Collapsed state** - communicate the expanded or collapsed state through the surrounding layout control when you add one.
+- **Icons** - validate icon meaning when collapsed navigation relies on icons to identify destinations.
+- **Labels** - use unique labels that make sense without additional context. The item text feeds the collapsed tooltip content.
 - **Keyboard navigation** - side menu items support focus, click, <kbd>Enter</kbd>, and <kbd>Space</kbd> interaction through the underlying button.
 
 ## API reference
@@ -839,6 +891,28 @@ The side menu renders the root navigation surface as an `<aside>`. Each `bq-side
 | `suffix` | The suffix slot |
 | `trigger` | The `<div>` container that holds the element that displays the tooltip on hover when the side menu is collapsed |
 
+### Events
+
+| Component | Event | Description | Type |
+|---|---|---|---|
+| `bq-side-menu` | `bqCollapse` | Fires when the side menu changes its width from expanded to collapsed and vice versa | `CustomEvent<{ collapse: boolean; }>` |
+| `bq-side-menu` | `bqSelect` | Fires when the active or selected menu item changes | `CustomEvent<HTMLBqSideMenuItemElement>` |
+| `bq-side-menu-item` | `bqBlur` | Fires when the menu item loses focus | `CustomEvent<HTMLBqSideMenuItemElement>` |
+| `bq-side-menu-item` | `bqClick` | Fires when the menu item is clicked | `CustomEvent<HTMLBqSideMenuItemElement>` |
+| `bq-side-menu-item` | `bqFocus` | Fires when the menu item receives focus | `CustomEvent<HTMLBqSideMenuItemElement>` |
+
+<Note>
+  - In React, prefix events with `on`: `onBqSelect`, `onBqCollapse`, `onBqClick`.
+  - In Angular, use event binding syntax: `(bqSelect)`, `(bqCollapse)`, `(bqClick)`.
+  - In Vue, use the `@` shorthand: `@bqSelect`, `@bqCollapse`, `@bqClick`.
+</Note>
+
+### Methods
+
+| Method | Description | Returns |
+|---|---|---|
+| `toggleCollapse()` | Toggles the collapse state of the side menu | `Promise<void>` |
+
 ### CSS custom properties
 
 <Expandable title="CSS variables" defaultOpen={true}>
@@ -861,28 +935,6 @@ The side menu renders the root navigation surface as an `<aside>`. Each `bq-side
 <Tip>
   Learn more about [styling with shadow parts](/theming/styles) and [CSS custom properties](/theming/global-css-variables).
 </Tip>
-
-### Events
-
-| Component | Event | Description | Type |
-|---|---|---|---|
-| `bq-side-menu` | `bqCollapse` | Fires when the side menu changes its width from expanded to collapsed and vice versa | `CustomEvent<{ collapse: boolean; }>` |
-| `bq-side-menu` | `bqSelect` | Fires when the active or selected menu item changes | `CustomEvent<HTMLBqSideMenuItemElement>` |
-| `bq-side-menu-item` | `bqBlur` | Fires when the menu item loses focus | `CustomEvent<HTMLBqSideMenuItemElement>` |
-| `bq-side-menu-item` | `bqClick` | Fires when the menu item is clicked | `CustomEvent<HTMLBqSideMenuItemElement>` |
-| `bq-side-menu-item` | `bqFocus` | Fires when the menu item receives focus | `CustomEvent<HTMLBqSideMenuItemElement>` |
-
-<Note>
-  - In React, prefix events with `on`: `onBqSelect`, `onBqCollapse`, `onBqClick`.
-  - In Angular, use event binding syntax: `(bqSelect)`, `(bqCollapse)`, `(bqClick)`.
-  - In Vue, use the `@` shorthand: `@bqSelect`, `@bqCollapse`, `@bqClick`.
-</Note>
-
-### Methods
-
-| Method | Description | Returns |
-|---|---|---|
-| `toggleCollapse()` | Toggles the collapse state of the side menu | `Promise<void>` |
 
 ## Resources
 

--- a/apps/beeq-docs/components/steps.mdx
+++ b/apps/beeq-docs/components/steps.mdx
@@ -7,7 +7,8 @@ import { CardTile } from '/snippets/CardTile.jsx';
 import { CodeLivePreview } from "/snippets/CodeLivePreview.jsx";
 
 <Frame className="px-4 py-4" caption="Steps component overview">
-  <img src="https://placeholdit.com/600x400" alt="Placeholder for the Steps component overview image" />
+  <img className="block dark:hidden" src="/components/images/steps/steps-overview-light.svg" alt="BEEQ Steps component overview" />
+  <img className="hidden dark:block" src="/components/images/steps/steps-overview-dark.svg" alt="BEEQ Steps component overview" />
 </Frame>
 
 Steps guide users through a sequential process such as a wizard, onboarding flow, or multistep form. Use them to show progress, the current step, completed steps, and steps that still need attention.
@@ -56,7 +57,8 @@ Steps guide users through a sequential process such as a wizard, onboarding flow
 ## Anatomy
 
 <Frame className="px-4 py-4" caption="Steps component anatomy">
-  <img src="https://placeholdit.com/1000x420" alt="Placeholder for the Steps component anatomy image" />
+  <img className="block dark:hidden" src="/components/images/steps/steps-anatomy-light.svg" alt="BEEQ Steps component anatomy" />
+  <img className="hidden dark:block" src="/components/images/steps/steps-anatomy-dark.svg" alt="BEEQ Steps component anatomy" />
 </Frame>
 
 Steps are composed of a label or prefix, title, optional description, and divider. Together they communicate position, meaning, and progress through the process.
@@ -73,29 +75,29 @@ Steps are composed of a label or prefix, title, optional description, and divide
 <CardGroup cols={2}>
   <CardTile
     title="Choose one type"
-    imageLightSrc="https://placeholdit.com/480x320"
-    imageDarkSrc="https://placeholdit.com/480x320"
+    imageLightSrc="/components/images/steps/steps-type-light.svg"
+    imageDarkSrc="/components/images/steps/steps-type-dark.svg"
   >
     Use one steps type per page. Mixing dots, numbers, and icons in the same view makes the process harder to follow.
   </CardTile>
   <CardTile
     title="Show current status"
-    imageLightSrc="https://placeholdit.com/480x320"
-    imageDarkSrc="https://placeholdit.com/480x320"
+    imageLightSrc="/components/images/steps/steps-status-light.svg"
+    imageDarkSrc="/components/images/steps/steps-status-dark.svg"
   >
     Distinguish the current step from completed and remaining steps. Use status, text, and icon changes so color is not the only signal.
   </CardTile>
   <CardTile
     title="Keep flows manageable"
-    imageLightSrc="https://placeholdit.com/480x320"
-    imageDarkSrc="https://placeholdit.com/480x320"
+    imageLightSrc="/components/images/steps/steps-manageable-flow-light.svg"
+    imageDarkSrc="/components/images/steps/steps-manageable-flow-dark.svg"
   >
     Keep processes concise. Long forms are easier to complete when the step count stays focused and predictable.
   </CardTile>
   <CardTile
     title="Pick the right orientation"
-    imageLightSrc="https://placeholdit.com/480x320"
-    imageDarkSrc="https://placeholdit.com/480x320"
+    imageLightSrc="/components/images/steps/steps-orientation-light.svg"
+    imageDarkSrc="/components/images/steps/steps-orientation-dark.svg"
   >
     Use horizontal steps for left-to-right progression. Use vertical steps when horizontal space is limited or when descriptions need more room.
   </CardTile>
@@ -188,29 +190,39 @@ Use `type="dot"` for a minimal progress indicator when the sequence is clear and
       </BqStepItem>
     </BqSteps>
     ```
-    ```html Angular icon="angular"
-    <bq-steps type="dot">
-      <bq-step-item status="default">
-        <bq-icon aria-hidden="true" slot="prefix" name="circle"></bq-icon>
-        <span>Details</span>
-        <span slot="description">Add your personal details</span>
-      </bq-step-item>
-      <bq-step-item status="error">
-        <bq-icon aria-hidden="true" slot="prefix" name="x-circle"></bq-icon>
-        <span>Payment</span>
-        <span slot="description">Resolve the payment error</span>
-      </bq-step-item>
-      <bq-step-item status="completed">
-        <bq-icon aria-hidden="true" slot="prefix" name="check-circle"></bq-icon>
-        <span>Review</span>
-        <span slot="description">Review completed</span>
-      </bq-step-item>
-      <bq-step-item status="current">
-        <bq-icon aria-hidden="true" slot="prefix" name="circle"></bq-icon>
-        <span>Confirm</span>
-        <span slot="description">Confirm your request</span>
-      </bq-step-item>
-    </bq-steps>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqIcon, BqStepItem, BqSteps } from "@beeq/angular/standalone";
+
+    @Component({
+      standalone: true,
+      imports: [BqIcon, BqStepItem, BqSteps],
+      template: `
+        <bq-steps type="dot">
+          <bq-step-item status="default">
+            <bq-icon aria-hidden="true" slot="prefix" name="circle"></bq-icon>
+            <span>Details</span>
+            <span slot="description">Add your personal details</span>
+          </bq-step-item>
+          <bq-step-item status="error">
+            <bq-icon aria-hidden="true" slot="prefix" name="x-circle"></bq-icon>
+            <span>Payment</span>
+            <span slot="description">Resolve the payment error</span>
+          </bq-step-item>
+          <bq-step-item status="completed">
+            <bq-icon aria-hidden="true" slot="prefix" name="check-circle"></bq-icon>
+            <span>Review</span>
+            <span slot="description">Review completed</span>
+          </bq-step-item>
+          <bq-step-item status="current">
+            <bq-icon aria-hidden="true" slot="prefix" name="circle"></bq-icon>
+            <span>Confirm</span>
+            <span slot="description">Confirm your request</span>
+          </bq-step-item>
+        </bq-steps>
+      `
+    })
+    export class DotStepsComponent {}
     ```
     ```vue Vue icon="vuejs"
     <script setup lang="ts">
@@ -307,24 +319,34 @@ Use `type="icon"` when each step benefits from a recognizable symbol. Icons shou
       </BqStepItem>
     </BqSteps>
     ```
-    ```html Angular icon="angular"
-    <bq-steps type="icon">
-      <bq-step-item status="completed">
-        <bq-icon aria-hidden="true" slot="prefix" name="airplane-takeoff"></bq-icon>
-        <span>Flight</span>
-        <span slot="description">Reserve your flight</span>
-      </bq-step-item>
-      <bq-step-item status="error">
-        <bq-icon aria-hidden="true" slot="prefix" name="car"></bq-icon>
-        <span>Rent a car</span>
-        <span slot="description">There was an error with your reservation</span>
-      </bq-step-item>
-      <bq-step-item status="current">
-        <bq-icon aria-hidden="true" slot="prefix" name="tree-palm"></bq-icon>
-        <span>Enjoy your holidays!</span>
-        <span slot="description">You're ready for your vacations</span>
-      </bq-step-item>
-    </bq-steps>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqIcon, BqStepItem, BqSteps } from "@beeq/angular/standalone";
+
+    @Component({
+      standalone: true,
+      imports: [BqIcon, BqStepItem, BqSteps],
+      template: `
+        <bq-steps type="icon">
+          <bq-step-item status="completed">
+            <bq-icon aria-hidden="true" slot="prefix" name="airplane-takeoff"></bq-icon>
+            <span>Flight</span>
+            <span slot="description">Reserve your flight</span>
+          </bq-step-item>
+          <bq-step-item status="error">
+            <bq-icon aria-hidden="true" slot="prefix" name="car"></bq-icon>
+            <span>Rent a car</span>
+            <span slot="description">There was an error with your reservation</span>
+          </bq-step-item>
+          <bq-step-item status="current">
+            <bq-icon aria-hidden="true" slot="prefix" name="tree-palm"></bq-icon>
+            <span>Enjoy your holidays!</span>
+            <span slot="description">You're ready for your vacations</span>
+          </bq-step-item>
+        </bq-steps>
+      `
+    })
+    export class IconStepsComponent {}
     ```
     ```vue Vue icon="vuejs"
     <script setup lang="ts">
@@ -431,29 +453,39 @@ Use `type="numeric"` when order and sequence need to be explicit.
       </BqStepItem>
     </BqSteps>
     ```
-    ```html Angular icon="angular"
-    <bq-steps type="numeric">
-      <bq-step-item status="default">
-        <span aria-label="Step 1" slot="prefix">1</span>
-        <span>Details</span>
-        <span slot="description">Description</span>
-      </bq-step-item>
-      <bq-step-item status="completed">
-        <span aria-label="Step 2" slot="prefix">2</span>
-        <span>Review</span>
-        <span slot="description">Description</span>
-      </bq-step-item>
-      <bq-step-item status="error">
-        <span aria-label="Step 3" slot="prefix">3</span>
-        <span>Payment</span>
-        <span slot="description">Description</span>
-      </bq-step-item>
-      <bq-step-item status="current">
-        <span aria-label="Step 4" slot="prefix">4</span>
-        <span>Confirm</span>
-        <span slot="description">Description</span>
-      </bq-step-item>
-    </bq-steps>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqStepItem, BqSteps } from "@beeq/angular/standalone";
+
+    @Component({
+      standalone: true,
+      imports: [BqStepItem, BqSteps],
+      template: `
+        <bq-steps type="numeric">
+          <bq-step-item status="default">
+            <span aria-label="Step 1" slot="prefix">1</span>
+            <span>Details</span>
+            <span slot="description">Description</span>
+          </bq-step-item>
+          <bq-step-item status="completed">
+            <span aria-label="Step 2" slot="prefix">2</span>
+            <span>Review</span>
+            <span slot="description">Description</span>
+          </bq-step-item>
+          <bq-step-item status="error">
+            <span aria-label="Step 3" slot="prefix">3</span>
+            <span>Payment</span>
+            <span slot="description">Description</span>
+          </bq-step-item>
+          <bq-step-item status="current">
+            <span aria-label="Step 4" slot="prefix">4</span>
+            <span>Confirm</span>
+            <span slot="description">Description</span>
+          </bq-step-item>
+        </bq-steps>
+      `
+    })
+    export class NumericStepsComponent {}
     ```
     ```vue Vue icon="vuejs"
     <script setup lang="ts">
@@ -566,24 +598,34 @@ Use `orientation="vertical"` when the process should unfold from top to bottom o
       </BqStepItem>
     </BqSteps>
     ```
-    ```html Angular icon="angular"
-    <bq-steps orientation="vertical" type="icon">
-      <bq-step-item status="completed">
-        <bq-icon aria-hidden="true" slot="prefix" name="airplane-takeoff"></bq-icon>
-        <span>Flight</span>
-        <span slot="description">Reserve your flight</span>
-      </bq-step-item>
-      <bq-step-item status="error">
-        <bq-icon aria-hidden="true" slot="prefix" name="car"></bq-icon>
-        <span>Rent a car</span>
-        <span slot="description">There was an error with your reservation</span>
-      </bq-step-item>
-      <bq-step-item status="current">
-        <bq-icon aria-hidden="true" slot="prefix" name="tree-palm"></bq-icon>
-        <span>Enjoy your holidays!</span>
-        <span slot="description">You're ready for your vacations</span>
-      </bq-step-item>
-    </bq-steps>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqIcon, BqStepItem, BqSteps } from "@beeq/angular/standalone";
+
+    @Component({
+      standalone: true,
+      imports: [BqIcon, BqStepItem, BqSteps],
+      template: `
+        <bq-steps orientation="vertical" type="icon">
+          <bq-step-item status="completed">
+            <bq-icon aria-hidden="true" slot="prefix" name="airplane-takeoff"></bq-icon>
+            <span>Flight</span>
+            <span slot="description">Reserve your flight</span>
+          </bq-step-item>
+          <bq-step-item status="error">
+            <bq-icon aria-hidden="true" slot="prefix" name="car"></bq-icon>
+            <span>Rent a car</span>
+            <span slot="description">There was an error with your reservation</span>
+          </bq-step-item>
+          <bq-step-item status="current">
+            <bq-icon aria-hidden="true" slot="prefix" name="tree-palm"></bq-icon>
+            <span>Enjoy your holidays!</span>
+            <span slot="description">You're ready for your vacations</span>
+          </bq-step-item>
+        </bq-steps>
+      `
+    })
+    export class VerticalStepsComponent {}
     ```
     ```vue Vue icon="vuejs"
     <script setup lang="ts">
@@ -679,24 +721,34 @@ Use `size="small"` in compact layouts. Use `divider-color` with a declarative co
       </BqStepItem>
     </BqSteps>
     ```
-    ```html Angular icon="angular"
-    <bq-steps divider-color="stroke--brand" size="small" type="numeric">
-      <bq-step-item status="completed">
-        <span aria-label="Step 1" slot="prefix">1</span>
-        <span>Account</span>
-        <span slot="description">Completed</span>
-      </bq-step-item>
-      <bq-step-item status="current">
-        <span aria-label="Step 2" slot="prefix">2</span>
-        <span>Preferences</span>
-        <span slot="description">Current step</span>
-      </bq-step-item>
-      <bq-step-item status="default">
-        <span aria-label="Step 3" slot="prefix">3</span>
-        <span>Finish</span>
-        <span slot="description">Next step</span>
-      </bq-step-item>
-    </bq-steps>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqStepItem, BqSteps } from "@beeq/angular/standalone";
+
+    @Component({
+      standalone: true,
+      imports: [BqStepItem, BqSteps],
+      template: `
+        <bq-steps divider-color="stroke--brand" size="small" type="numeric">
+          <bq-step-item status="completed">
+            <span aria-label="Step 1" slot="prefix">1</span>
+            <span>Account</span>
+            <span slot="description">Completed</span>
+          </bq-step-item>
+          <bq-step-item status="current">
+            <span aria-label="Step 2" slot="prefix">2</span>
+            <span>Preferences</span>
+            <span slot="description">Current step</span>
+          </bq-step-item>
+          <bq-step-item status="default">
+            <span aria-label="Step 3" slot="prefix">3</span>
+            <span>Finish</span>
+            <span slot="description">Next step</span>
+          </bq-step-item>
+        </bq-steps>
+      `
+    })
+    export class SmallStepsComponent {}
     ```
     ```vue Vue icon="vuejs"
     <script setup lang="ts">
@@ -855,25 +907,6 @@ The `bq-steps` container renders with `role="list"`, and each `bq-step-item` ren
 | `title` | Step item title |
 | `description` | Step item description |
 
-### CSS custom properties
-
-<Expandable title="CSS variables" defaultOpen={true}>
-  | Variable | Description | Default |
-  |---|---|---|
-  | `--bq-steps--divider-color` | Divider color | `var(--bq-stroke--secondary)` |
-  | `--bq-steps--gap` | Gap between steps | `var(--bq-spacing-m)` |
-  | `--bq-step-item--prefix-color` | Prefix icon color | `var(--bq-icon--secondary)` |
-  | `--bq-step-item--prefix-color-current` | Prefix icon color for the current state | `var(--bq-icon--brand)` |
-  | `--bq-step-item--prefix-color-completed` | Prefix icon color for the completed state | `var(--bq-icon--success)` |
-  | `--bq-step-item--prefix-color-error` | Prefix icon color for the error state | `var(--bq-icon--danger)` |
-  | `--bq-step-item--prefix-num-size` | Prefix number size | `var(--bq-spacing-xl)` |
-  | `--bq-step-item--prefix-num-bg-color` | Prefix number background color | `var(--bq-background--secondary)` |
-</Expandable>
-
-<Tip>
-  Learn more about [styling with shadow parts](/theming/styles) and [CSS custom properties](/theming/global-css-variables).
-</Tip>
-
 ### Events
 
 | Component | Event | Description | Type |
@@ -894,10 +927,29 @@ The `bq-steps` container renders with `role="list"`, and each `bq-step-item` ren
 |---|---|---|---|
 | `bq-steps` | `setCurrentStepItem(newCurrentStep)` | Sets the provided step item as current and resets the previous current item to default | `Promise<void>` |
 
+### CSS custom properties
+
+<Expandable title="CSS variables" defaultOpen={true}>
+  | Variable | Description | Default |
+  |---|---|---|
+  | `--bq-steps--divider-color` | Divider color | `var(--bq-stroke--secondary)` |
+  | `--bq-steps--gap` | Gap between steps | `var(--bq-spacing-m)` |
+  | `--bq-step-item--prefix-color` | Prefix icon color | `var(--bq-icon--secondary)` |
+  | `--bq-step-item--prefix-color-current` | Prefix icon color for the current state | `var(--bq-icon--brand)` |
+  | `--bq-step-item--prefix-color-completed` | Prefix icon color for the completed state | `var(--bq-icon--success)` |
+  | `--bq-step-item--prefix-color-error` | Prefix icon color for the error state | `var(--bq-icon--danger)` |
+  | `--bq-step-item--prefix-num-size` | Prefix number size | `var(--bq-spacing-xl)` |
+  | `--bq-step-item--prefix-num-bg-color` | Prefix number background color | `var(--bq-background--secondary)` |
+</Expandable>
+
+<Tip>
+  Learn more about [styling with shadow parts](/theming/styles) and [CSS custom properties](/theming/global-css-variables).
+</Tip>
+
 ## Resources
 
 <CardGroup cols={2}>
-  <Card horizontal title="Interactive playground" icon="code" href="https://storybook.beeq.design/?path=/story/components-steps--dots">
+  <Card horizontal title="Interactive playground" icon="code" href="https://storybook.beeq.design/?path=/story/components-steps--default">
     Explore Steps variants and states in Storybook
   </Card>
   <Card horizontal title="Source code" icon="github" href="https://github.com/Endava/BEEQ/tree/main/packages/beeq/src/components/steps">

--- a/apps/beeq-docs/components/steps.mdx
+++ b/apps/beeq-docs/components/steps.mdx
@@ -1,0 +1,906 @@
+---
+title: Steps
+description: "Steps display a series of stages in a process so users can understand progress, current status, and what comes next."
+---
+
+import { CardTile } from '/snippets/CardTile.jsx';
+import { CodeLivePreview } from "/snippets/CodeLivePreview.jsx";
+
+<Frame className="px-4 py-4" caption="Steps component overview">
+  <img src="https://placeholdit.com/600x400" alt="Placeholder for the Steps component overview image" />
+</Frame>
+
+Steps guide users through a sequential process such as a wizard, onboarding flow, or multistep form. Use them to show progress, the current step, completed steps, and steps that still need attention.
+
+<Note>
+  Use `bq-step-item` inside `bq-steps`. The parent component passes `type`, `orientation`, `size`, and divider settings down to each step item.
+</Note>
+
+## When to use
+
+<CardGroup cols={2}>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="thumbs-up" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Use steps when
+    </span>
+    - Users need to complete a sequential, multistep process
+    - The workflow has a clear order and progress state
+    - Users benefit from seeing current, completed, remaining, or error states
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="thumbs-down" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Do not use steps when
+    </span>
+    - Users can complete tasks in any order
+    - The process has only one or two simple actions
+    - A status message or progress bar communicates the state more clearly
+  </Card>
+</CardGroup>
+
+## Patterns
+
+<CardGroup cols={3}>
+  <Card title="Dots">
+    Dots provide a compact progress indicator for straightforward linear flows.
+  </Card>
+  <Card title="Numbers">
+    Numbers make the order explicit when users need to understand sequence at a glance.
+  </Card>
+  <Card title="Icons">
+    Icons add visual meaning when each step represents a recognizable action or context.
+  </Card>
+</CardGroup>
+
+## Anatomy
+
+<Frame className="px-4 py-4" caption="Steps component anatomy">
+  <img src="https://placeholdit.com/1000x420" alt="Placeholder for the Steps component anatomy image" />
+</Frame>
+
+Steps are composed of a label or prefix, title, optional description, and divider. Together they communicate position, meaning, and progress through the process.
+
+| Part | Element | Description |
+|---|---|---|
+| **1** | Prefix | Dot, number, or icon that visually identifies the step |
+| **2** | Title | Step label that describes the task or stage |
+| **3** | Description | Optional supporting text for more context |
+| **4** | Divider | Connector that shows sequence between steps |
+
+## Design guidelines
+
+<CardGroup cols={2}>
+  <CardTile
+    title="Choose one type"
+    imageLightSrc="https://placeholdit.com/480x320"
+    imageDarkSrc="https://placeholdit.com/480x320"
+  >
+    Use one steps type per page. Mixing dots, numbers, and icons in the same view makes the process harder to follow.
+  </CardTile>
+  <CardTile
+    title="Show current status"
+    imageLightSrc="https://placeholdit.com/480x320"
+    imageDarkSrc="https://placeholdit.com/480x320"
+  >
+    Distinguish the current step from completed and remaining steps. Use status, text, and icon changes so color is not the only signal.
+  </CardTile>
+  <CardTile
+    title="Keep flows manageable"
+    imageLightSrc="https://placeholdit.com/480x320"
+    imageDarkSrc="https://placeholdit.com/480x320"
+  >
+    Keep processes concise. Long forms are easier to complete when the step count stays focused and predictable.
+  </CardTile>
+  <CardTile
+    title="Pick the right orientation"
+    imageLightSrc="https://placeholdit.com/480x320"
+    imageDarkSrc="https://placeholdit.com/480x320"
+  >
+    Use horizontal steps for left-to-right progression. Use vertical steps when horizontal space is limited or when descriptions need more room.
+  </CardTile>
+</CardGroup>
+
+### Label and icon
+
+Labels describe each step, while icons provide visual cues. Use meaningful titles and reserve icons for cases where the symbol helps users understand the action or context.
+
+### States
+
+Steps support `default`, `current`, `completed`, `error`, and `disabled` states. Use these states to show what users have finished, where they are now, and what requires attention.
+
+## Usage
+
+### Dots
+
+Use `type="dot"` for a minimal progress indicator when the sequence is clear and the step labels carry most of the meaning.
+
+<CodeLivePreview code={`<bq-steps type="dot">
+  <bq-step-item status="default">
+    <bq-icon aria-hidden="true" slot="prefix" name="circle"></bq-icon>
+    <span>Details</span>
+    <span slot="description">Add your personal details</span>
+  </bq-step-item>
+  <bq-step-item status="error">
+    <bq-icon aria-hidden="true" slot="prefix" name="x-circle"></bq-icon>
+    <span>Payment</span>
+    <span slot="description">Resolve the payment error</span>
+  </bq-step-item>
+  <bq-step-item status="completed">
+    <bq-icon aria-hidden="true" slot="prefix" name="check-circle"></bq-icon>
+    <span>Review</span>
+    <span slot="description">Review completed</span>
+  </bq-step-item>
+  <bq-step-item status="current">
+    <bq-icon aria-hidden="true" slot="prefix" name="circle"></bq-icon>
+    <span>Confirm</span>
+    <span slot="description">Confirm your request</span>
+  </bq-step-item>
+</bq-steps>`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-steps type="dot">
+      <bq-step-item status="default">
+        <bq-icon aria-hidden="true" slot="prefix" name="circle"></bq-icon>
+        <span>Details</span>
+        <span slot="description">Add your personal details</span>
+      </bq-step-item>
+      <bq-step-item status="error">
+        <bq-icon aria-hidden="true" slot="prefix" name="x-circle"></bq-icon>
+        <span>Payment</span>
+        <span slot="description">Resolve the payment error</span>
+      </bq-step-item>
+      <bq-step-item status="completed">
+        <bq-icon aria-hidden="true" slot="prefix" name="check-circle"></bq-icon>
+        <span>Review</span>
+        <span slot="description">Review completed</span>
+      </bq-step-item>
+      <bq-step-item status="current">
+        <bq-icon aria-hidden="true" slot="prefix" name="circle"></bq-icon>
+        <span>Confirm</span>
+        <span slot="description">Confirm your request</span>
+      </bq-step-item>
+    </bq-steps>
+    ```
+    ```jsx React icon="react"
+    import { BqIcon, BqStepItem, BqSteps } from "@beeq/react";
+
+    <BqSteps type="dot">
+      <BqStepItem status="default">
+        <BqIcon aria-hidden="true" slot="prefix" name="circle" />
+        <span>Details</span>
+        <span slot="description">Add your personal details</span>
+      </BqStepItem>
+      <BqStepItem status="error">
+        <BqIcon aria-hidden="true" slot="prefix" name="x-circle" />
+        <span>Payment</span>
+        <span slot="description">Resolve the payment error</span>
+      </BqStepItem>
+      <BqStepItem status="completed">
+        <BqIcon aria-hidden="true" slot="prefix" name="check-circle" />
+        <span>Review</span>
+        <span slot="description">Review completed</span>
+      </BqStepItem>
+      <BqStepItem status="current">
+        <BqIcon aria-hidden="true" slot="prefix" name="circle" />
+        <span>Confirm</span>
+        <span slot="description">Confirm your request</span>
+      </BqStepItem>
+    </BqSteps>
+    ```
+    ```html Angular icon="angular"
+    <bq-steps type="dot">
+      <bq-step-item status="default">
+        <bq-icon aria-hidden="true" slot="prefix" name="circle"></bq-icon>
+        <span>Details</span>
+        <span slot="description">Add your personal details</span>
+      </bq-step-item>
+      <bq-step-item status="error">
+        <bq-icon aria-hidden="true" slot="prefix" name="x-circle"></bq-icon>
+        <span>Payment</span>
+        <span slot="description">Resolve the payment error</span>
+      </bq-step-item>
+      <bq-step-item status="completed">
+        <bq-icon aria-hidden="true" slot="prefix" name="check-circle"></bq-icon>
+        <span>Review</span>
+        <span slot="description">Review completed</span>
+      </bq-step-item>
+      <bq-step-item status="current">
+        <bq-icon aria-hidden="true" slot="prefix" name="circle"></bq-icon>
+        <span>Confirm</span>
+        <span slot="description">Confirm your request</span>
+      </bq-step-item>
+    </bq-steps>
+    ```
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqIcon, BqStepItem, BqSteps } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSteps type="dot">
+        <BqStepItem status="default">
+          <BqIcon aria-hidden="true" slot="prefix" name="circle" />
+          <span>Details</span>
+          <span slot="description">Add your personal details</span>
+        </BqStepItem>
+        <BqStepItem status="error">
+          <BqIcon aria-hidden="true" slot="prefix" name="x-circle" />
+          <span>Payment</span>
+          <span slot="description">Resolve the payment error</span>
+        </BqStepItem>
+        <BqStepItem status="completed">
+          <BqIcon aria-hidden="true" slot="prefix" name="check-circle" />
+          <span>Review</span>
+          <span slot="description">Review completed</span>
+        </BqStepItem>
+        <BqStepItem status="current">
+          <BqIcon aria-hidden="true" slot="prefix" name="circle" />
+          <span>Confirm</span>
+          <span slot="description">Confirm your request</span>
+        </BqStepItem>
+      </BqSteps>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Icons
+
+Use `type="icon"` when each step benefits from a recognizable symbol. Icons should support the label, not replace it.
+
+<CodeLivePreview code={`<bq-steps type="icon">
+  <bq-step-item status="completed">
+    <bq-icon aria-hidden="true" slot="prefix" name="airplane-takeoff"></bq-icon>
+    <span>Flight</span>
+    <span slot="description">Reserve your flight</span>
+  </bq-step-item>
+  <bq-step-item status="error">
+    <bq-icon aria-hidden="true" slot="prefix" name="car"></bq-icon>
+    <span>Rent a car</span>
+    <span slot="description">There was an error with your reservation</span>
+  </bq-step-item>
+  <bq-step-item status="current">
+    <bq-icon aria-hidden="true" slot="prefix" name="tree-palm"></bq-icon>
+    <span>Enjoy your holidays!</span>
+    <span slot="description">You're ready for your vacations</span>
+  </bq-step-item>
+</bq-steps>`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-steps type="icon">
+      <bq-step-item status="completed">
+        <bq-icon aria-hidden="true" slot="prefix" name="airplane-takeoff"></bq-icon>
+        <span>Flight</span>
+        <span slot="description">Reserve your flight</span>
+      </bq-step-item>
+      <bq-step-item status="error">
+        <bq-icon aria-hidden="true" slot="prefix" name="car"></bq-icon>
+        <span>Rent a car</span>
+        <span slot="description">There was an error with your reservation</span>
+      </bq-step-item>
+      <bq-step-item status="current">
+        <bq-icon aria-hidden="true" slot="prefix" name="tree-palm"></bq-icon>
+        <span>Enjoy your holidays!</span>
+        <span slot="description">You're ready for your vacations</span>
+      </bq-step-item>
+    </bq-steps>
+    ```
+    ```jsx React icon="react"
+    import { BqIcon, BqStepItem, BqSteps } from "@beeq/react";
+
+    <BqSteps type="icon">
+      <BqStepItem status="completed">
+        <BqIcon aria-hidden="true" slot="prefix" name="airplane-takeoff" />
+        <span>Flight</span>
+        <span slot="description">Reserve your flight</span>
+      </BqStepItem>
+      <BqStepItem status="error">
+        <BqIcon aria-hidden="true" slot="prefix" name="car" />
+        <span>Rent a car</span>
+        <span slot="description">There was an error with your reservation</span>
+      </BqStepItem>
+      <BqStepItem status="current">
+        <BqIcon aria-hidden="true" slot="prefix" name="tree-palm" />
+        <span>Enjoy your holidays!</span>
+        <span slot="description">You're ready for your vacations</span>
+      </BqStepItem>
+    </BqSteps>
+    ```
+    ```html Angular icon="angular"
+    <bq-steps type="icon">
+      <bq-step-item status="completed">
+        <bq-icon aria-hidden="true" slot="prefix" name="airplane-takeoff"></bq-icon>
+        <span>Flight</span>
+        <span slot="description">Reserve your flight</span>
+      </bq-step-item>
+      <bq-step-item status="error">
+        <bq-icon aria-hidden="true" slot="prefix" name="car"></bq-icon>
+        <span>Rent a car</span>
+        <span slot="description">There was an error with your reservation</span>
+      </bq-step-item>
+      <bq-step-item status="current">
+        <bq-icon aria-hidden="true" slot="prefix" name="tree-palm"></bq-icon>
+        <span>Enjoy your holidays!</span>
+        <span slot="description">You're ready for your vacations</span>
+      </bq-step-item>
+    </bq-steps>
+    ```
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqIcon, BqStepItem, BqSteps } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSteps type="icon">
+        <BqStepItem status="completed">
+          <BqIcon aria-hidden="true" slot="prefix" name="airplane-takeoff" />
+          <span>Flight</span>
+          <span slot="description">Reserve your flight</span>
+        </BqStepItem>
+        <BqStepItem status="error">
+          <BqIcon aria-hidden="true" slot="prefix" name="car" />
+          <span>Rent a car</span>
+          <span slot="description">There was an error with your reservation</span>
+        </BqStepItem>
+        <BqStepItem status="current">
+          <BqIcon aria-hidden="true" slot="prefix" name="tree-palm" />
+          <span>Enjoy your holidays!</span>
+          <span slot="description">You're ready for your vacations</span>
+        </BqStepItem>
+      </BqSteps>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Numbers
+
+Use `type="numeric"` when order and sequence need to be explicit.
+
+<CodeLivePreview code={`<bq-steps type="numeric">
+  <bq-step-item status="default">
+    <span aria-label="Step 1" slot="prefix">1</span>
+    <span>Details</span>
+    <span slot="description">Description</span>
+  </bq-step-item>
+  <bq-step-item status="completed">
+    <span aria-label="Step 2" slot="prefix">2</span>
+    <span>Review</span>
+    <span slot="description">Description</span>
+  </bq-step-item>
+  <bq-step-item status="error">
+    <span aria-label="Step 3" slot="prefix">3</span>
+    <span>Payment</span>
+    <span slot="description">Description</span>
+  </bq-step-item>
+  <bq-step-item status="current">
+    <span aria-label="Step 4" slot="prefix">4</span>
+    <span>Confirm</span>
+    <span slot="description">Description</span>
+  </bq-step-item>
+</bq-steps>`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-steps type="numeric">
+      <bq-step-item status="default">
+        <span aria-label="Step 1" slot="prefix">1</span>
+        <span>Details</span>
+        <span slot="description">Description</span>
+      </bq-step-item>
+      <bq-step-item status="completed">
+        <span aria-label="Step 2" slot="prefix">2</span>
+        <span>Review</span>
+        <span slot="description">Description</span>
+      </bq-step-item>
+      <bq-step-item status="error">
+        <span aria-label="Step 3" slot="prefix">3</span>
+        <span>Payment</span>
+        <span slot="description">Description</span>
+      </bq-step-item>
+      <bq-step-item status="current">
+        <span aria-label="Step 4" slot="prefix">4</span>
+        <span>Confirm</span>
+        <span slot="description">Description</span>
+      </bq-step-item>
+    </bq-steps>
+    ```
+    ```jsx React icon="react"
+    import { BqStepItem, BqSteps } from "@beeq/react";
+
+    <BqSteps type="numeric">
+      <BqStepItem status="default">
+        <span aria-label="Step 1" slot="prefix">1</span>
+        <span>Details</span>
+        <span slot="description">Description</span>
+      </BqStepItem>
+      <BqStepItem status="completed">
+        <span aria-label="Step 2" slot="prefix">2</span>
+        <span>Review</span>
+        <span slot="description">Description</span>
+      </BqStepItem>
+      <BqStepItem status="error">
+        <span aria-label="Step 3" slot="prefix">3</span>
+        <span>Payment</span>
+        <span slot="description">Description</span>
+      </BqStepItem>
+      <BqStepItem status="current">
+        <span aria-label="Step 4" slot="prefix">4</span>
+        <span>Confirm</span>
+        <span slot="description">Description</span>
+      </BqStepItem>
+    </BqSteps>
+    ```
+    ```html Angular icon="angular"
+    <bq-steps type="numeric">
+      <bq-step-item status="default">
+        <span aria-label="Step 1" slot="prefix">1</span>
+        <span>Details</span>
+        <span slot="description">Description</span>
+      </bq-step-item>
+      <bq-step-item status="completed">
+        <span aria-label="Step 2" slot="prefix">2</span>
+        <span>Review</span>
+        <span slot="description">Description</span>
+      </bq-step-item>
+      <bq-step-item status="error">
+        <span aria-label="Step 3" slot="prefix">3</span>
+        <span>Payment</span>
+        <span slot="description">Description</span>
+      </bq-step-item>
+      <bq-step-item status="current">
+        <span aria-label="Step 4" slot="prefix">4</span>
+        <span>Confirm</span>
+        <span slot="description">Description</span>
+      </bq-step-item>
+    </bq-steps>
+    ```
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqStepItem, BqSteps } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSteps type="numeric">
+        <BqStepItem status="default">
+          <span aria-label="Step 1" slot="prefix">1</span>
+          <span>Details</span>
+          <span slot="description">Description</span>
+        </BqStepItem>
+        <BqStepItem status="completed">
+          <span aria-label="Step 2" slot="prefix">2</span>
+          <span>Review</span>
+          <span slot="description">Description</span>
+        </BqStepItem>
+        <BqStepItem status="error">
+          <span aria-label="Step 3" slot="prefix">3</span>
+          <span>Payment</span>
+          <span slot="description">Description</span>
+        </BqStepItem>
+        <BqStepItem status="current">
+          <span aria-label="Step 4" slot="prefix">4</span>
+          <span>Confirm</span>
+          <span slot="description">Description</span>
+        </BqStepItem>
+      </BqSteps>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+## Options
+
+### Orientation
+
+Use `orientation="vertical"` when the process should unfold from top to bottom or when labels and descriptions need more room.
+
+<CodeLivePreview code={`<style>
+  :host {
+    align-items: stretch !important;
+    justify-content: flex-start !important;
+  }
+
+  .steps-demo--vertical {
+    block-size: 28rem;
+    display: flex;
+  }
+</style>
+
+<div class="steps-demo--vertical">
+  <bq-steps orientation="vertical" type="icon">
+    <bq-step-item status="completed">
+      <bq-icon aria-hidden="true" slot="prefix" name="airplane-takeoff"></bq-icon>
+      <span>Flight</span>
+      <span slot="description">Reserve your flight</span>
+    </bq-step-item>
+    <bq-step-item status="error">
+      <bq-icon aria-hidden="true" slot="prefix" name="car"></bq-icon>
+      <span>Rent a car</span>
+      <span slot="description">There was an error with your reservation</span>
+    </bq-step-item>
+    <bq-step-item status="current">
+      <bq-icon aria-hidden="true" slot="prefix" name="tree-palm"></bq-icon>
+      <span>Enjoy your holidays!</span>
+      <span slot="description">You're ready for your vacations</span>
+    </bq-step-item>
+  </bq-steps>
+</div>`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-steps orientation="vertical" type="icon">
+      <bq-step-item status="completed">
+        <bq-icon aria-hidden="true" slot="prefix" name="airplane-takeoff"></bq-icon>
+        <span>Flight</span>
+        <span slot="description">Reserve your flight</span>
+      </bq-step-item>
+      <bq-step-item status="error">
+        <bq-icon aria-hidden="true" slot="prefix" name="car"></bq-icon>
+        <span>Rent a car</span>
+        <span slot="description">There was an error with your reservation</span>
+      </bq-step-item>
+      <bq-step-item status="current">
+        <bq-icon aria-hidden="true" slot="prefix" name="tree-palm"></bq-icon>
+        <span>Enjoy your holidays!</span>
+        <span slot="description">You're ready for your vacations</span>
+      </bq-step-item>
+    </bq-steps>
+    ```
+    ```jsx React icon="react"
+    import { BqIcon, BqStepItem, BqSteps } from "@beeq/react";
+
+    <BqSteps orientation="vertical" type="icon">
+      <BqStepItem status="completed">
+        <BqIcon aria-hidden="true" slot="prefix" name="airplane-takeoff" />
+        <span>Flight</span>
+        <span slot="description">Reserve your flight</span>
+      </BqStepItem>
+      <BqStepItem status="error">
+        <BqIcon aria-hidden="true" slot="prefix" name="car" />
+        <span>Rent a car</span>
+        <span slot="description">There was an error with your reservation</span>
+      </BqStepItem>
+      <BqStepItem status="current">
+        <BqIcon aria-hidden="true" slot="prefix" name="tree-palm" />
+        <span>Enjoy your holidays!</span>
+        <span slot="description">You're ready for your vacations</span>
+      </BqStepItem>
+    </BqSteps>
+    ```
+    ```html Angular icon="angular"
+    <bq-steps orientation="vertical" type="icon">
+      <bq-step-item status="completed">
+        <bq-icon aria-hidden="true" slot="prefix" name="airplane-takeoff"></bq-icon>
+        <span>Flight</span>
+        <span slot="description">Reserve your flight</span>
+      </bq-step-item>
+      <bq-step-item status="error">
+        <bq-icon aria-hidden="true" slot="prefix" name="car"></bq-icon>
+        <span>Rent a car</span>
+        <span slot="description">There was an error with your reservation</span>
+      </bq-step-item>
+      <bq-step-item status="current">
+        <bq-icon aria-hidden="true" slot="prefix" name="tree-palm"></bq-icon>
+        <span>Enjoy your holidays!</span>
+        <span slot="description">You're ready for your vacations</span>
+      </bq-step-item>
+    </bq-steps>
+    ```
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqIcon, BqStepItem, BqSteps } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSteps orientation="vertical" type="icon">
+        <BqStepItem status="completed">
+          <BqIcon aria-hidden="true" slot="prefix" name="airplane-takeoff" />
+          <span>Flight</span>
+          <span slot="description">Reserve your flight</span>
+        </BqStepItem>
+        <BqStepItem status="error">
+          <BqIcon aria-hidden="true" slot="prefix" name="car" />
+          <span>Rent a car</span>
+          <span slot="description">There was an error with your reservation</span>
+        </BqStepItem>
+        <BqStepItem status="current">
+          <BqIcon aria-hidden="true" slot="prefix" name="tree-palm" />
+          <span>Enjoy your holidays!</span>
+          <span slot="description">You're ready for your vacations</span>
+        </BqStepItem>
+      </BqSteps>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+<Tip>
+  Vertical steps adapt to the height of their container. Give the surrounding layout enough block size when you need the divider to span a taller area.
+</Tip>
+
+### Size and divider color
+
+Use `size="small"` in compact layouts. Use `divider-color` with a declarative color token when the connector needs a different emphasis.
+
+<CodeLivePreview code={`<bq-steps divider-color="stroke--brand" size="small" type="numeric">
+  <bq-step-item status="completed">
+    <span aria-label="Step 1" slot="prefix">1</span>
+    <span>Account</span>
+    <span slot="description">Completed</span>
+  </bq-step-item>
+  <bq-step-item status="current">
+    <span aria-label="Step 2" slot="prefix">2</span>
+    <span>Preferences</span>
+    <span slot="description">Current step</span>
+  </bq-step-item>
+  <bq-step-item status="default">
+    <span aria-label="Step 3" slot="prefix">3</span>
+    <span>Finish</span>
+    <span slot="description">Next step</span>
+  </bq-step-item>
+</bq-steps>`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-steps divider-color="stroke--brand" size="small" type="numeric">
+      <bq-step-item status="completed">
+        <span aria-label="Step 1" slot="prefix">1</span>
+        <span>Account</span>
+        <span slot="description">Completed</span>
+      </bq-step-item>
+      <bq-step-item status="current">
+        <span aria-label="Step 2" slot="prefix">2</span>
+        <span>Preferences</span>
+        <span slot="description">Current step</span>
+      </bq-step-item>
+      <bq-step-item status="default">
+        <span aria-label="Step 3" slot="prefix">3</span>
+        <span>Finish</span>
+        <span slot="description">Next step</span>
+      </bq-step-item>
+    </bq-steps>
+    ```
+    ```jsx React icon="react"
+    import { BqStepItem, BqSteps } from "@beeq/react";
+
+    <BqSteps dividerColor="stroke--brand" size="small" type="numeric">
+      <BqStepItem status="completed">
+        <span aria-label="Step 1" slot="prefix">1</span>
+        <span>Account</span>
+        <span slot="description">Completed</span>
+      </BqStepItem>
+      <BqStepItem status="current">
+        <span aria-label="Step 2" slot="prefix">2</span>
+        <span>Preferences</span>
+        <span slot="description">Current step</span>
+      </BqStepItem>
+      <BqStepItem status="default">
+        <span aria-label="Step 3" slot="prefix">3</span>
+        <span>Finish</span>
+        <span slot="description">Next step</span>
+      </BqStepItem>
+    </BqSteps>
+    ```
+    ```html Angular icon="angular"
+    <bq-steps divider-color="stroke--brand" size="small" type="numeric">
+      <bq-step-item status="completed">
+        <span aria-label="Step 1" slot="prefix">1</span>
+        <span>Account</span>
+        <span slot="description">Completed</span>
+      </bq-step-item>
+      <bq-step-item status="current">
+        <span aria-label="Step 2" slot="prefix">2</span>
+        <span>Preferences</span>
+        <span slot="description">Current step</span>
+      </bq-step-item>
+      <bq-step-item status="default">
+        <span aria-label="Step 3" slot="prefix">3</span>
+        <span>Finish</span>
+        <span slot="description">Next step</span>
+      </bq-step-item>
+    </bq-steps>
+    ```
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqStepItem, BqSteps } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSteps dividerColor="stroke--brand" size="small" type="numeric">
+        <BqStepItem status="completed">
+          <span aria-label="Step 1" slot="prefix">1</span>
+          <span>Account</span>
+          <span slot="description">Completed</span>
+        </BqStepItem>
+        <BqStepItem status="current">
+          <span aria-label="Step 2" slot="prefix">2</span>
+          <span>Preferences</span>
+          <span slot="description">Current step</span>
+        </BqStepItem>
+        <BqStepItem status="default">
+          <span aria-label="Step 3" slot="prefix">3</span>
+          <span>Finish</span>
+          <span slot="description">Next step</span>
+        </BqStepItem>
+      </BqSteps>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+## Best practices
+
+<CardGroup cols={2}>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Use one steps component per page so the process stays clear and cohesive.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Avoid multiple steppers in the same view because they can compete for attention and disrupt the flow.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Write labels that describe the task or destination for each step.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Avoid labels that only repeat the status, such as current or completed.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Confirm progress with status, text, and icon changes after a step is completed.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Do not rely on color alone to communicate the state of a step.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Keep the number of steps manageable so users feel the process is achievable.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Avoid turning long or non-linear workflows into a single rigid step sequence.
+  </Card>
+</CardGroup>
+
+## Accessibility
+
+The `bq-steps` container renders with `role="list"`, and each `bq-step-item` renders with `role="listitem"` around an interactive button. The current step maps to `aria-current="step"`, and disabled items use the native `disabled` button state.
+
+- **Keyboard** - users can move through step items with <kbd>Tab</kbd> and <kbd>Shift</kbd> + <kbd>Tab</kbd>. They can activate an enabled step with <kbd>Enter</kbd> or <kbd>Space</kbd>.
+- **Current step** - set `status="current"` on one step item so assistive technology can announce the current position.
+- **Status communication** - pair color with text, icon shape, or description changes so users do not need color perception to understand progress.
+- **Icons and numbers** - mark decorative icons with `aria-hidden="true"`. When numeric prefixes are used, provide an `aria-label` such as `Step 1`.
+- **Descriptions** - use the `description` slot when users need more context about a step, an error, or the expected next action.
+
+## API reference
+
+### Properties
+
+#### `bq-steps`
+
+| Property | Attribute | Description | Type | Default |
+|---|---|---|---|---|
+| `dividerColor` | `divider-color` | Color token for the line that connects steps | `string` | `'stroke--primary'` |
+| `orientation` | `orientation` | Direction of the steps | `'horizontal'` \| `'vertical'` | `'horizontal'` |
+| `size` | `size` | Size of the steps | `'medium'` \| `'small'` | `'medium'` |
+| `type` | `type` | Prefix type passed to step items | `'numeric'` \| `'icon'` \| `'dot'` | `undefined` |
+
+#### `bq-step-item`
+
+| Property | Attribute | Description | Type | Default |
+|---|---|---|---|---|
+| `dividerColor` | `divider-color` | Color token for the divider after this item; usually inherited from `bq-steps` | `string` | `'stroke--primary'` |
+| `orientation` | `orientation` | Direction of the item; usually inherited from `bq-steps` | `'horizontal'` \| `'vertical'` | `'horizontal'` |
+| `size` | `size` | Prefix size; usually inherited from `bq-steps` | `'medium'` \| `'small'` | `'medium'` |
+| `status` | `status` | Visual and semantic state of the item | `'default'` \| `'current'` \| `'completed'` \| `'error'` \| `'disabled'` | `'default'` |
+| `type` | `type` | Prefix type; usually inherited from `bq-steps` | `'numeric'` \| `'icon'` \| `'dot'` | `undefined` |
+
+### Slots
+
+#### `bq-steps`
+
+| Slot | Description |
+|---|---|
+| *(default)* | Step items |
+
+#### `bq-step-item`
+
+| Slot | Description |
+|---|---|
+| *(default)* | Step item title content |
+| `prefix` | Dot, icon, or number shown before the title |
+| `description` | Supporting text shown below the title |
+
+### Shadow parts
+
+#### `bq-steps`
+
+| Part | Description |
+|---|---|
+| `container` | Container wrapper of the Steps component |
+| `divider-base` | Base wrapper of the divider component |
+| `divider-dash-start` | Start dash of the divider component |
+| `divider-dash-end` | End dash of the divider component |
+
+#### `bq-step-item`
+
+| Part | Description |
+|---|---|
+| `base` | Step item button wrapper |
+| `title` | Step item title |
+| `description` | Step item description |
+
+### CSS custom properties
+
+<Expandable title="CSS variables" defaultOpen={true}>
+  | Variable | Description | Default |
+  |---|---|---|
+  | `--bq-steps--divider-color` | Divider color | `var(--bq-stroke--secondary)` |
+  | `--bq-steps--gap` | Gap between steps | `var(--bq-spacing-m)` |
+  | `--bq-step-item--prefix-color` | Prefix icon color | `var(--bq-icon--secondary)` |
+  | `--bq-step-item--prefix-color-current` | Prefix icon color for the current state | `var(--bq-icon--brand)` |
+  | `--bq-step-item--prefix-color-completed` | Prefix icon color for the completed state | `var(--bq-icon--success)` |
+  | `--bq-step-item--prefix-color-error` | Prefix icon color for the error state | `var(--bq-icon--danger)` |
+  | `--bq-step-item--prefix-num-size` | Prefix number size | `var(--bq-spacing-xl)` |
+  | `--bq-step-item--prefix-num-bg-color` | Prefix number background color | `var(--bq-background--secondary)` |
+</Expandable>
+
+<Tip>
+  Learn more about [styling with shadow parts](/theming/styles) and [CSS custom properties](/theming/global-css-variables).
+</Tip>
+
+### Events
+
+| Component | Event | Description | Type |
+|---|---|---|---|
+| `bq-step-item` | `bqClick` | Fires when an enabled step item is clicked | `CustomEvent<HTMLBqStepItemElement>` |
+| `bq-step-item` | `bqFocus` | Fires when a step item receives focus | `CustomEvent<HTMLBqStepItemElement>` |
+| `bq-step-item` | `bqBlur` | Fires when a step item loses focus | `CustomEvent<HTMLBqStepItemElement>` |
+
+<Note>
+  - In React, prefix events with `on`: `onBqClick`, `onBqFocus`, `onBqBlur`.
+  - In Angular, use event binding syntax: `(bqClick)`, `(bqFocus)`, `(bqBlur)`.
+  - In Vue, use the `@` shorthand: `@bqClick`, `@bqFocus`, `@bqBlur`.
+</Note>
+
+### Methods
+
+| Component | Method | Description | Returns |
+|---|---|---|---|
+| `bq-steps` | `setCurrentStepItem(newCurrentStep)` | Sets the provided step item as current and resets the previous current item to default | `Promise<void>` |
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card horizontal title="Interactive playground" icon="code" href="https://storybook.beeq.design/?path=/story/components-steps--dots">
+    Explore Steps variants and states in Storybook
+  </Card>
+  <Card horizontal title="Source code" icon="github" href="https://github.com/Endava/BEEQ/tree/main/packages/beeq/src/components/steps">
+    View the component source on GitHub
+  </Card>
+</CardGroup>

--- a/apps/beeq-docs/components/steps.mdx
+++ b/apps/beeq-docs/components/steps.mdx
@@ -42,15 +42,18 @@ Steps guide users through a sequential process such as a wizard, onboarding flow
 
 ## Patterns
 
-<CardGroup cols={3}>
-  <Card title="Dots">
-    Dots provide a compact progress indicator for straightforward linear flows.
+<CardGroup cols={2}>
+  <Card title="Multistep forms">
+    Split long forms into clear stages so users can see what is complete, where they are, and what remains.
   </Card>
-  <Card title="Numbers">
-    Numbers make the order explicit when users need to understand sequence at a glance.
+  <Card title="Onboarding and wizards">
+    Guide users through setup flows where each step depends on the previous one.
   </Card>
-  <Card title="Icons">
-    Icons add visual meaning when each step represents a recognizable action or context.
+  <Card title="Process overviews">
+    Summarize a task, service, or project flow when readers need the full sequence before they start.
+  </Card>
+  <Card title="Progress tracking">
+    Show completed, current, upcoming, blocked, or disabled stages in a process that changes over time.
   </Card>
 </CardGroup>
 
@@ -107,353 +110,91 @@ Steps are composed of a label or prefix, title, optional description, and divide
 
 Labels describe each step, while icons provide visual cues. Use meaningful titles and reserve icons for cases where the symbol helps users understand the action or context.
 
-### States
-
-Steps support `default`, `current`, `completed`, `error`, and `disabled` states. Use these states to show what users have finished, where they are now, and what requires attention.
-
 ## Usage
 
-### Dots
+Start with `bq-steps` and one `bq-step-item` for each stage. There are three types of steps: `numeric`, `dot`, and `icon`.
 
-Use `type="dot"` for a minimal progress indicator when the sequence is clear and the step labels carry most of the meaning.
+<Warning>
+  You **must specify the type** you want to use on `bq-steps`. If you don't, the default styles will apply, but it may not match your content or design intent.
+</Warning>
 
-<CodeLivePreview code={`<bq-steps type="dot">
-  <bq-step-item status="default">
-    <bq-icon aria-hidden="true" slot="prefix" name="circle"></bq-icon>
-    <span>Details</span>
-    <span slot="description">Add your personal details</span>
-  </bq-step-item>
-  <bq-step-item status="error">
-    <bq-icon aria-hidden="true" slot="prefix" name="x-circle"></bq-icon>
-    <span>Payment</span>
-    <span slot="description">Resolve the payment error</span>
-  </bq-step-item>
-  <bq-step-item status="completed">
-    <bq-icon aria-hidden="true" slot="prefix" name="check-circle"></bq-icon>
-    <span>Review</span>
-    <span slot="description">Review completed</span>
-  </bq-step-item>
-  <bq-step-item status="current">
-    <bq-icon aria-hidden="true" slot="prefix" name="circle"></bq-icon>
-    <span>Confirm</span>
-    <span slot="description">Confirm your request</span>
-  </bq-step-item>
-</bq-steps>`}>
+### Numeric
+
+Start with the numeric type to show a clear sequence and position in the process. Each step should have a number prefix that matches its order.
+
+<CodeLivePreview mode="iframe" height="15rem" removePadding code={`
+  <style>
+    body {
+      padding: var(--bq-spacing-m);
+    }
+
+    /* Optional: Set a fixed width for numeric prefixes */
+    span[slot="prefix"] {
+      min-inline-size: var(--bq-step-item--prefix-number-size, var(--bq-spacing-xl));
+    }
+  </style>
+  <bq-steps type="numeric">
+    <bq-step-item>
+      <span aria-label="Step 1" slot="prefix">1</span>
+      <span>Account</span>
+      <span slot="description">Create your account</span>
+    </bq-step-item>
+    <bq-step-item>
+      <span aria-label="Step 2" slot="prefix">2</span>
+      <span>Profile</span>
+      <span slot="description">Complete your profile details</span>
+    </bq-step-item>
+    <bq-step-item>
+      <span aria-label="Step 3" slot="prefix">3</span>
+      <span>Review and Submit</span>
+      <span slot="description">Review your details and submit</span>
+    </bq-step-item>
+  </bq-steps>
+`}>
   <CodeGroup>
-    ```html HTML icon="html5"
-    <bq-steps type="dot">
-      <bq-step-item status="default">
-        <bq-icon aria-hidden="true" slot="prefix" name="circle"></bq-icon>
-        <span>Details</span>
-        <span slot="description">Add your personal details</span>
-      </bq-step-item>
-      <bq-step-item status="error">
-        <bq-icon aria-hidden="true" slot="prefix" name="x-circle"></bq-icon>
-        <span>Payment</span>
-        <span slot="description">Resolve the payment error</span>
-      </bq-step-item>
-      <bq-step-item status="completed">
-        <bq-icon aria-hidden="true" slot="prefix" name="check-circle"></bq-icon>
-        <span>Review</span>
-        <span slot="description">Review completed</span>
-      </bq-step-item>
-      <bq-step-item status="current">
-        <bq-icon aria-hidden="true" slot="prefix" name="circle"></bq-icon>
-        <span>Confirm</span>
-        <span slot="description">Confirm your request</span>
-      </bq-step-item>
-    </bq-steps>
-    ```
-    ```jsx React icon="react"
-    import { BqIcon, BqStepItem, BqSteps } from "@beeq/react";
-
-    <BqSteps type="dot">
-      <BqStepItem status="default">
-        <BqIcon aria-hidden="true" slot="prefix" name="circle" />
-        <span>Details</span>
-        <span slot="description">Add your personal details</span>
-      </BqStepItem>
-      <BqStepItem status="error">
-        <BqIcon aria-hidden="true" slot="prefix" name="x-circle" />
-        <span>Payment</span>
-        <span slot="description">Resolve the payment error</span>
-      </BqStepItem>
-      <BqStepItem status="completed">
-        <BqIcon aria-hidden="true" slot="prefix" name="check-circle" />
-        <span>Review</span>
-        <span slot="description">Review completed</span>
-      </BqStepItem>
-      <BqStepItem status="current">
-        <BqIcon aria-hidden="true" slot="prefix" name="circle" />
-        <span>Confirm</span>
-        <span slot="description">Confirm your request</span>
-      </BqStepItem>
-    </BqSteps>
-    ```
-    ```ts Angular icon="angular"
-    import { Component } from "@angular/core";
-    import { BqIcon, BqStepItem, BqSteps } from "@beeq/angular/standalone";
-
-    @Component({
-      standalone: true,
-      imports: [BqIcon, BqStepItem, BqSteps],
-      template: `
-        <bq-steps type="dot">
-          <bq-step-item status="default">
-            <bq-icon aria-hidden="true" slot="prefix" name="circle"></bq-icon>
-            <span>Details</span>
-            <span slot="description">Add your personal details</span>
-          </bq-step-item>
-          <bq-step-item status="error">
-            <bq-icon aria-hidden="true" slot="prefix" name="x-circle"></bq-icon>
-            <span>Payment</span>
-            <span slot="description">Resolve the payment error</span>
-          </bq-step-item>
-          <bq-step-item status="completed">
-            <bq-icon aria-hidden="true" slot="prefix" name="check-circle"></bq-icon>
-            <span>Review</span>
-            <span slot="description">Review completed</span>
-          </bq-step-item>
-          <bq-step-item status="current">
-            <bq-icon aria-hidden="true" slot="prefix" name="circle"></bq-icon>
-            <span>Confirm</span>
-            <span slot="description">Confirm your request</span>
-          </bq-step-item>
-        </bq-steps>
-      `
-    })
-    export class DotStepsComponent {}
-    ```
-    ```vue Vue icon="vuejs"
-    <script setup lang="ts">
-    import { BqIcon, BqStepItem, BqSteps } from "@beeq/vue";
-    </script>
-
-    <template>
-      <BqSteps type="dot">
-        <BqStepItem status="default">
-          <BqIcon aria-hidden="true" slot="prefix" name="circle" />
-          <span>Details</span>
-          <span slot="description">Add your personal details</span>
-        </BqStepItem>
-        <BqStepItem status="error">
-          <BqIcon aria-hidden="true" slot="prefix" name="x-circle" />
-          <span>Payment</span>
-          <span slot="description">Resolve the payment error</span>
-        </BqStepItem>
-        <BqStepItem status="completed">
-          <BqIcon aria-hidden="true" slot="prefix" name="check-circle" />
-          <span>Review</span>
-          <span slot="description">Review completed</span>
-        </BqStepItem>
-        <BqStepItem status="current">
-          <BqIcon aria-hidden="true" slot="prefix" name="circle" />
-          <span>Confirm</span>
-          <span slot="description">Confirm your request</span>
-        </BqStepItem>
-      </BqSteps>
-    </template>
-    ```
-  </CodeGroup>
-</CodeLivePreview>
-
-### Icons
-
-Use `type="icon"` when each step benefits from a recognizable symbol. Icons should support the label, not replace it.
-
-<CodeLivePreview code={`<bq-steps type="icon">
-  <bq-step-item status="completed">
-    <bq-icon aria-hidden="true" slot="prefix" name="airplane-takeoff"></bq-icon>
-    <span>Flight</span>
-    <span slot="description">Reserve your flight</span>
-  </bq-step-item>
-  <bq-step-item status="error">
-    <bq-icon aria-hidden="true" slot="prefix" name="car"></bq-icon>
-    <span>Rent a car</span>
-    <span slot="description">There was an error with your reservation</span>
-  </bq-step-item>
-  <bq-step-item status="current">
-    <bq-icon aria-hidden="true" slot="prefix" name="tree-palm"></bq-icon>
-    <span>Enjoy your holidays!</span>
-    <span slot="description">You're ready for your vacations</span>
-  </bq-step-item>
-</bq-steps>`}>
-  <CodeGroup>
-    ```html HTML icon="html5"
-    <bq-steps type="icon">
-      <bq-step-item status="completed">
-        <bq-icon aria-hidden="true" slot="prefix" name="airplane-takeoff"></bq-icon>
-        <span>Flight</span>
-        <span slot="description">Reserve your flight</span>
-      </bq-step-item>
-      <bq-step-item status="error">
-        <bq-icon aria-hidden="true" slot="prefix" name="car"></bq-icon>
-        <span>Rent a car</span>
-        <span slot="description">There was an error with your reservation</span>
-      </bq-step-item>
-      <bq-step-item status="current">
-        <bq-icon aria-hidden="true" slot="prefix" name="tree-palm"></bq-icon>
-        <span>Enjoy your holidays!</span>
-        <span slot="description">You're ready for your vacations</span>
-      </bq-step-item>
-    </bq-steps>
-    ```
-    ```jsx React icon="react"
-    import { BqIcon, BqStepItem, BqSteps } from "@beeq/react";
-
-    <BqSteps type="icon">
-      <BqStepItem status="completed">
-        <BqIcon aria-hidden="true" slot="prefix" name="airplane-takeoff" />
-        <span>Flight</span>
-        <span slot="description">Reserve your flight</span>
-      </BqStepItem>
-      <BqStepItem status="error">
-        <BqIcon aria-hidden="true" slot="prefix" name="car" />
-        <span>Rent a car</span>
-        <span slot="description">There was an error with your reservation</span>
-      </BqStepItem>
-      <BqStepItem status="current">
-        <BqIcon aria-hidden="true" slot="prefix" name="tree-palm" />
-        <span>Enjoy your holidays!</span>
-        <span slot="description">You're ready for your vacations</span>
-      </BqStepItem>
-    </BqSteps>
-    ```
-    ```ts Angular icon="angular"
-    import { Component } from "@angular/core";
-    import { BqIcon, BqStepItem, BqSteps } from "@beeq/angular/standalone";
-
-    @Component({
-      standalone: true,
-      imports: [BqIcon, BqStepItem, BqSteps],
-      template: `
-        <bq-steps type="icon">
-          <bq-step-item status="completed">
-            <bq-icon aria-hidden="true" slot="prefix" name="airplane-takeoff"></bq-icon>
-            <span>Flight</span>
-            <span slot="description">Reserve your flight</span>
-          </bq-step-item>
-          <bq-step-item status="error">
-            <bq-icon aria-hidden="true" slot="prefix" name="car"></bq-icon>
-            <span>Rent a car</span>
-            <span slot="description">There was an error with your reservation</span>
-          </bq-step-item>
-          <bq-step-item status="current">
-            <bq-icon aria-hidden="true" slot="prefix" name="tree-palm"></bq-icon>
-            <span>Enjoy your holidays!</span>
-            <span slot="description">You're ready for your vacations</span>
-          </bq-step-item>
-        </bq-steps>
-      `
-    })
-    export class IconStepsComponent {}
-    ```
-    ```vue Vue icon="vuejs"
-    <script setup lang="ts">
-    import { BqIcon, BqStepItem, BqSteps } from "@beeq/vue";
-    </script>
-
-    <template>
-      <BqSteps type="icon">
-        <BqStepItem status="completed">
-          <BqIcon aria-hidden="true" slot="prefix" name="airplane-takeoff" />
-          <span>Flight</span>
-          <span slot="description">Reserve your flight</span>
-        </BqStepItem>
-        <BqStepItem status="error">
-          <BqIcon aria-hidden="true" slot="prefix" name="car" />
-          <span>Rent a car</span>
-          <span slot="description">There was an error with your reservation</span>
-        </BqStepItem>
-        <BqStepItem status="current">
-          <BqIcon aria-hidden="true" slot="prefix" name="tree-palm" />
-          <span>Enjoy your holidays!</span>
-          <span slot="description">You're ready for your vacations</span>
-        </BqStepItem>
-      </BqSteps>
-    </template>
-    ```
-  </CodeGroup>
-</CodeLivePreview>
-
-### Numbers
-
-Use `type="numeric"` when order and sequence need to be explicit.
-
-<CodeLivePreview code={`<bq-steps type="numeric">
-  <bq-step-item status="default">
-    <span aria-label="Step 1" slot="prefix">1</span>
-    <span>Details</span>
-    <span slot="description">Description</span>
-  </bq-step-item>
-  <bq-step-item status="completed">
-    <span aria-label="Step 2" slot="prefix">2</span>
-    <span>Review</span>
-    <span slot="description">Description</span>
-  </bq-step-item>
-  <bq-step-item status="error">
-    <span aria-label="Step 3" slot="prefix">3</span>
-    <span>Payment</span>
-    <span slot="description">Description</span>
-  </bq-step-item>
-  <bq-step-item status="current">
-    <span aria-label="Step 4" slot="prefix">4</span>
-    <span>Confirm</span>
-    <span slot="description">Description</span>
-  </bq-step-item>
-</bq-steps>`}>
-  <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-steps type="numeric">
-      <bq-step-item status="default">
+      <bq-step-item>
         <span aria-label="Step 1" slot="prefix">1</span>
-        <span>Details</span>
-        <span slot="description">Description</span>
+        <span>Account</span>
+        <span slot="description">Create your account</span>
       </bq-step-item>
-      <bq-step-item status="completed">
+      <bq-step-item>
         <span aria-label="Step 2" slot="prefix">2</span>
-        <span>Review</span>
-        <span slot="description">Description</span>
+        <span>Profile</span>
+        <span slot="description">Complete your profile details</span>
       </bq-step-item>
-      <bq-step-item status="error">
+      <bq-step-item>
         <span aria-label="Step 3" slot="prefix">3</span>
-        <span>Payment</span>
-        <span slot="description">Description</span>
-      </bq-step-item>
-      <bq-step-item status="current">
-        <span aria-label="Step 4" slot="prefix">4</span>
-        <span>Confirm</span>
-        <span slot="description">Description</span>
+        <span>Review and Submit</span>
+        <span slot="description">Review your details and submit</span>
       </bq-step-item>
     </bq-steps>
     ```
-    ```jsx React icon="react"
+
+    ```jsx React icon="react" expandable
     import { BqStepItem, BqSteps } from "@beeq/react";
 
     <BqSteps type="numeric">
-      <BqStepItem status="default">
+      <BqStepItem>
         <span aria-label="Step 1" slot="prefix">1</span>
-        <span>Details</span>
-        <span slot="description">Description</span>
+        <span>Account</span>
+        <span slot="description">Create your account</span>
       </BqStepItem>
-      <BqStepItem status="completed">
+      <BqStepItem>
         <span aria-label="Step 2" slot="prefix">2</span>
-        <span>Review</span>
-        <span slot="description">Description</span>
+        <span>Profile</span>
+        <span slot="description">Complete your profile details</span>
       </BqStepItem>
-      <BqStepItem status="error">
+      <BqStepItem>
         <span aria-label="Step 3" slot="prefix">3</span>
-        <span>Payment</span>
-        <span slot="description">Description</span>
-      </BqStepItem>
-      <BqStepItem status="current">
-        <span aria-label="Step 4" slot="prefix">4</span>
-        <span>Confirm</span>
-        <span slot="description">Description</span>
+        <span>Review and Submit</span>
+        <span slot="description">Review your details and submit</span>
       </BqStepItem>
     </BqSteps>
     ```
-    ```ts Angular icon="angular"
+
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqStepItem, BqSteps } from "@beeq/angular/standalone";
 
@@ -462,57 +203,477 @@ Use `type="numeric"` when order and sequence need to be explicit.
       imports: [BqStepItem, BqSteps],
       template: `
         <bq-steps type="numeric">
-          <bq-step-item status="default">
+          <bq-step-item>
             <span aria-label="Step 1" slot="prefix">1</span>
-            <span>Details</span>
-            <span slot="description">Description</span>
+            <span>Account</span>
+            <span slot="description">Create your account</span>
           </bq-step-item>
-          <bq-step-item status="completed">
+          <bq-step-item>
             <span aria-label="Step 2" slot="prefix">2</span>
-            <span>Review</span>
-            <span slot="description">Description</span>
+            <span>Profile</span>
+            <span slot="description">Complete your profile details</span>
           </bq-step-item>
-          <bq-step-item status="error">
+          <bq-step-item>
             <span aria-label="Step 3" slot="prefix">3</span>
-            <span>Payment</span>
-            <span slot="description">Description</span>
-          </bq-step-item>
-          <bq-step-item status="current">
-            <span aria-label="Step 4" slot="prefix">4</span>
-            <span>Confirm</span>
-            <span slot="description">Description</span>
+            <span>Review and Submit</span>
+            <span slot="description">Review your details and submit</span>
           </bq-step-item>
         </bq-steps>
       `
     })
     export class NumericStepsComponent {}
     ```
-    ```vue Vue icon="vuejs"
+
+    ```vue Vue icon="vuejs" expandable
+    <script setup lang="ts">
+    import { BqStepItem, BqSteps } from "@beeq/vue";
+    </script>
+
+    <template>
+      <bq-steps type="numeric">
+        <bq-step-item>
+          <span aria-label="Step 1" slot="prefix">1</span>
+          <span>Account</span>
+          <span slot="description">Create your account</span>
+        </bq-step-item>
+        <bq-step-item>
+          <span aria-label="Step 2" slot="prefix">2</span>
+          <span>Profile</span>
+          <span slot="description">Complete your profile details</span>
+        </bq-step-item>
+        <bq-step-item>
+          <span aria-label="Step 3" slot="prefix">3</span>
+          <span>Review and Submit</span>
+          <span slot="description">Review your details and submit</span>
+        </bq-step-item>
+      </bq-steps>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Dot
+
+Use `type="dot"` for a minimal progress indicator when the sequence is clear and the step labels carry most of the meaning.
+
+<CodeLivePreview mode="iframe" height="15rem" removePadding code={`
+  <style>
+    body {
+      padding: var(--bq-spacing-m);
+    }
+  </style>
+  <bq-steps type="dot">
+    <bq-step-item>
+      <bq-icon aria-hidden="true" slot="prefix" name="check-circle"></bq-icon>
+      <span>Plan</span>
+      <span slot="description">Scope approved</span>
+    </bq-step-item>
+    <bq-step-item>
+      <bq-icon aria-hidden="true" slot="prefix" name="circle"></bq-icon>
+      <span>Build</span>
+      <span slot="description">Work in progress</span>
+    </bq-step-item>
+    <bq-step-item>
+      <bq-icon aria-hidden="true" slot="prefix" name="circle"></bq-icon>
+      <span>Launch</span>
+      <span slot="description">Ready next</span>
+    </bq-step-item>
+  </bq-steps>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5" expandable
+    <bq-steps type="dot">
+      <bq-step-item>
+        <bq-icon aria-hidden="true" slot="prefix" name="check-circle"></bq-icon>
+        <span>Plan</span>
+        <span slot="description">Scope approved</span>
+      </bq-step-item>
+      <bq-step-item>
+        <bq-icon aria-hidden="true" slot="prefix" name="circle"></bq-icon>
+        <span>Build</span>
+        <span slot="description">Work in progress</span>
+      </bq-step-item>
+      <bq-step-item>
+        <bq-icon aria-hidden="true" slot="prefix" name="circle"></bq-icon>
+        <span>Launch</span>
+        <span slot="description">Ready next</span>
+      </bq-step-item>
+    </bq-steps>
+    ```
+
+    ```jsx React icon="react" expandable
+    import { BqIcon, BqStepItem, BqSteps } from "@beeq/react";
+
+    <BqSteps type="dot">
+      <BqStepItem>
+        <BqIcon aria-hidden="true" slot="prefix" name="check-circle" />
+        <span>Plan</span>
+        <span slot="description">Scope approved</span>
+      </BqStepItem>
+      <BqStepItem>
+        <BqIcon aria-hidden="true" slot="prefix" name="circle" />
+        <span>Build</span>
+        <span slot="description">Work in progress</span>
+      </BqStepItem>
+      <BqStepItem>
+        <BqIcon aria-hidden="true" slot="prefix" name="circle" />
+        <span>Launch</span>
+        <span slot="description">Ready next</span>
+      </BqStepItem>
+    </BqSteps>
+    ```
+
+    ```ts Angular icon="angular" expandable
+    import { Component } from "@angular/core";
+    import { BqIcon, BqStepItem, BqSteps } from "@beeq/angular/standalone";
+
+    @Component({
+      standalone: true,
+      imports: [BqIcon, BqStepItem, BqSteps],
+      template: `
+        <bq-steps type="dot">
+          <bq-step-item>
+            <bq-icon aria-hidden="true" slot="prefix" name="check-circle"></bq-icon>
+            <span>Plan</span>
+            <span slot="description">Scope approved</span>
+          </bq-step-item>
+          <bq-step-item>
+            <bq-icon aria-hidden="true" slot="prefix" name="circle"></bq-icon>
+            <span>Build</span>
+            <span slot="description">Work in progress</span>
+          </bq-step-item>
+          <bq-step-item>
+            <bq-icon aria-hidden="true" slot="prefix" name="circle"></bq-icon>
+            <span>Launch</span>
+            <span slot="description">Ready next</span>
+          </bq-step-item>
+        </bq-steps>
+      `
+    })
+    export class DotStepsComponent {}
+    ```
+
+    ```vue Vue icon="vuejs" expandable
+    <script setup lang="ts">
+    import { BqIcon, BqStepItem, BqSteps } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSteps type="dot">
+        <BqStepItem>
+          <BqIcon aria-hidden="true" slot="prefix" name="check-circle" />
+          <span>Plan</span>
+          <span slot="description">Scope approved</span>
+        </BqStepItem>
+        <BqStepItem>
+          <BqIcon aria-hidden="true" slot="prefix" name="circle" />
+          <span>Build</span>
+          <span slot="description">Work in progress</span>
+        </BqStepItem>
+        <BqStepItem>
+          <BqIcon aria-hidden="true" slot="prefix" name="circle" />
+          <span>Launch</span>
+          <span slot="description">Ready next</span>
+        </BqStepItem>
+      </BqSteps>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Icon
+
+Use `type="icon"` when each step benefits from a recognizable symbol. Icons should support the label, not replace it.
+
+<CodeLivePreview mode="iframe" height="15rem" removePadding code={`
+  <style>
+    body {
+      padding: var(--bq-spacing-m);
+    }
+  </style>
+  <bq-steps type="icon">
+    <bq-step-item>
+      <bq-icon aria-hidden="true" slot="prefix" name="user"></bq-icon>
+      <span>Account</span>
+      <span slot="description">Account created</span>
+    </bq-step-item>
+    <bq-step-item>
+      <bq-icon aria-hidden="true" slot="prefix" name="gear"></bq-icon>
+      <span>Settings</span>
+      <span slot="description">Choose preferences</span>
+    </bq-step-item>
+    <bq-step-item>
+      <bq-icon aria-hidden="true" slot="prefix" name="check-circle"></bq-icon>
+      <span>Confirm</span>
+      <span slot="description">Review and submit</span>
+    </bq-step-item>
+  </bq-steps>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5" expandable
+    <bq-steps type="icon">
+      <bq-step-item>
+        <bq-icon aria-hidden="true" slot="prefix" name="user"></bq-icon>
+        <span>Account</span>
+        <span slot="description">Account created</span>
+      </bq-step-item>
+      <bq-step-item>
+        <bq-icon aria-hidden="true" slot="prefix" name="gear"></bq-icon>
+        <span>Settings</span>
+        <span slot="description">Choose preferences</span>
+      </bq-step-item>
+      <bq-step-item>
+        <bq-icon aria-hidden="true" slot="prefix" name="check-circle"></bq-icon>
+        <span>Confirm</span>
+        <span slot="description">Review and submit</span>
+      </bq-step-item>
+    </bq-steps>
+    ```
+
+    ```jsx React icon="react" expandable
+    import { BqIcon, BqStepItem, BqSteps } from "@beeq/react";
+
+    <BqSteps type="icon">
+      <BqStepItem>
+        <BqIcon aria-hidden="true" slot="prefix" name="user" />
+        <span>Account</span>
+        <span slot="description">Account created</span>
+      </BqStepItem>
+      <BqStepItem>
+        <BqIcon aria-hidden="true" slot="prefix" name="gear" />
+        <span>Settings</span>
+        <span slot="description">Choose preferences</span>
+      </BqStepItem>
+      <BqStepItem>
+        <BqIcon aria-hidden="true" slot="prefix" name="check-circle" />
+        <span>Confirm</span>
+        <span slot="description">Review and submit</span>
+      </BqStepItem>
+    </BqSteps>
+    ```
+
+    ```ts Angular icon="angular" expandable
+    import { Component } from "@angular/core";
+    import { BqIcon, BqStepItem, BqSteps } from "@beeq/angular/standalone";
+
+    @Component({
+      standalone: true,
+      imports: [BqIcon, BqStepItem, BqSteps],
+      template: `
+        <bq-steps type="icon">
+          <bq-step-item>
+            <bq-icon aria-hidden="true" slot="prefix" name="user"></bq-icon>
+            <span>Account</span>
+            <span slot="description">Account created</span>
+          </bq-step-item>
+          <bq-step-item>
+            <bq-icon aria-hidden="true" slot="prefix" name="gear"></bq-icon>
+            <span>Settings</span>
+            <span slot="description">Choose preferences</span>
+          </bq-step-item>
+          <bq-step-item>
+            <bq-icon aria-hidden="true" slot="prefix" name="check-circle"></bq-icon>
+            <span>Confirm</span>
+            <span slot="description">Review and submit</span>
+          </bq-step-item>
+        </bq-steps>
+      `
+    })
+    export class IconStepsComponent {}
+    ```
+
+    ```vue Vue icon="vuejs" expandable
+    <script setup lang="ts">
+    import { BqIcon, BqStepItem, BqSteps } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSteps type="icon">
+        <BqStepItem>
+          <BqIcon aria-hidden="true" slot="prefix" name="user" />
+          <span>Account</span>
+          <span slot="description">Account created</span>
+        </BqStepItem>
+        <BqStepItem>
+          <BqIcon aria-hidden="true" slot="prefix" name="gear" />
+          <span>Settings</span>
+          <span slot="description">Choose preferences</span>
+        </BqStepItem>
+        <BqStepItem>
+          <BqIcon aria-hidden="true" slot="prefix" name="check-circle" />
+          <span>Confirm</span>
+          <span slot="description">Review and submit</span>
+        </BqStepItem>
+      </BqSteps>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+## Status
+
+Use the `status` attribute to show progress and guide users through the process.
+The current step should be visually distinct from completed and remaining steps.
+
+<Tip>
+  The status should be applied to the `bq-step-item` element. This ensures that the entire step, including the label and description, reflects the current state.
+</Tip>
+
+| Status | Description |
+|---|---|
+| `default` | The default state for steps that have not been reached yet. It should be visually distinct from current and completed steps. |
+| `current` | The step the user is currently on. It should be visually highlighted to indicate focus. |
+| `completed` | A step that has been finished. It should be visually distinct from the current and remaining steps. |
+| `disabled` | A step that is not available for interaction, often because a previous step has not been completed. It should be visually subdued to indicate it cannot be accessed yet. |
+| `error` | A step that has an issue that needs attention. It should be visually distinct to indicate a problem. |
+
+<CodeLivePreview mode="iframe" height="10rem" removePadding code={`
+  <style>
+    body {
+      padding: var(--bq-spacing-m);
+    }
+
+    span[slot="prefix"] {
+      min-inline-size: var(--bq-step-item--prefix-number-size, var(--bq-spacing-xl));
+    }
+  </style>
+  <bq-steps type="numeric">
+    <bq-step-item status="completed">
+      <span aria-label="Step 1" slot="prefix">1</span>
+      <span>Completed</span>
+      <span slot="description">Completed</span>
+    </bq-step-item>
+    <bq-step-item status="current">
+      <span aria-label="Step 2" slot="prefix">2</span>
+      <span>Current</span>
+      <span slot="description">Current step</span>
+    </bq-step-item>
+    <bq-step-item status="error">
+      <span aria-label="Step 3" slot="prefix">3</span>
+      <span>Error</span>
+      <span slot="description">You need to address an issue</span>
+    </bq-step-item>
+    <bq-step-item status="disabled">
+      <span aria-label="Step 4" slot="prefix">4</span>
+      <span>Disabled</span>
+      <span slot="description">Complete previous steps first</span>
+    </bq-step-item>
+  </bq-steps>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5" expandable
+    <bq-steps type="numeric">
+      <bq-step-item status="completed">
+        <span aria-label="Step 1" slot="prefix">1</span>
+        <span>Completed</span>
+        <span slot="description">Completed</span>
+      </bq-step-item>
+      <bq-step-item status="current">
+        <span aria-label="Step 2" slot="prefix">2</span>
+        <span>Current</span>
+        <span slot="description">Current step</span>
+      </bq-step-item>
+      <bq-step-item status="error">
+        <span aria-label="Step 3" slot="prefix">3</span>
+        <span>Error</span>
+        <span slot="description">You need to address an issue</span>
+      </bq-step-item>
+      <bq-step-item status="disabled">
+        <span aria-label="Step 4" slot="prefix">4</span>
+        <span>Disabled</span>
+        <span slot="description">Complete previous steps first</span>
+      </bq-step-item>
+    </bq-steps>
+    ```
+
+    ```jsx React icon="react" expandable
+    import { BqStepItem, BqSteps } from "@beeq/react";
+
+    <BqSteps type="numeric">
+      <BqStepItem status="completed">
+        <span aria-label="Step 1" slot="prefix">1</span>
+        <span>Completed</span>
+        <span slot="description">Completed</span>
+      </BqStepItem>
+      <BqStepItem status="current">
+        <span aria-label="Step 2" slot="prefix">2</span>
+        <span>Current</span>
+        <span slot="description">Current step</span>
+      </BqStepItem>
+      <BqStepItem status="error">
+        <span aria-label="Step 3" slot="prefix">3</span>
+        <span>Error</span>
+        <span slot="description">You need to address an issue</span>
+      </BqStepItem>
+      <BqStepItem status="disabled">
+        <span aria-label="Step 4" slot="prefix">4</span>
+        <span>Disabled</span>
+        <span slot="description">Complete previous steps first</span>
+      </BqStepItem>
+    </BqSteps>
+    ```
+
+    ```ts Angular icon="angular" expandable
+    import { Component } from "@angular/core";
+    import { BqStepItem, BqSteps } from "@beeq/angular/standalone";
+
+    @Component({
+      standalone: true,
+      imports: [BqStepItem, BqSteps],
+      template: `
+        <bq-steps type="numeric">
+          <bq-step-item status="completed">
+            <span aria-label="Step 1" slot="prefix">1</span>
+            <span>Completed</span>
+            <span slot="description">Completed</span>
+          </bq-step-item>
+          <bq-step-item status="current">
+            <span aria-label="Step 2" slot="prefix">2</span>
+            <span>Current</span>
+            <span slot="description">Current step</span>
+          </bq-step-item>
+          <bq-step-item status="error">
+            <span aria-label="Step 3" slot="prefix">3</span>
+            <span>Error</span>
+            <span slot="description">You need to address an issue</span>
+          </bq-step-item>
+          <bq-step-item status="disabled">
+            <span aria-label="Step 4" slot="prefix">4</span>
+            <span>Disabled</span>
+            <span slot="description">Complete previous steps first</span>
+          </bq-step-item>
+        </bq-steps>
+      `
+    })
+    export class StatusStepsComponent {}
+    ```
+
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqStepItem, BqSteps } from "@beeq/vue";
     </script>
 
     <template>
       <BqSteps type="numeric">
-        <BqStepItem status="default">
-          <span aria-label="Step 1" slot="prefix">1</span>
-          <span>Details</span>
-          <span slot="description">Description</span>
-        </BqStepItem>
         <BqStepItem status="completed">
+          <span aria-label="Step 1" slot="prefix">1</span>
+          <span>Completed</span>
+          <span slot="description">Completed</span>
+        </BqStepItem>
+        <BqStepItem status="current">
           <span aria-label="Step 2" slot="prefix">2</span>
-          <span>Review</span>
-          <span slot="description">Description</span>
+          <span>Current</span>
+          <span slot="description">Current step</span>
         </BqStepItem>
         <BqStepItem status="error">
           <span aria-label="Step 3" slot="prefix">3</span>
-          <span>Payment</span>
-          <span slot="description">Description</span>
+          <span>Error</span>
+          <span slot="description">You need to address an issue</span>
         </BqStepItem>
-        <BqStepItem status="current">
+        <BqStepItem status="disabled">
           <span aria-label="Step 4" slot="prefix">4</span>
-          <span>Confirm</span>
-          <span slot="description">Description</span>
+          <span>Disabled</span>
+          <span slot="description">Complete previous steps first</span>
         </BqStepItem>
       </BqSteps>
     </template>
@@ -526,162 +687,214 @@ Use `type="numeric"` when order and sequence need to be explicit.
 
 Use `orientation="vertical"` when the process should unfold from top to bottom or when labels and descriptions need more room.
 
-<CodeLivePreview code={`<style>
-  :host {
-    align-items: stretch !important;
-    justify-content: flex-start !important;
-  }
+<CodeLivePreview mode="iframe" height="20rem" removePadding code={`
+  <style>
+    body {
+      display: flex;
+      padding: var(--bq-spacing-m);
+    }
 
-  .steps-demo--vertical {
-    block-size: 28rem;
-    display: flex;
-  }
-</style>
+    .container {
+      display: flex;
+      flex-direction: column;
+      flex-grow: 1;
+    }
 
-<div class="steps-demo--vertical">
-  <bq-steps orientation="vertical" type="icon">
-    <bq-step-item status="completed">
-      <bq-icon aria-hidden="true" slot="prefix" name="airplane-takeoff"></bq-icon>
-      <span>Flight</span>
-      <span slot="description">Reserve your flight</span>
-    </bq-step-item>
-    <bq-step-item status="error">
-      <bq-icon aria-hidden="true" slot="prefix" name="car"></bq-icon>
-      <span>Rent a car</span>
-      <span slot="description">There was an error with your reservation</span>
-    </bq-step-item>
-    <bq-step-item status="current">
-      <bq-icon aria-hidden="true" slot="prefix" name="tree-palm"></bq-icon>
-      <span>Enjoy your holidays!</span>
-      <span slot="description">You're ready for your vacations</span>
-    </bq-step-item>
-  </bq-steps>
-</div>`}>
-  <CodeGroup>
-    ```html HTML icon="html5"
-    <bq-steps orientation="vertical" type="icon">
+    span[slot="prefix"] {
+      min-inline-size: var(--bq-step-item--prefix-number-size, var(--bq-spacing-xl));
+    }
+  </style>
+
+  <div class="container">
+    <bq-steps orientation="vertical" type="numeric">
       <bq-step-item status="completed">
-        <bq-icon aria-hidden="true" slot="prefix" name="airplane-takeoff"></bq-icon>
-        <span>Flight</span>
-        <span slot="description">Reserve your flight</span>
-      </bq-step-item>
-      <bq-step-item status="error">
-        <bq-icon aria-hidden="true" slot="prefix" name="car"></bq-icon>
-        <span>Rent a car</span>
-        <span slot="description">There was an error with your reservation</span>
+        <span aria-label="Step 1" slot="prefix">1</span>
+        <span>Request</span>
       </bq-step-item>
       <bq-step-item status="current">
-        <bq-icon aria-hidden="true" slot="prefix" name="tree-palm"></bq-icon>
-        <span>Enjoy your holidays!</span>
-        <span slot="description">You're ready for your vacations</span>
+        <span aria-label="Step 2" slot="prefix">2</span>
+        <span>Review</span>
+      </bq-step-item>
+      <bq-step-item>
+        <span aria-label="Step 3" slot="prefix">3</span>
+        <span>Decision</span>
       </bq-step-item>
     </bq-steps>
-    ```
-    ```jsx React icon="react"
-    import { BqIcon, BqStepItem, BqSteps } from "@beeq/react";
+  </div>
+`}>
+  <CodeGroup>
+    ```css styles.css icon="css" expandable
+    body {
+      display: flex;
+      padding: var(--bq-spacing-m);
+    }
 
-    <BqSteps orientation="vertical" type="icon">
-      <BqStepItem status="completed">
-        <BqIcon aria-hidden="true" slot="prefix" name="airplane-takeoff" />
-        <span>Flight</span>
-        <span slot="description">Reserve your flight</span>
-      </BqStepItem>
-      <BqStepItem status="error">
-        <BqIcon aria-hidden="true" slot="prefix" name="car" />
-        <span>Rent a car</span>
-        <span slot="description">There was an error with your reservation</span>
-      </BqStepItem>
-      <BqStepItem status="current">
-        <BqIcon aria-hidden="true" slot="prefix" name="tree-palm" />
-        <span>Enjoy your holidays!</span>
-        <span slot="description">You're ready for your vacations</span>
-      </BqStepItem>
-    </BqSteps>
+    .container {
+      display: flex;
+      flex-direction: column;
+      flex-grow: 1;
+    }
     ```
-    ```ts Angular icon="angular"
+    ```html HTML icon="html5" expandable
+    <div class="container">
+      <bq-steps orientation="vertical" type="numeric">
+        <bq-step-item status="completed">
+          <span aria-label="Step 1" slot="prefix">1</span>
+          <span>Request</span>
+        </bq-step-item>
+        <bq-step-item status="current">
+          <span aria-label="Step 2" slot="prefix">2</span>
+          <span>Review</span>
+        </bq-step-item>
+        <bq-step-item>
+          <span aria-label="Step 3" slot="prefix">3</span>
+          <span>Decision</span>
+        </bq-step-item>
+      </bq-steps>
+    </div>
+    ```
+
+    ```jsx React icon="react" expandable
+    import { BqStepItem, BqSteps } from "@beeq/react";
+    import "./styles.css";
+
+    <div className="container">
+      <BqSteps orientation="vertical" type="numeric">
+        <BqStepItem status="completed">
+          <span aria-label="Step 1" slot="prefix">1</span>
+          <span>Request</span>
+        </BqStepItem>
+        <BqStepItem status="current">
+          <span aria-label="Step 2" slot="prefix">2</span>
+          <span>Review</span>
+        </BqStepItem>
+        <BqStepItem>
+          <span aria-label="Step 3" slot="prefix">3</span>
+          <span>Decision</span>
+        </BqStepItem>
+      </BqSteps>
+    </div>
+    ```
+
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
-    import { BqIcon, BqStepItem, BqSteps } from "@beeq/angular/standalone";
+    import { BqStepItem, BqSteps } from "@beeq/angular/standalone";
 
     @Component({
       standalone: true,
-      imports: [BqIcon, BqStepItem, BqSteps],
+      imports: [BqStepItem, BqSteps],
       template: `
-        <bq-steps orientation="vertical" type="icon">
-          <bq-step-item status="completed">
-            <bq-icon aria-hidden="true" slot="prefix" name="airplane-takeoff"></bq-icon>
-            <span>Flight</span>
-            <span slot="description">Reserve your flight</span>
-          </bq-step-item>
-          <bq-step-item status="error">
-            <bq-icon aria-hidden="true" slot="prefix" name="car"></bq-icon>
-            <span>Rent a car</span>
-            <span slot="description">There was an error with your reservation</span>
-          </bq-step-item>
-          <bq-step-item status="current">
-            <bq-icon aria-hidden="true" slot="prefix" name="tree-palm"></bq-icon>
-            <span>Enjoy your holidays!</span>
-            <span slot="description">You're ready for your vacations</span>
-          </bq-step-item>
-        </bq-steps>
+        <div class="container">
+          <bq-steps orientation="vertical" type="numeric">
+            <bq-step-item status="completed">
+              <span aria-label="Step 1" slot="prefix">1</span>
+              <span>Request</span>
+            </bq-step-item>
+            <bq-step-item status="current">
+              <span aria-label="Step 2" slot="prefix">2</span>
+              <span>Review</span>
+            </bq-step-item>
+            <bq-step-item>
+              <span aria-label="Step 3" slot="prefix">3</span>
+              <span>Decision</span>
+            </bq-step-item>
+          </bq-steps>
+        </div>
+      `,
+      style: `
+        body {
+          display: flex;
+          padding: var(--bq-spacing-m);
+        }
+
+        .container {
+          display: flex;
+          flex-direction: column;
+          flex-grow: 1;
+        }
       `
     })
     export class VerticalStepsComponent {}
     ```
-    ```vue Vue icon="vuejs"
+
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
-    import { BqIcon, BqStepItem, BqSteps } from "@beeq/vue";
+    import { BqStepItem, BqSteps } from "@beeq/vue";
     </script>
 
     <template>
-      <BqSteps orientation="vertical" type="icon">
-        <BqStepItem status="completed">
-          <BqIcon aria-hidden="true" slot="prefix" name="airplane-takeoff" />
-          <span>Flight</span>
-          <span slot="description">Reserve your flight</span>
-        </BqStepItem>
-        <BqStepItem status="error">
-          <BqIcon aria-hidden="true" slot="prefix" name="car" />
-          <span>Rent a car</span>
-          <span slot="description">There was an error with your reservation</span>
-        </BqStepItem>
-        <BqStepItem status="current">
-          <BqIcon aria-hidden="true" slot="prefix" name="tree-palm" />
-          <span>Enjoy your holidays!</span>
-          <span slot="description">You're ready for your vacations</span>
-        </BqStepItem>
-      </BqSteps>
+      <div class="container">
+        <BqSteps orientation="vertical" type="numeric">
+          <BqStepItem status="completed">
+            <span aria-label="Step 1" slot="prefix">1</span>
+            <span>Request</span>
+          </BqStepItem>
+          <BqStepItem status="current">
+            <span aria-label="Step 2" slot="prefix">2</span>
+            <span>Review</span>
+          </BqStepItem>
+          <BqStepItem>
+            <span aria-label="Step 3" slot="prefix">3</span>
+            <span>Decision</span>
+          </BqStepItem>
+        </BqSteps>
+      </div>
     </template>
+
+    <style>
+      body {
+        display: flex;
+        padding: var(--bq-spacing-m);
+      }
+
+      .container {
+        display: flex;
+        flex-direction: column;
+        flex-grow: 1;
+      }
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>
 
 <Tip>
-  Vertical steps adapt to the height of their container. Give the surrounding layout enough block size when you need the divider to span a taller area.
+  Vertical steps adapt to the height of their container. You must ensure that the container holding the steps has enough block size to allow the divider to span the desired area.
 </Tip>
 
 ### Size and divider color
 
 Use `size="small"` in compact layouts. Use `divider-color` with a declarative color token when the connector needs a different emphasis.
 
-<CodeLivePreview code={`<bq-steps divider-color="stroke--brand" size="small" type="numeric">
-  <bq-step-item status="completed">
-    <span aria-label="Step 1" slot="prefix">1</span>
-    <span>Account</span>
-    <span slot="description">Completed</span>
-  </bq-step-item>
-  <bq-step-item status="current">
-    <span aria-label="Step 2" slot="prefix">2</span>
-    <span>Preferences</span>
-    <span slot="description">Current step</span>
-  </bq-step-item>
-  <bq-step-item status="default">
-    <span aria-label="Step 3" slot="prefix">3</span>
-    <span>Finish</span>
-    <span slot="description">Next step</span>
-  </bq-step-item>
-</bq-steps>`}>
+<CodeLivePreview mode="iframe" height="10rem" removePadding code={`
+  <style>
+    body {
+      padding: var(--bq-spacing-m);
+    }
+
+    span[slot="prefix"] {
+      min-inline-size: var(--bq-spacing-l);
+    }
+  </style>
+  <bq-steps divider-color="stroke--brand" size="small" type="numeric">
+    <bq-step-item status="completed">
+      <span aria-label="Step 1" slot="prefix">1</span>
+      <span>Account</span>
+      <span slot="description">Completed</span>
+    </bq-step-item>
+    <bq-step-item status="current">
+      <span aria-label="Step 2" slot="prefix">2</span>
+      <span>Preferences</span>
+      <span slot="description">Current step</span>
+    </bq-step-item>
+    <bq-step-item>
+      <span aria-label="Step 3" slot="prefix">3</span>
+      <span>Finish</span>
+      <span slot="description">Next step</span>
+    </bq-step-item>
+  </bq-steps>
+`}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-steps divider-color="stroke--brand" size="small" type="numeric">
       <bq-step-item status="completed">
         <span aria-label="Step 1" slot="prefix">1</span>
@@ -693,14 +906,15 @@ Use `size="small"` in compact layouts. Use `divider-color` with a declarative co
         <span>Preferences</span>
         <span slot="description">Current step</span>
       </bq-step-item>
-      <bq-step-item status="default">
+      <bq-step-item>
         <span aria-label="Step 3" slot="prefix">3</span>
         <span>Finish</span>
         <span slot="description">Next step</span>
       </bq-step-item>
     </bq-steps>
     ```
-    ```jsx React icon="react"
+
+    ```jsx React icon="react" expandable
     import { BqStepItem, BqSteps } from "@beeq/react";
 
     <BqSteps dividerColor="stroke--brand" size="small" type="numeric">
@@ -714,14 +928,15 @@ Use `size="small"` in compact layouts. Use `divider-color` with a declarative co
         <span>Preferences</span>
         <span slot="description">Current step</span>
       </BqStepItem>
-      <BqStepItem status="default">
+      <BqStepItem>
         <span aria-label="Step 3" slot="prefix">3</span>
         <span>Finish</span>
         <span slot="description">Next step</span>
       </BqStepItem>
     </BqSteps>
     ```
-    ```ts Angular icon="angular"
+
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqStepItem, BqSteps } from "@beeq/angular/standalone";
 
@@ -740,7 +955,7 @@ Use `size="small"` in compact layouts. Use `divider-color` with a declarative co
             <span>Preferences</span>
             <span slot="description">Current step</span>
           </bq-step-item>
-          <bq-step-item status="default">
+          <bq-step-item>
             <span aria-label="Step 3" slot="prefix">3</span>
             <span>Finish</span>
             <span slot="description">Next step</span>
@@ -750,7 +965,8 @@ Use `size="small"` in compact layouts. Use `divider-color` with a declarative co
     })
     export class SmallStepsComponent {}
     ```
-    ```vue Vue icon="vuejs"
+
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqStepItem, BqSteps } from "@beeq/vue";
     </script>
@@ -767,7 +983,7 @@ Use `size="small"` in compact layouts. Use `divider-color` with a declarative co
           <span>Preferences</span>
           <span slot="description">Current step</span>
         </BqStepItem>
-        <BqStepItem status="default">
+        <BqStepItem>
           <span aria-label="Step 3" slot="prefix">3</span>
           <span>Finish</span>
           <span slot="description">Next step</span>
@@ -909,11 +1125,13 @@ The `bq-steps` container renders with `role="list"`, and each `bq-step-item` ren
 
 ### Events
 
-| Component | Event | Description | Type |
-|---|---|---|---|
-| `bq-step-item` | `bqClick` | Fires when an enabled step item is clicked | `CustomEvent<HTMLBqStepItemElement>` |
-| `bq-step-item` | `bqFocus` | Fires when a step item receives focus | `CustomEvent<HTMLBqStepItemElement>` |
-| `bq-step-item` | `bqBlur` | Fires when a step item loses focus | `CustomEvent<HTMLBqStepItemElement>` |
+#### `bq-step-item`
+
+| Event | Description | Type |
+|---|---|---|
+| `bqClick` | Fires when an enabled step item is clicked | `CustomEvent<HTMLBqStepItemElement>` |
+| `bqFocus` | Fires when a step item receives focus | `CustomEvent<HTMLBqStepItemElement>` |
+| `bqBlur` | Fires when a step item loses focus | `CustomEvent<HTMLBqStepItemElement>` |
 
 <Note>
   - In React, prefix events with `on`: `onBqClick`, `onBqFocus`, `onBqBlur`.
@@ -923,27 +1141,34 @@ The `bq-steps` container renders with `role="list"`, and each `bq-step-item` ren
 
 ### Methods
 
-| Component | Method | Description | Returns |
-|---|---|---|---|
-| `bq-steps` | `setCurrentStepItem(newCurrentStep)` | Sets the provided step item as current and resets the previous current item to default | `Promise<void>` |
+#### `bq-steps`
+
+| Method | Description | Returns |
+|---|---|---|
+| `setCurrentStepItem(newCurrentStep)` | Sets the provided step item as current and resets the previous current item to default | `Promise<void>` |
 
 ### CSS custom properties
 
-<Expandable title="CSS variables" defaultOpen={true}>
-  | Variable | Description | Default |
-  |---|---|---|
-  | `--bq-steps--divider-color` | Divider color | `var(--bq-stroke--secondary)` |
-  | `--bq-steps--gap` | Gap between steps | `var(--bq-spacing-m)` |
-  | `--bq-step-item--prefix-color` | Prefix icon color | `var(--bq-icon--secondary)` |
-  | `--bq-step-item--prefix-color-current` | Prefix icon color for the current state | `var(--bq-icon--brand)` |
-  | `--bq-step-item--prefix-color-completed` | Prefix icon color for the completed state | `var(--bq-icon--success)` |
-  | `--bq-step-item--prefix-color-error` | Prefix icon color for the error state | `var(--bq-icon--danger)` |
-  | `--bq-step-item--prefix-num-size` | Prefix number size | `var(--bq-spacing-xl)` |
-  | `--bq-step-item--prefix-num-bg-color` | Prefix number background color | `var(--bq-background--secondary)` |
-</Expandable>
+#### `bq-steps`
+
+| Variable | Description | Default |
+|---|---|---|
+| `--bq-steps--divider-color` | Divider color | `var(--bq-stroke--primary)` |
+| `--bq-steps--gap` | Gap between steps | `var(--bq-spacing-m)` |
+
+#### `bq-step-item`
+
+| Variable | Description | Default |
+|---|---|---|
+| `--bq-step-item--prefix-color` | Prefix icon color | `var(--bq-icon--secondary)` |
+| `--bq-step-item--prefix-color-current` | | Prefix icon color for the current state | `var(--bq-icon--brand)` |
+| `--bq-step-item--prefix-color-completed` | Prefix icon color for the completed state | `var(--bq-icon--success)` |
+| `--bq-step-item--prefix-color-error` | Prefix icon color for the error state | `var(--bq-icon--danger)` |
+| `--bq-step-item--prefix-num-size` | Prefix number size | `var(--bq-spacing-xl)` |
+| `--bq-step-item--prefix-num-bg-color` | Prefix number background color | `var(--bq-background--secondary)` |
 
 <Tip>
-  Learn more about [styling with shadow parts](/theming/styles) and [CSS custom properties](/theming/global-css-variables).
+  Learn more about [styling with shadow parts](/guides/styles) and [CSS custom properties](/theming/global-css-variables).
 </Tip>
 
 ## Resources

--- a/apps/beeq-docs/snippets/CodeLivePreview.jsx
+++ b/apps/beeq-docs/snippets/CodeLivePreview.jsx
@@ -1,68 +1,169 @@
+import { useEffect, useRef } from 'react';
+
 /**
- * A React component that renders a live preview of code snippets, supporting BEEQ web components and syncing with Mintlify's dark/light mode.
+ * CodeLivePreview
  *
- * @param {string} code - The HTML code to render in the live preview.
- * @param {ReactNode} children - Optional code section to render below the preview (e.g. for displaying the source code).
- * @param {string} height - Optional minimum height for the preview area (e.g. "200px").
+ * Renders interactive HTML examples inside docs while keeping styling predictable.
  *
- * @example
- * ```mdx
- * <CodeLivePreview code={`
- *   <bq-button appearance="primary">
- *     Click me
- *     <bq-icon name="plus" slot="suffix"></bq-icon>
- *   </bq-button>`}>
- *   <CodeGroup>
- *     ```mdx HTML
- *     <bq-button appearance="primary">
- *       Click me
- *       <bq-icon name="plus" slot="suffix"></bq-icon>
- *     </bq-button>
- *     ```
+ * Rendering modes:
+ * - shadow (default): fast, isolated from Mintlify styles, inherits CSS variables
+ * - iframe: full document isolation for components that mutate global document state
  *
- *     ```mdx React
- *     import { BqButton, BqIcon } from "@beeq/react";
+ * Why iframe mode exists:
+ * Some components are designed for app layouts and mutate document.body classes.
+ * In docs, that can cause page-level layout shifts. Iframe mode contains those side
+ * effects inside the iframe document, so the parent docs page remains stable.
  *
- *     <BqButton appearance="primary">
- *       Click me
- *       <BqIcon name="plus" slot="suffix" />
- *     </BqButton>
- *     ```
- *   </CodeGroup>
- * </CodeLivePreview>
- * ```
+ * @param {Object} props
+ * @param {string} props.code - HTML snippet injected into preview runtime.
+ * @param {React.ReactNode} props.children - Optional code tabs rendered below preview.
+ * @param {string} [props.height] - Minimum preview height (for stable layout).
+ * @param {boolean} [props.removePadding=false] - Whether to remove default padding from preview container.
+ * @param {'shadow' | 'iframe'} [props.mode='shadow'] - Preview isolation strategy.
  */
-export const CodeLivePreview = ({ code, children, height }) => {
+export const CodeLivePreview = ({ code, children, height, removePadding = false, mode = 'shadow' }) => {
   const previewRef = useRef(null);
 
-  // Load BEEQ web components (once)
-  useEffect(() => {
-    if (document.querySelector('script[data-beeq]')) return;
+  // Constants are centralized so URLs and selectors are not duplicated.
+  const BEEQ_ESM_URL = 'https://esm.sh/@beeq/core@beta/dist/beeq/beeq.esm.js';
+  const BEEQ_CSS_URL = 'https://esm.sh/@beeq/core@beta/dist/beeq/beeq.css';
+  const BEEQ_ICONS_URL = 'https://esm.sh/@beeq/core/dist/beeq/svg';
+
+  /**
+   * Ensures BEEQ web components are loaded in the parent document.
+   * Needed for shadow mode only; iframe mode loads its own runtime internally.
+   */
+  const ensureParentBeeqRuntime = () => {
+    if (document.querySelector('script[data-beeq-parent-runtime]')) return;
 
     const script = document.createElement('script');
     script.type = 'module';
-    script.src = 'https://esm.sh/@beeq/core@beta/dist/beeq/beeq.esm.js';
-    script.dataset.beeq = 'https://esm.sh/@beeq/core/dist/beeq/svg';
+    script.src = BEEQ_ESM_URL;
+    script.dataset.beeqParentRuntime = BEEQ_ICONS_URL;
     document.head.appendChild(script);
-  }, []);
+  };
 
-  // Attach a shadow root to the preview container and inject the code HTML.
-  // The shadow root isolates Mintlify/Tailwind styles so BEEQ components and
-  // any raw HTML elements in the preview always render with beeq.css only.
-  // CSS custom properties (--bq-*) still inherit through the shadow boundary,
-  // so design tokens and dark/light mode continue to work without changes.
+  /**
+   * Executes inline and external scripts from injected markup.
+   *
+   * Why not rely on browser auto-execution from innerHTML:
+   * Browsers do not execute inline scripts inserted via innerHTML.
+   * We recreate script execution manually and pass previewRoot so snippets can
+   * query only inside their sandbox.
+   *
+   * @param {Document | ShadowRoot} root - Container holding injected snippet.
+   * @param {Window} runtimeWindow - Window where Function constructor should run.
+   * @param {Document | ShadowRoot} previewRootArg - Value passed as previewRoot.
+   * @param {string} [skipAttr] - Optional data-attribute used to skip internal scripts.
+   */
+  const executeSnippetScripts = (root, runtimeWindow, previewRootArg, skipAttr) => {
+    root.querySelectorAll('script').forEach((oldScript) => {
+      if (skipAttr && oldScript.hasAttribute(skipAttr)) return;
+
+      if (oldScript.src) {
+        const newScript = runtimeWindow.document.createElement('script');
+        newScript.src = oldScript.src;
+        oldScript.replaceWith(newScript);
+        return;
+      }
+
+      runtimeWindow.Function('previewRoot', oldScript.textContent || '')(previewRootArg);
+      oldScript.remove();
+    });
+  };
+
+  /**
+   * Keeps iframe visual mode aligned with parent docs mode.
+   * This mirrors either explicit bq-mode or dark class from parent document.
+   *
+   * @param {Document} iframeDoc
+   */
+  const syncIframeMode = (iframeDoc) => {
+    const root = document.documentElement;
+    const explicitMode = root.getAttribute('bq-mode');
+    const isDark = root.classList.contains('dark');
+    const resolvedMode = explicitMode || (isDark ? 'dark' : 'light');
+
+    iframeDoc.documentElement.setAttribute('bq-mode', resolvedMode);
+    iframeDoc.body.setAttribute('bq-mode', resolvedMode);
+  };
+
+  // Parent runtime is only needed for shadow mode.
   useEffect(() => {
-    const el = previewRef.current;
-    if (!el) return;
+    if (mode === 'shadow') ensureParentBeeqRuntime();
+  }, [mode]);
 
-    // Attach shadow root once; reuse on subsequent code changes.
-    const shadowRoot = el.shadowRoot ?? el.attachShadow({ mode: 'open' });
+  /**
+   * Main rendering effect.
+   * Re-runs when code, mode, or height changes.
+   */
+  useEffect(() => {
+    const container = previewRef.current;
+    if (!container) return;
 
-    // Adopt the component-fix stylesheet on first attach.
-    // Mintlify evaluates snippets via eval/new Function (no module scope), so
-    // the sheet is created inline and guarded by adoptedStyleSheets.length —
-    // shadowRoot is reused across code changes, so this block runs only once.
+    if (removePadding) container.style.padding = '0';
+
+    // We recreate preview surface on each change to avoid stale event handlers/state.
+    container.innerHTML = '';
+
+    if (mode === 'iframe') {
+      const iframe = document.createElement('iframe');
+      iframe.className = 'preview-iframe';
+      iframe.style.width = '100%';
+      iframe.style.border = '0';
+      iframe.style.display = 'block';
+      iframe.style.minHeight = height ?? '0px';
+      iframe.setAttribute('title', 'Live code preview');
+      iframe.setAttribute('loading', 'lazy');
+      iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin');
+      container.appendChild(iframe);
+
+      const iframeDoc = iframe.contentDocument;
+      const iframeWin = iframe.contentWindow;
+      if (!iframeDoc || !iframeWin) return;
+
+      // Build an isolated document for the preview.
+      // Any body mutations from components are now contained inside this iframe.
+      iframeDoc.open();
+      iframeDoc.write(
+        [
+          '<!doctype html>',
+          '<html>',
+          '<head>',
+          '  <meta charset="utf-8" />',
+          '  <meta name="viewport" content="width=device-width, initial-scale=1" />',
+          '  <style>html,body{margin:0;padding:0;min-height:100%;}</style>',
+          `  <link rel="stylesheet" href="${BEEQ_CSS_URL}" />`,
+          `  <script type="module" src="${BEEQ_ESM_URL}" data-beeq-iframe-runtime="${BEEQ_ICONS_URL}"></script>`,
+          '</head>',
+          '<body>',
+          code,
+          '</body>',
+          '</html>',
+        ].join('\n'),
+      );
+      iframeDoc.close();
+
+      // Initial mode sync and reactive sync for future parent mode changes.
+      syncIframeMode(iframeDoc);
+      const modeObserver = new MutationObserver(() => syncIframeMode(iframeDoc));
+      modeObserver.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ['class', 'bq-mode'],
+      });
+
+      // Re-execute snippet scripts with previewRoot as iframe document.
+      executeSnippetScripts(iframeDoc, iframeWin, iframeDoc, 'data-beeq-iframe-runtime');
+
+      // Cleanup observer to avoid leaks on rerender/unmount.
+      return () => modeObserver.disconnect();
+    }
+
+    // Default shadow mode path.
+    const shadowRoot = container.shadowRoot ?? container.attachShadow({ mode: 'open' });
+
     if (!shadowRoot.adoptedStyleSheets.length) {
+      // One-time fix sheet for overlay-related parts in isolated previews.
       const fixSheet = new CSSStyleSheet();
       fixSheet.replaceSync(`
         bq-dropdown::part(panel),
@@ -74,36 +175,21 @@ export const CodeLivePreview = ({ code, children, height }) => {
       shadowRoot.adoptedStyleSheets = [fixSheet];
     }
 
-    // Inject beeq.css (for raw HTML elements) + the hidden="false" fix + user code.
-    // Setting innerHTML replaces all shadow content; the browser uses the
-    // cached beeq.css response on subsequent updates.
-    shadowRoot.innerHTML = [
-      '<link rel="stylesheet" href="https://esm.sh/@beeq/core@beta/dist/beeq/beeq.css">',
-      code,
-    ].join('');
+    // Inject styles + snippet markup.
+    shadowRoot.innerHTML = [`<link rel="stylesheet" href="${BEEQ_CSS_URL}">`, code].join('');
 
-    // Re-execute any <script> blocks inside the injected HTML.
-    // Inline scripts are executed via new Function so the shadow root can be
-    // passed in as 'previewRoot' — document.currentScript is always null for
-    // dynamically created script elements, so getRootNode() would throw.
-    shadowRoot.querySelectorAll('script').forEach((oldScript) => {
-      if (oldScript.src) {
-        const newScript = document.createElement('script');
-        newScript.src = oldScript.src;
-        oldScript.replaceWith(newScript);
-      } else {
-        new Function('previewRoot', oldScript.textContent)(shadowRoot);
-        oldScript.remove();
-      }
-    });
-  }, [code]);
+    // Re-execute snippet scripts with previewRoot as shadow root.
+    executeSnippetScripts(shadowRoot, window, shadowRoot);
+
+    return undefined;
+  }, [code, mode, height]);
 
   return (
     <div className="code-live-preview not-prose">
-      {/* Live preview — shadow root attached imperatively for full style isolation */}
+      {/* Preview surface. In shadow mode it hosts a ShadowRoot, in iframe mode it hosts an iframe. */}
       <div className="preview" ref={previewRef} style={{ minHeight: height }} />
 
-      {/* Code section — rendered via children (e.g. CodeGroup from MDX) */}
+      {/* Code tabs/source section */}
       {children && <div className="code">{children}</div>}
     </div>
   );


### PR DESCRIPTION
This PR expands the Mintlify migration batch and aligns the migrated component pages with the newer documentation structure already used for Alert component and Breadcrumb component.

Included in this PR:

migrate Side-Menu docs to Mintlify
migrate Steps docs to Mintlify

The migrated pages now follow a more consistent structure with:

overview
when to use / when not to use
anatomy
variants and common usage patterns
best practices
accessibility guidance
API reference
resources

Documentation
This PR is documentation-only.

Pages added:

apps/beeq-docs/components/side-menu.mdx
apps/beeq-docs/components/steps.mdx