### PR TITLE
docs: migrate docs (drawer, slider, switch, textarea, tag) to Mintlify

### DIFF
--- a/apps/beeq-docs/components/drawer.mdx
+++ b/apps/beeq-docs/components/drawer.mdx
@@ -259,22 +259,31 @@ The default state of the drawer component displays a standard drawer with a head
     }
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqButton, BqDrawer, BqIcon } from "@beeq/angular/standalone" -->
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqButton, BqDrawer, BqIcon } from "@beeq/angular/standalone";
 
-    <bq-button (bqClick)="drawer.show()">Open Drawer</bq-button>
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqButton, BqDrawer, BqIcon],
+      template: `
+        <bq-button (bqClick)="drawer.show()">Open Drawer</bq-button>
 
-    <bq-drawer #drawer position="end">
-      <div class="drawer-title" slot="title">
-        <bq-icon name="user-circle" weight="bold"></bq-icon>
-        Title
-      </div>
-      <div class="drawer-description">Content</div>
-      <div class="drawer-footer" slot="footer">
-        <bq-button appearance="primary" block size="small">Button</bq-button>
-        <bq-button appearance="link" block size="small">Button</bq-button>
-      </div>
-    </bq-drawer>
+        <bq-drawer #drawer position="end">
+          <div class="drawer-title" slot="title">
+            <bq-icon name="user-circle" weight="bold"></bq-icon>
+            Title
+          </div>
+          <div class="drawer-description">Content</div>
+          <div class="drawer-footer" slot="footer">
+            <bq-button appearance="primary" block size="small">Button</bq-button>
+            <bq-button appearance="link" block size="small">Button</bq-button>
+          </div>
+        </bq-drawer>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -421,18 +430,27 @@ The no-footer variant removes the footer section, providing a cleaner interface 
     }
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqButton, BqDrawer, BqIcon } from "@beeq/angular/standalone" -->
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqButton, BqDrawer, BqIcon } from "@beeq/angular/standalone";
 
-    <bq-button (bqClick)="drawer.show()">Open Drawer</bq-button>
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqButton, BqDrawer, BqIcon],
+      template: `
+        <bq-button (bqClick)="drawer.show()">Open Drawer</bq-button>
 
-    <bq-drawer #drawer position="end">
-      <div class="drawer-title" slot="title">
-        <bq-icon name="user-circle" weight="bold"></bq-icon>
-        Title
-      </div>
-      <div class="drawer-description">Content</div>
-    </bq-drawer>
+        <bq-drawer #drawer position="end">
+          <div class="drawer-title" slot="title">
+            <bq-icon name="user-circle" weight="bold"></bq-icon>
+            Title
+          </div>
+          <div class="drawer-description">Content</div>
+        </bq-drawer>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -601,22 +619,31 @@ The `position` prop allows you to specify the edge from which the drawer appears
     }
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqButton, BqDrawer, BqIcon } from "@beeq/angular/standalone" -->
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqButton, BqDrawer, BqIcon } from "@beeq/angular/standalone";
 
-    <bq-button (bqClick)="drawer.show()">Open Drawer</bq-button>
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqButton, BqDrawer, BqIcon],
+      template: `
+        <bq-button (bqClick)="drawer.show()">Open Drawer</bq-button>
 
-    <bq-drawer #drawer position="start">
-      <div class="drawer-title" slot="title">
-        <bq-icon name="user-circle" weight="bold"></bq-icon>
-        Title
-      </div>
-      <div class="drawer-description">Content</div>
-      <div class="drawer-footer" slot="footer">
-        <bq-button appearance="primary" block size="small">Button</bq-button>
-        <bq-button appearance="link" block size="small">Button</bq-button>
-      </div>
-    </bq-drawer>
+        <bq-drawer #drawer position="start">
+          <div class="drawer-title" slot="title">
+            <bq-icon name="user-circle" weight="bold"></bq-icon>
+            Title
+          </div>
+          <div class="drawer-description">Content</div>
+          <div class="drawer-footer" slot="footer">
+            <bq-button appearance="primary" block size="small">Button</bq-button>
+            <bq-button appearance="link" block size="small">Button</bq-button>
+          </div>
+        </bq-drawer>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -791,22 +818,31 @@ The backdrop variant adds a semi-transparent overlay behind the drawer, helping 
     }
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqButton, BqDrawer, BqIcon } from "@beeq/angular/standalone" -->
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqButton, BqDrawer, BqIcon } from "@beeq/angular/standalone";
 
-    <bq-button (bqClick)="drawer.show()">Open Drawer</bq-button>
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqButton, BqDrawer, BqIcon],
+      template: `
+        <bq-button (bqClick)="drawer.show()">Open Drawer</bq-button>
 
-    <bq-drawer #drawer position="end" enable-backdrop>
-      <div class="drawer-title" slot="title">
-        <bq-icon name="user-circle" weight="bold"></bq-icon>
-        Title
-      </div>
-      <div class="drawer-description">Content</div>
-      <div class="drawer-footer" slot="footer">
-        <bq-button appearance="primary" block size="small">Button</bq-button>
-        <bq-button appearance="link" block size="small">Button</bq-button>
-      </div>
-    </bq-drawer>
+        <bq-drawer #drawer position="end" enable-backdrop>
+          <div class="drawer-title" slot="title">
+            <bq-icon name="user-circle" weight="bold"></bq-icon>
+            Title
+          </div>
+          <div class="drawer-description">Content</div>
+          <div class="drawer-footer" slot="footer">
+            <bq-button appearance="primary" block size="small">Button</bq-button>
+            <bq-button appearance="link" block size="small">Button</bq-button>
+          </div>
+        </bq-drawer>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -992,23 +1028,32 @@ Replace the default footer divider by slotting a custom element into `slot="foot
     }
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqButton, BqDivider, BqDrawer, BqIcon } from "@beeq/angular/standalone" -->
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqButton, BqDivider, BqDrawer, BqIcon } from "@beeq/angular/standalone";
 
-    <bq-button (bqClick)="drawer.show()">Open Drawer</bq-button>
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqButton, BqDivider, BqDrawer, BqIcon],
+      template: `
+        <bq-button (bqClick)="drawer.show()">Open Drawer</bq-button>
 
-    <bq-drawer #drawer position="end" enable-backdrop>
-      <div class="drawer-title" slot="title">
-        <bq-icon name="user-circle" weight="bold"></bq-icon>
-        Title
-      </div>
-      <div class="drawer-description">Content</div>
-      <bq-divider class="drawer-footer-divider" slot="footer-divider" stroke-color="stroke--primary" stroke-thickness="1"></bq-divider>
-      <div class="drawer-footer" slot="footer">
-        <bq-button appearance="primary" block size="small">Button</bq-button>
-        <bq-button appearance="link" block size="small">Button</bq-button>
-      </div>
-    </bq-drawer>
+        <bq-drawer #drawer position="end" enable-backdrop>
+          <div class="drawer-title" slot="title">
+            <bq-icon name="user-circle" weight="bold"></bq-icon>
+            Title
+          </div>
+          <div class="drawer-description">Content</div>
+          <bq-divider class="drawer-footer-divider" slot="footer-divider" stroke-color="stroke--primary" stroke-thickness="1"></bq-divider>
+          <div class="drawer-footer" slot="footer">
+            <bq-button appearance="primary" block size="small">Button</bq-button>
+            <bq-button appearance="link" block size="small">Button</bq-button>
+          </div>
+        </bq-drawer>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -1129,17 +1174,26 @@ By default, clicking outside the panel or pressing `Esc` closes the drawer. Set 
     }
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqButton, BqDrawer } from "@beeq/angular/standalone" -->
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqButton, BqDrawer } from "@beeq/angular/standalone";
 
-    <bq-button (bqClick)="drawer.show()">Open locked drawer</bq-button>
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqButton, BqDrawer],
+      template: `
+        <bq-button (bqClick)="drawer.show()">Open locked drawer</bq-button>
 
-    <bq-drawer #drawer position="end" enable-backdrop close-on-click-outside close-on-esc>
-      <span slot="title">Unsaved changes</span>
-      <div class="drawer-content">
-        <p>Use the close button to dismiss.</p>
-      </div>
-    </bq-drawer>
+        <bq-drawer #drawer position="end" enable-backdrop close-on-click-outside close-on-esc>
+          <span slot="title">Unsaved changes</span>
+          <div class="drawer-content">
+            <p>Use the close button to dismiss.</p>
+          </div>
+        </bq-drawer>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/drawer.mdx
+++ b/apps/beeq-docs/components/drawer.mdx
@@ -1,0 +1,1345 @@
+---
+title: Drawer
+description: A drawer is a panel that is typically overlaid on top of a page and slides in from off-canvas (tied to a side of the screen). It contains a set of information or actions. Since the user can interact with the Drawer without leaving the current page, tasks can be achieved more efficiently within the same context.
+---
+
+import { CodeLivePreview } from "/snippets/CodeLivePreview.jsx";
+
+<Frame className="px-4 py-4" caption="Drawer component overview">
+  <img className="block dark:hidden" src="/components/images/drawer/drawer-overview-light.svg" alt="BEEQ Drawer component overview" />
+  <img className="hidden dark:block" src="/components/images/drawer/drawer-overview-dark.svg" alt="BEEQ Drawer component overview" />
+</Frame>
+
+`bq-drawer` is a panel that is typically overlaid on top of a page and slides in from off-canvas (tied to a side of the screen). It contains a set of information or actions — navigation menus, settings, notifications, or contextual actions. Since the user can interact with the drawer without leaving the current page, tasks can be achieved more efficiently within the same context.
+
+<Note>
+  The drawer manages its own open/close animation and backdrop. Call the `show()` and `hide()` methods programmatically, or toggle the `open` prop, to control visibility. Do not remove the element from the DOM to hide it — use `hide()` instead.
+</Note>
+
+## When to use
+
+<CardGroup cols={2}>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="thumbs-up" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Use drawer when
+    </span>
+
+    * You need to surface supplementary content — navigation menus, settings, notifications, or contextual actions — without navigating away from the current page
+    * Users need a convenient way to access additional information or functionality while maintaining a clean and organised layout
+    * The content is too complex or lengthy for a tooltip, popover, or dropdown
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="thumbs-down" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Do not use drawer when
+    </span>
+
+    * Its presence would add unnecessary complexity or confusion — for simple applications where all necessary information can be displayed directly on the main screen
+    * It would obscure essential content or functionality
+    * There are better alternatives available for presenting supplementary information or navigation options, such as a dedicated page or `bq-dialog`
+  </Card>
+</CardGroup>
+
+## Patterns
+
+<CardGroup cols={2}>
+  <Card title="With footer">
+    A drawer component with a footer is beneficial because it allows users to access additional actions or information related to the content displayed in the drawer without cluttering the main interface. The footer provides a designated space for secondary actions, such as buttons or links, enhancing usability and providing a seamless user experience.
+  </Card>
+  <Card title="Without footer">
+    This type of drawer is useful for presenting concise information or primary actions without additional clutter. It allows for a cleaner and more focused user experience, particularly when the primary purpose of the drawer is to display content or options that do not require secondary actions.
+  </Card>
+</CardGroup>
+
+## Anatomy
+
+<Frame className="px-4 py-4" caption="Drawer component anatomy">
+  <img className="block dark:hidden" src="/components/images/drawer/drawer-anatomy-light.svg" alt="BEEQ Drawer component anatomy" />
+  <img className="hidden dark:block" src="/components/images/drawer/drawer-anatomy-dark.svg" alt="BEEQ Drawer component anatomy" />
+</Frame>
+
+The drawer panel contains a header with an optional icon and headline, a scrollable content area (container/slot), an optional footer divider, and optional footer actions.
+
+| Part | Element | Description |
+|---|---|---|
+| **1** | Headline | The title text displayed in the drawer header |
+| **2** | Icon (optional) | An optional icon displayed alongside the headline in the header |
+| **3** | Close icon button | The icon button that dismisses the drawer |
+| **4** | Container / Slot | The main content area that holds the default slot; supports rich media, forms, icons, buttons, and more |
+| **5** | Divider | The horizontal rule between the body and footer (shown when a footer is present) |
+| **6** | Actions (optional) | Footer action buttons; typically one primary button and one secondary button |
+
+## Design guidelines
+
+### Position
+
+Always position the drawer close to the relevant content to avoid confusing users and ensure intuitive navigation.
+
+<Steps>
+  <Step title="end (default)">
+    The panel slides in from the end (right in LTR layouts). Use this for filter panels, detail views, and secondary settings — placing them on the right keeps them adjacent to the content being acted on.
+  </Step>
+  <Step title="start">
+    The panel slides in from the start (left in LTR layouts). Use this for primary navigation menus that users expect on the left side.
+  </Step>
+</Steps>
+
+### Container
+
+The drawer container area can hold rich media, images, forms, icons, buttons, and more. Its internal layout can be adjusted for the use case — use flexbox or grid inside the default slot to control how content is arranged.
+
+### Backdrop
+
+The backdrop dims the page content behind the drawer, reinforcing that the drawer is in focus.
+
+<Note>
+  Enable the backdrop (`enable-backdrop`) when the drawer contains a form or detail view that should feel visually separate from the page. For lightweight navigation drawers that share the screen with the page, omit the backdrop to keep the experience lighter.
+</Note>
+
+### Width
+
+The default drawer width is `320px`, controlled by `--bq-drawer--width`. Increase it for content-heavy panels such as filter forms or data tables, but keep it narrow enough that the underlying page remains recognisably visible.
+
+### Footer
+
+Add a footer to house actions that apply to all content in the panel (e.g. save a form or close the panel). Buttons are left-aligned, and only one primary button should be used at a time. The footer slot is only rendered when it contains content.
+
+### Keep it simple and clear
+
+While drawers can efficiently store additional information not included on the parent page, it is essential to avoid overwhelming users with excessive content. Proper organisation and grouping of information within the drawer are crucial to ensure clarity and usability.
+
+## Usage
+
+<Tip>
+  When using the Drawer component, make sure to place it higher in the DOM hierarchy — for example, as a direct child of `<body>` and not inside a container element. This ensures the drawer's fixed positioning and z-index work correctly across all layouts.
+</Tip>
+
+### Default
+
+The default state of the drawer component displays a standard drawer with a header, content area, and footer. It typically slides in from the end (right) edge of the screen. Use this for general purposes when you need a drawer to provide additional content or options without disrupting the main view.
+
+<CodeLivePreview code={`
+  <!--
+    bq-drawer uses position: fixed, which is trapped inside the CodeLivePreview
+    shadow root. The drawer and its <style data-drawer-styles> are teleported to
+    document.body immediately on init — see the IIFE script below.
+  -->
+
+  <bq-button>Open Drawer</bq-button>
+
+  <style data-drawer-styles>
+    .drawer-title {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+
+    .drawer-description {
+      display: flex;
+      height: 100%;
+      align-items: center;
+      justify-content: center;
+      border-radius: var(--bq-radius--xs);
+      border: 1px dashed var(--bq-stroke--brand);
+      background-color: var(--bq-red-100);
+    }
+
+    .drawer-footer {
+      display: flex;
+      justify-content: center;
+      gap: var(--bq-spacing-xs);
+      flex: 1;
+    }
+  </style>
+
+  <bq-drawer position="end">
+    <div class="drawer-title" slot="title">
+      <bq-icon name="user-circle" weight="bold"></bq-icon>
+      Title
+    </div>
+    <div class="drawer-description">Content</div>
+    <div class="drawer-footer" slot="footer">
+      <bq-button appearance="primary" block size="small">Button</bq-button>
+      <bq-button appearance="link" block size="small">Button</bq-button>
+    </div>
+  </bq-drawer>
+
+  <script>
+    (() => {
+      const btn = previewRoot.querySelector('bq-button');
+      const drawer = previewRoot.querySelector('bq-drawer');
+      const styleEl = previewRoot.querySelector('[data-drawer-styles]');
+      if (styleEl) document.body.appendChild(styleEl);
+      document.body.appendChild(drawer);
+      if (!document.head.querySelector('[data-bq-drawer-preview]')) {
+        const s = document.createElement('style');
+        s.setAttribute('data-bq-drawer-preview', '');
+        s.textContent = 'bq-drawer::part(panel){top:4rem;z-index:9999}'
+          + 'bq-drawer::part(backdrop){top:4rem;z-index:9998}';
+        document.head.appendChild(s);
+      }
+      btn?.addEventListener('bqClick', () => drawer?.show());
+    })();
+  </script>
+`}>
+  <CodeGroup>
+    ```css CSS icon="css3"
+    .drawer-title {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+
+    .drawer-description {
+      display: flex;
+      height: 100%;
+      align-items: center;
+      justify-content: center;
+      border-radius: var(--bq-radius--xs);
+      border: 1px dashed var(--bq-stroke--brand);
+      background-color: var(--bq-red-100);
+    }
+
+    .drawer-footer {
+      display: flex;
+      justify-content: center;
+      gap: var(--bq-spacing-xs);
+      flex: 1;
+    }
+    ```
+
+    ```html HTML icon="html5"
+    <bq-button>Open Drawer</bq-button>
+
+    <bq-drawer position="end">
+      <div class="drawer-title" slot="title">
+        <bq-icon name="user-circle" weight="bold"></bq-icon>
+        Title
+      </div>
+      <div class="drawer-description">Content</div>
+      <div class="drawer-footer" slot="footer">
+        <bq-button appearance="primary" block size="small">Button</bq-button>
+        <bq-button appearance="link" block size="small">Button</bq-button>
+      </div>
+    </bq-drawer>
+    ```
+
+    ```javascript JavaScript icon="js"
+    const btn = document.querySelector('bq-button');
+    const drawer = document.querySelector('bq-drawer');
+    btn.addEventListener('bqClick', () => drawer.show());
+    ```
+
+    ```jsx React icon="react"
+    import { useRef } from "react";
+    import { BqButton, BqDrawer, BqIcon } from "@beeq/react";
+
+    export default function App() {
+      const drawerRef = useRef(null);
+
+      return (
+        <>
+          <BqButton onBqClick={() => drawerRef.current?.show()}>Open Drawer</BqButton>
+
+          <BqDrawer ref={drawerRef} position="end">
+            <div className="drawer-title" slot="title">
+              <BqIcon name="user-circle" weight="bold" />
+              Title
+            </div>
+            <div className="drawer-description">Content</div>
+            <div className="drawer-footer" slot="footer">
+              <BqButton appearance="primary" block size="small">Button</BqButton>
+              <BqButton appearance="link" block size="small">Button</BqButton>
+            </div>
+          </BqDrawer>
+        </>
+      );
+    }
+    ```
+
+    ```html Angular icon="angular"
+    <!-- Standalone: import { BqButton, BqDrawer, BqIcon } from "@beeq/angular/standalone" -->
+
+    <bq-button (bqClick)="drawer.show()">Open Drawer</bq-button>
+
+    <bq-drawer #drawer position="end">
+      <div class="drawer-title" slot="title">
+        <bq-icon name="user-circle" weight="bold"></bq-icon>
+        Title
+      </div>
+      <div class="drawer-description">Content</div>
+      <div class="drawer-footer" slot="footer">
+        <bq-button appearance="primary" block size="small">Button</bq-button>
+        <bq-button appearance="link" block size="small">Button</bq-button>
+      </div>
+    </bq-drawer>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { ref } from "vue";
+    import { BqButton, BqDrawer, BqIcon } from "@beeq/vue";
+
+    const drawerRef = ref(null);
+    </script>
+
+    <template>
+      <BqButton @bqClick="drawerRef?.show()">Open Drawer</BqButton>
+
+      <BqDrawer ref="drawerRef" position="end">
+        <div class="drawer-title" slot="title">
+          <BqIcon name="user-circle" weight="bold" />
+          Title
+        </div>
+        <div class="drawer-description">Content</div>
+        <div class="drawer-footer" slot="footer">
+          <BqButton appearance="primary" block size="small">Button</BqButton>
+          <BqButton appearance="link" block size="small">Button</BqButton>
+        </div>
+      </BqDrawer>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### No footer
+
+The no-footer variant removes the footer section, providing a cleaner interface without additional controls at the bottom. Use this when the drawer's primary purpose is to display content or options that do not require secondary actions.
+
+<CodeLivePreview code={`
+  <!--
+    bq-drawer uses position: fixed, which is trapped inside the CodeLivePreview
+    shadow root. The drawer and its <style data-drawer-styles> are teleported to
+    document.body immediately on init — see the IIFE script below.
+  -->
+
+  <bq-button>Open Drawer</bq-button>
+
+  <style data-drawer-styles>
+    .drawer-title {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+
+    .drawer-description {
+      display: flex;
+      height: 100%;
+      align-items: center;
+      justify-content: center;
+      border-radius: var(--bq-radius--xs);
+      border: 1px dashed var(--bq-stroke--brand);
+      background-color: var(--bq-red-100);
+    }
+  </style>
+
+  <bq-drawer position="end">
+    <div class="drawer-title" slot="title">
+      <bq-icon name="user-circle" weight="bold"></bq-icon>
+      Title
+    </div>
+    <div class="drawer-description">Content</div>
+  </bq-drawer>
+
+  <script>
+    (() => {
+      const btn = previewRoot.querySelector('bq-button');
+      const drawer = previewRoot.querySelector('bq-drawer');
+      const styleEl = previewRoot.querySelector('[data-drawer-styles]');
+      if (styleEl) document.body.appendChild(styleEl);
+      document.body.appendChild(drawer);
+      if (!document.head.querySelector('[data-bq-drawer-preview]')) {
+        const s = document.createElement('style');
+        s.setAttribute('data-bq-drawer-preview', '');
+        s.textContent = 'bq-drawer::part(panel){top:4rem;z-index:9999}'
+          + 'bq-drawer::part(backdrop){top:4rem;z-index:9998}';
+        document.head.appendChild(s);
+      }
+      btn?.addEventListener('bqClick', () => drawer?.show());
+    })();
+  </script>
+`}>
+  <CodeGroup>
+    ```css CSS icon="css3"
+    .drawer-title {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+
+    .drawer-description {
+      display: flex;
+      height: 100%;
+      align-items: center;
+      justify-content: center;
+      border-radius: var(--bq-radius--xs);
+      border: 1px dashed var(--bq-stroke--brand);
+      background-color: var(--bq-red-100);
+    }
+    ```
+
+    ```html HTML icon="html5"
+    <bq-button>Open Drawer</bq-button>
+
+    <bq-drawer position="end">
+      <div class="drawer-title" slot="title">
+        <bq-icon name="user-circle" weight="bold"></bq-icon>
+        Title
+      </div>
+      <div class="drawer-description">Content</div>
+    </bq-drawer>
+    ```
+
+    ```javascript JavaScript icon="js"
+    const btn = document.querySelector('bq-button');
+    const drawer = document.querySelector('bq-drawer');
+    btn.addEventListener('bqClick', () => drawer.show());
+    ```
+
+    ```jsx React icon="react"
+    import { useRef } from "react";
+    import { BqButton, BqDrawer, BqIcon } from "@beeq/react";
+
+    export default function App() {
+      const drawerRef = useRef(null);
+
+      return (
+        <>
+          <BqButton onBqClick={() => drawerRef.current?.show()}>Open Drawer</BqButton>
+
+          <BqDrawer ref={drawerRef} position="end">
+            <div className="drawer-title" slot="title">
+              <BqIcon name="user-circle" weight="bold" />
+              Title
+            </div>
+            <div className="drawer-description">Content</div>
+          </BqDrawer>
+        </>
+      );
+    }
+    ```
+
+    ```html Angular icon="angular"
+    <!-- Standalone: import { BqButton, BqDrawer, BqIcon } from "@beeq/angular/standalone" -->
+
+    <bq-button (bqClick)="drawer.show()">Open Drawer</bq-button>
+
+    <bq-drawer #drawer position="end">
+      <div class="drawer-title" slot="title">
+        <bq-icon name="user-circle" weight="bold"></bq-icon>
+        Title
+      </div>
+      <div class="drawer-description">Content</div>
+    </bq-drawer>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { ref } from "vue";
+    import { BqButton, BqDrawer, BqIcon } from "@beeq/vue";
+
+    const drawerRef = ref(null);
+    </script>
+
+    <template>
+      <BqButton @bqClick="drawerRef?.show()">Open Drawer</BqButton>
+
+      <BqDrawer ref="drawerRef" position="end">
+        <div class="drawer-title" slot="title">
+          <BqIcon name="user-circle" weight="bold" />
+          Title
+        </div>
+        <div class="drawer-description">Content</div>
+      </BqDrawer>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Start position
+
+The `position` prop allows you to specify the edge from which the drawer appears. Use `position="start"` to open from the left edge — ideal for primary navigation menus.
+
+<CodeLivePreview code={`
+  <!--
+    bq-drawer uses position: fixed, which is trapped inside the CodeLivePreview
+    shadow root. The drawer and its <style data-drawer-styles> are teleported to
+    document.body immediately on init — see the IIFE script below.
+  -->
+
+  <bq-button>Open Drawer</bq-button>
+
+  <style data-drawer-styles>
+    .drawer-title {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+
+    .drawer-description {
+      display: flex;
+      height: 100%;
+      align-items: center;
+      justify-content: center;
+      border-radius: var(--bq-radius--xs);
+      border: 1px dashed var(--bq-stroke--brand);
+      background-color: var(--bq-red-100);
+    }
+
+    .drawer-footer {
+      display: flex;
+      justify-content: center;
+      gap: var(--bq-spacing-xs);
+      flex: 1;
+    }
+  </style>
+
+  <bq-drawer position="start">
+    <div class="drawer-title" slot="title">
+      <bq-icon name="user-circle" weight="bold"></bq-icon>
+      Title
+    </div>
+    <div class="drawer-description">Content</div>
+    <div class="drawer-footer" slot="footer">
+      <bq-button appearance="primary" block size="small">Button</bq-button>
+      <bq-button appearance="link" block size="small">Button</bq-button>
+    </div>
+  </bq-drawer>
+
+  <script>
+    (() => {
+      const btn = previewRoot.querySelector('bq-button');
+      const drawer = previewRoot.querySelector('bq-drawer');
+      const styleEl = previewRoot.querySelector('[data-drawer-styles]');
+      if (styleEl) document.body.appendChild(styleEl);
+      document.body.appendChild(drawer);
+      if (!document.head.querySelector('[data-bq-drawer-preview]')) {
+        const s = document.createElement('style');
+        s.setAttribute('data-bq-drawer-preview', '');
+        s.textContent = 'bq-drawer::part(panel){top:4rem;z-index:9999}'
+          + 'bq-drawer::part(backdrop){top:4rem;z-index:9998}';
+        document.head.appendChild(s);
+      }
+      btn?.addEventListener('bqClick', () => drawer?.show());
+    })();
+  </script>
+`}>
+  <CodeGroup>
+    ```css CSS icon="css3"
+    .drawer-title {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+
+    .drawer-description {
+      display: flex;
+      height: 100%;
+      align-items: center;
+      justify-content: center;
+      border-radius: var(--bq-radius--xs);
+      border: 1px dashed var(--bq-stroke--brand);
+      background-color: var(--bq-red-100);
+    }
+
+    .drawer-footer {
+      display: flex;
+      justify-content: center;
+      gap: var(--bq-spacing-xs);
+      flex: 1;
+    }
+    ```
+
+    ```html HTML icon="html5"
+    <bq-button>Open Drawer</bq-button>
+
+    <bq-drawer position="start">
+      <div class="drawer-title" slot="title">
+        <bq-icon name="user-circle" weight="bold"></bq-icon>
+        Title
+      </div>
+      <div class="drawer-description">Content</div>
+      <div class="drawer-footer" slot="footer">
+        <bq-button appearance="primary" block size="small">Button</bq-button>
+        <bq-button appearance="link" block size="small">Button</bq-button>
+      </div>
+    </bq-drawer>
+    ```
+
+    ```javascript JavaScript icon="js"
+    const btn = document.querySelector('bq-button');
+    const drawer = document.querySelector('bq-drawer');
+    btn.addEventListener('bqClick', () => drawer.show());
+    ```
+
+    ```jsx React icon="react"
+    import { useRef } from "react";
+    import { BqButton, BqDrawer, BqIcon } from "@beeq/react";
+
+    export default function App() {
+      const drawerRef = useRef(null);
+
+      return (
+        <>
+          <BqButton onBqClick={() => drawerRef.current?.show()}>Open Drawer</BqButton>
+
+          <BqDrawer ref={drawerRef} position="start">
+            <div className="drawer-title" slot="title">
+              <BqIcon name="user-circle" weight="bold" />
+              Title
+            </div>
+            <div className="drawer-description">Content</div>
+            <div className="drawer-footer" slot="footer">
+              <BqButton appearance="primary" block size="small">Button</BqButton>
+              <BqButton appearance="link" block size="small">Button</BqButton>
+            </div>
+          </BqDrawer>
+        </>
+      );
+    }
+    ```
+
+    ```html Angular icon="angular"
+    <!-- Standalone: import { BqButton, BqDrawer, BqIcon } from "@beeq/angular/standalone" -->
+
+    <bq-button (bqClick)="drawer.show()">Open Drawer</bq-button>
+
+    <bq-drawer #drawer position="start">
+      <div class="drawer-title" slot="title">
+        <bq-icon name="user-circle" weight="bold"></bq-icon>
+        Title
+      </div>
+      <div class="drawer-description">Content</div>
+      <div class="drawer-footer" slot="footer">
+        <bq-button appearance="primary" block size="small">Button</bq-button>
+        <bq-button appearance="link" block size="small">Button</bq-button>
+      </div>
+    </bq-drawer>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { ref } from "vue";
+    import { BqButton, BqDrawer, BqIcon } from "@beeq/vue";
+
+    const drawerRef = ref(null);
+    </script>
+
+    <template>
+      <BqButton @bqClick="drawerRef?.show()">Open Drawer</BqButton>
+
+      <BqDrawer ref="drawerRef" position="start">
+        <div class="drawer-title" slot="title">
+          <BqIcon name="user-circle" weight="bold" />
+          Title
+        </div>
+        <div class="drawer-description">Content</div>
+        <div class="drawer-footer" slot="footer">
+          <BqButton appearance="primary" block size="small">Button</BqButton>
+          <BqButton appearance="link" block size="small">Button</BqButton>
+        </div>
+      </BqDrawer>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+## Options
+
+### With backdrop
+
+The backdrop variant adds a semi-transparent overlay behind the drawer, helping to focus user attention on the drawer content while dimming the background. Enable this variant when you want to visually separate the drawer from the rest of the interface and provide a modal-like experience.
+
+<CodeLivePreview code={`
+  <!--
+    bq-drawer uses position: fixed, which is trapped inside the CodeLivePreview
+    shadow root. The drawer and its <style data-drawer-styles> are teleported to
+    document.body immediately on init — see the IIFE script below.
+  -->
+
+  <bq-button>Open Drawer</bq-button>
+
+  <style data-drawer-styles>
+    .drawer-title {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+
+    .drawer-description {
+      display: flex;
+      height: 100%;
+      align-items: center;
+      justify-content: center;
+      border-radius: var(--bq-radius--xs);
+      border: 1px dashed var(--bq-stroke--brand);
+      background-color: var(--bq-red-100);
+    }
+
+    .drawer-footer {
+      display: flex;
+      justify-content: center;
+      gap: var(--bq-spacing-xs);
+      flex: 1;
+    }
+  </style>
+
+  <bq-drawer position="end" enable-backdrop>
+    <div class="drawer-title" slot="title">
+      <bq-icon name="user-circle" weight="bold"></bq-icon>
+      Title
+    </div>
+    <div class="drawer-description">Content</div>
+    <div class="drawer-footer" slot="footer">
+      <bq-button appearance="primary" block size="small">Button</bq-button>
+      <bq-button appearance="link" block size="small">Button</bq-button>
+    </div>
+  </bq-drawer>
+
+  <script>
+    (() => {
+      const btn = previewRoot.querySelector('bq-button');
+      const drawer = previewRoot.querySelector('bq-drawer');
+      const styleEl = previewRoot.querySelector('[data-drawer-styles]');
+      if (styleEl) document.body.appendChild(styleEl);
+      document.body.appendChild(drawer);
+      if (!document.head.querySelector('[data-bq-drawer-preview]')) {
+        const s = document.createElement('style');
+        s.setAttribute('data-bq-drawer-preview', '');
+        s.textContent = 'bq-drawer::part(panel){top:4rem;z-index:9999}'
+          + 'bq-drawer::part(backdrop){top:4rem;z-index:9998}';
+        document.head.appendChild(s);
+      }
+      btn?.addEventListener('bqClick', () => drawer?.show());
+    })();
+  </script>
+`}>
+  <CodeGroup>
+    ```css CSS icon="css3"
+    .drawer-title {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+
+    .drawer-description {
+      display: flex;
+      height: 100%;
+      align-items: center;
+      justify-content: center;
+      border-radius: var(--bq-radius--xs);
+      border: 1px dashed var(--bq-stroke--brand);
+      background-color: var(--bq-red-100);
+    }
+
+    .drawer-footer {
+      display: flex;
+      justify-content: center;
+      gap: var(--bq-spacing-xs);
+      flex: 1;
+    }
+    ```
+
+    ```html HTML icon="html5"
+    <bq-button>Open Drawer</bq-button>
+
+    <bq-drawer position="end" enable-backdrop>
+      <div class="drawer-title" slot="title">
+        <bq-icon name="user-circle" weight="bold"></bq-icon>
+        Title
+      </div>
+      <div class="drawer-description">Content</div>
+      <div class="drawer-footer" slot="footer">
+        <bq-button appearance="primary" block size="small">Button</bq-button>
+        <bq-button appearance="link" block size="small">Button</bq-button>
+      </div>
+    </bq-drawer>
+    ```
+
+    ```javascript JavaScript icon="js"
+    const btn = document.querySelector('bq-button');
+    const drawer = document.querySelector('bq-drawer');
+    btn.addEventListener('bqClick', () => drawer.show());
+    ```
+
+    ```jsx React icon="react"
+    import { useRef } from "react";
+    import { BqButton, BqDrawer, BqIcon } from "@beeq/react";
+
+    export default function App() {
+      const drawerRef = useRef(null);
+
+      return (
+        <>
+          <BqButton onBqClick={() => drawerRef.current?.show()}>Open Drawer</BqButton>
+
+          <BqDrawer ref={drawerRef} position="end" enableBackdrop>
+            <div className="drawer-title" slot="title">
+              <BqIcon name="user-circle" weight="bold" />
+              Title
+            </div>
+            <div className="drawer-description">Content</div>
+            <div className="drawer-footer" slot="footer">
+              <BqButton appearance="primary" block size="small">Button</BqButton>
+              <BqButton appearance="link" block size="small">Button</BqButton>
+            </div>
+          </BqDrawer>
+        </>
+      );
+    }
+    ```
+
+    ```html Angular icon="angular"
+    <!-- Standalone: import { BqButton, BqDrawer, BqIcon } from "@beeq/angular/standalone" -->
+
+    <bq-button (bqClick)="drawer.show()">Open Drawer</bq-button>
+
+    <bq-drawer #drawer position="end" enable-backdrop>
+      <div class="drawer-title" slot="title">
+        <bq-icon name="user-circle" weight="bold"></bq-icon>
+        Title
+      </div>
+      <div class="drawer-description">Content</div>
+      <div class="drawer-footer" slot="footer">
+        <bq-button appearance="primary" block size="small">Button</bq-button>
+        <bq-button appearance="link" block size="small">Button</bq-button>
+      </div>
+    </bq-drawer>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { ref } from "vue";
+    import { BqButton, BqDrawer, BqIcon } from "@beeq/vue";
+
+    const drawerRef = ref(null);
+    </script>
+
+    <template>
+      <BqButton @bqClick="drawerRef?.show()">Open Drawer</BqButton>
+
+      <BqDrawer ref="drawerRef" position="end" enableBackdrop>
+        <div class="drawer-title" slot="title">
+          <BqIcon name="user-circle" weight="bold" />
+          Title
+        </div>
+        <div class="drawer-description">Content</div>
+        <div class="drawer-footer" slot="footer">
+          <BqButton appearance="primary" block size="small">Button</BqButton>
+          <BqButton appearance="link" block size="small">Button</BqButton>
+        </div>
+      </BqDrawer>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Custom footer divider
+
+Replace the default footer divider by slotting a custom element into `slot="footer-divider"`. The example below uses `bq-divider` with a custom stroke.
+
+<CodeLivePreview code={`
+  <!--
+    bq-drawer uses position: fixed, which is trapped inside the CodeLivePreview
+    shadow root. The drawer and its <style data-drawer-styles> are teleported to
+    document.body immediately on init — see the IIFE script below.
+  -->
+
+  <bq-button>Open Drawer</bq-button>
+
+  <style data-drawer-styles>
+    .drawer-title {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+
+    .drawer-description {
+      display: flex;
+      height: 100%;
+      align-items: center;
+      justify-content: center;
+      border-radius: var(--bq-radius--xs);
+      border: 1px dashed var(--bq-stroke--brand);
+      background-color: var(--bq-red-100);
+    }
+
+    .drawer-footer-divider {
+      display: block;
+      margin-bottom: var(--bq-spacing-m);
+    }
+
+    .drawer-footer {
+      display: flex;
+      justify-content: center;
+      gap: var(--bq-spacing-xs);
+      flex: 1;
+    }
+  </style>
+
+  <bq-drawer position="end" enable-backdrop>
+    <div class="drawer-title" slot="title">
+      <bq-icon name="user-circle" weight="bold"></bq-icon>
+      Title
+    </div>
+    <div class="drawer-description">Content</div>
+    <bq-divider class="drawer-footer-divider" slot="footer-divider" stroke-color="stroke--primary" stroke-thickness="1"></bq-divider>
+    <div class="drawer-footer" slot="footer">
+      <bq-button appearance="primary" block size="small">Button</bq-button>
+      <bq-button appearance="link" block size="small">Button</bq-button>
+    </div>
+  </bq-drawer>
+
+  <script>
+    (() => {
+      const btn = previewRoot.querySelector('bq-button');
+      const drawer = previewRoot.querySelector('bq-drawer');
+      const styleEl = previewRoot.querySelector('[data-drawer-styles]');
+      if (styleEl) document.body.appendChild(styleEl);
+      document.body.appendChild(drawer);
+      if (!document.head.querySelector('[data-bq-drawer-preview]')) {
+        const s = document.createElement('style');
+        s.setAttribute('data-bq-drawer-preview', '');
+        s.textContent = 'bq-drawer::part(panel){top:4rem;z-index:9999}'
+          + 'bq-drawer::part(backdrop){top:4rem;z-index:9998}';
+        document.head.appendChild(s);
+      }
+      btn?.addEventListener('bqClick', () => drawer?.show());
+    })();
+  </script>
+`}>
+  <CodeGroup>
+    ```css CSS icon="css3"
+    .drawer-title {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+
+    .drawer-description {
+      display: flex;
+      height: 100%;
+      align-items: center;
+      justify-content: center;
+      border-radius: var(--bq-radius--xs);
+      border: 1px dashed var(--bq-stroke--brand);
+      background-color: var(--bq-red-100);
+    }
+
+    .drawer-footer-divider {
+      display: block;
+      margin-bottom: var(--bq-spacing-m);
+    }
+
+    .drawer-footer {
+      display: flex;
+      justify-content: center;
+      gap: var(--bq-spacing-xs);
+      flex: 1;
+    }
+    ```
+
+    ```html HTML icon="html5"
+    <bq-button>Open Drawer</bq-button>
+
+    <bq-drawer position="end" enable-backdrop>
+      <div class="drawer-title" slot="title">
+        <bq-icon name="user-circle" weight="bold"></bq-icon>
+        Title
+      </div>
+      <div class="drawer-description">Content</div>
+      <bq-divider class="drawer-footer-divider" slot="footer-divider" stroke-color="stroke--primary" stroke-thickness="1"></bq-divider>
+      <div class="drawer-footer" slot="footer">
+        <bq-button appearance="primary" block size="small">Button</bq-button>
+        <bq-button appearance="link" block size="small">Button</bq-button>
+      </div>
+    </bq-drawer>
+    ```
+
+    ```javascript JavaScript icon="js"
+    const btn = document.querySelector('bq-button');
+    const drawer = document.querySelector('bq-drawer');
+    btn.addEventListener('bqClick', () => drawer.show());
+    ```
+
+    ```jsx React icon="react"
+    import { useRef } from "react";
+    import { BqButton, BqDivider, BqDrawer, BqIcon } from "@beeq/react";
+
+    export default function App() {
+      const drawerRef = useRef(null);
+
+      return (
+        <>
+          <BqButton onBqClick={() => drawerRef.current?.show()}>Open Drawer</BqButton>
+
+          <BqDrawer ref={drawerRef} position="end" enableBackdrop>
+            <div className="drawer-title" slot="title">
+              <BqIcon name="user-circle" weight="bold" />
+              Title
+            </div>
+            <div className="drawer-description">Content</div>
+            <BqDivider className="drawer-footer-divider" slot="footer-divider" strokeColor="stroke--primary" strokeThickness={1} />
+            <div className="drawer-footer" slot="footer">
+              <BqButton appearance="primary" block size="small">Button</BqButton>
+              <BqButton appearance="link" block size="small">Button</BqButton>
+            </div>
+          </BqDrawer>
+        </>
+      );
+    }
+    ```
+
+    ```html Angular icon="angular"
+    <!-- Standalone: import { BqButton, BqDivider, BqDrawer, BqIcon } from "@beeq/angular/standalone" -->
+
+    <bq-button (bqClick)="drawer.show()">Open Drawer</bq-button>
+
+    <bq-drawer #drawer position="end" enable-backdrop>
+      <div class="drawer-title" slot="title">
+        <bq-icon name="user-circle" weight="bold"></bq-icon>
+        Title
+      </div>
+      <div class="drawer-description">Content</div>
+      <bq-divider class="drawer-footer-divider" slot="footer-divider" stroke-color="stroke--primary" stroke-thickness="1"></bq-divider>
+      <div class="drawer-footer" slot="footer">
+        <bq-button appearance="primary" block size="small">Button</bq-button>
+        <bq-button appearance="link" block size="small">Button</bq-button>
+      </div>
+    </bq-drawer>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { ref } from "vue";
+    import { BqButton, BqDivider, BqDrawer, BqIcon } from "@beeq/vue";
+
+    const drawerRef = ref(null);
+    </script>
+
+    <template>
+      <BqButton @bqClick="drawerRef?.show()">Open Drawer</BqButton>
+
+      <BqDrawer ref="drawerRef" position="end" enableBackdrop>
+        <div class="drawer-title" slot="title">
+          <BqIcon name="user-circle" weight="bold" />
+          Title
+        </div>
+        <div class="drawer-description">Content</div>
+        <BqDivider class="drawer-footer-divider" slot="footer-divider" strokeColor="stroke--primary" :strokeThickness="1" />
+        <div class="drawer-footer" slot="footer">
+          <BqButton appearance="primary" block size="small">Button</BqButton>
+          <BqButton appearance="link" block size="small">Button</BqButton>
+        </div>
+      </BqDrawer>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Close behavior
+
+By default, clicking outside the panel or pressing `Esc` closes the drawer. Set `close-on-click-outside` or `close-on-esc` to prevent those interactions when the user must explicitly confirm before dismissing.
+
+<CodeLivePreview code={`
+  <!--
+    bq-drawer uses position: fixed, which is trapped inside the CodeLivePreview
+    shadow root. The drawer and its <style data-drawer-styles> are teleported to
+    document.body immediately on init — see the IIFE script below.
+  -->
+
+  <bq-button>Open locked drawer</bq-button>
+
+  <style data-drawer-styles>
+    .drawer-content {
+      padding: var(--bq-spacing-m) 0;
+    }
+  </style>
+
+  <bq-drawer position="end" enable-backdrop close-on-click-outside close-on-esc>
+    <span slot="title">Unsaved changes</span>
+    <div class="drawer-content">
+      <p>This drawer cannot be closed by clicking outside or pressing Esc — the user must use the close button.</p>
+    </div>
+  </bq-drawer>
+
+  <script>
+    (() => {
+      const btn = previewRoot.querySelector('bq-button');
+      const drawer = previewRoot.querySelector('bq-drawer');
+      const styleEl = previewRoot.querySelector('[data-drawer-styles]');
+      if (styleEl) document.body.appendChild(styleEl);
+      document.body.appendChild(drawer);
+      if (!document.head.querySelector('[data-bq-drawer-preview]')) {
+        const s = document.createElement('style');
+        s.setAttribute('data-bq-drawer-preview', '');
+        s.textContent = 'bq-drawer::part(panel){top:4rem;z-index:9999}'
+          + 'bq-drawer::part(backdrop){top:4rem;z-index:9998}';
+        document.head.appendChild(s);
+      }
+      btn?.addEventListener('bqClick', () => drawer?.show());
+    })();
+  </script>
+`}>
+  <CodeGroup>
+    ```css CSS icon="css3"
+    .drawer-content {
+      padding: var(--bq-spacing-m) 0;
+    }
+    ```
+
+    ```html HTML icon="html5"
+    <bq-button>Open locked drawer</bq-button>
+
+    <bq-drawer position="end" enable-backdrop close-on-click-outside close-on-esc>
+      <span slot="title">Unsaved changes</span>
+      <div class="drawer-content">
+        <p>Use the close button to dismiss.</p>
+      </div>
+    </bq-drawer>
+    ```
+
+    ```javascript JavaScript icon="js"
+    const btn = document.querySelector('bq-button');
+    const drawer = document.querySelector('bq-drawer');
+    btn.addEventListener('bqClick', () => drawer.show());
+    ```
+
+    ```jsx React icon="react"
+    import { useRef } from "react";
+    import { BqButton, BqDrawer } from "@beeq/react";
+
+    export default function App() {
+      const drawerRef = useRef(null);
+
+      return (
+        <>
+          <BqButton onBqClick={() => drawerRef.current?.show()}>Open locked drawer</BqButton>
+
+          <BqDrawer ref={drawerRef} position="end" enableBackdrop closeOnClickOutside closeOnEsc>
+            <span slot="title">Unsaved changes</span>
+            <div className="drawer-content">
+              <p>Use the close button to dismiss.</p>
+            </div>
+          </BqDrawer>
+        </>
+      );
+    }
+    ```
+
+    ```html Angular icon="angular"
+    <!-- Standalone: import { BqButton, BqDrawer } from "@beeq/angular/standalone" -->
+
+    <bq-button (bqClick)="drawer.show()">Open locked drawer</bq-button>
+
+    <bq-drawer #drawer position="end" enable-backdrop close-on-click-outside close-on-esc>
+      <span slot="title">Unsaved changes</span>
+      <div class="drawer-content">
+        <p>Use the close button to dismiss.</p>
+      </div>
+    </bq-drawer>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { ref } from "vue";
+    import { BqButton, BqDrawer } from "@beeq/vue";
+
+    const drawerRef = ref(null);
+    </script>
+
+    <template>
+      <BqButton @bqClick="drawerRef?.show()">Open locked drawer</BqButton>
+
+      <BqDrawer ref="drawerRef" position="end" enableBackdrop closeOnClickOutside closeOnEsc>
+        <span slot="title">Unsaved changes</span>
+        <div class="drawer-content">
+          <p>Use the close button to dismiss.</p>
+        </div>
+      </BqDrawer>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+## Best practices
+
+<CardGroup cols={2}>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Place drawers along the screen's edge — typically the right side — to prevent interference with navigational components on the left edge.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Inset a drawer significantly from the screen edges. Doing so makes its position and scroll behaviour unclear and can obscure primary content.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Always provide a meaningful `title` slot so users and screen readers know the purpose of the panel before interacting with its content.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Leave the title slot empty. A drawer without a title gives assistive technologies no label for the `role="dialog"` and leaves sighted users without orientation.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Use `enable-backdrop` when the drawer contains a form or a detail view that requires focused attention — it visually separates the panel from the underlying page.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Use a drawer for critical, blocking confirmations such as destructive action prompts. Use `bq-dialog` for those — a drawer implies the page behind it is still accessible.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Place primary actions (Save, Apply, Confirm) in the `footer` slot so they are always accessible at the bottom of the panel, even when the body content is long and scrollable.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Bury primary action buttons in the scrollable body. Users who do not scroll to the bottom will miss them and may not know how to complete the task.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Use `close-on-click-outside` and `close-on-esc` together when the panel contains unsaved changes that would be lost if the user accidentally dismisses it.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Lock the close behavior by default on every drawer. Preventing Esc and outside-click dismissal frustrates users who expect those standard interactions to work.
+  </Card>
+</CardGroup>
+
+## Accessibility
+
+`bq-drawer` renders a `role="dialog"` panel with `aria-modal="true"` and `aria-labelledby` pointing to the built-in title element. When the drawer is closed, `aria-hidden="true"` is set on the panel so assistive technologies skip its content entirely.
+
+The built-in close button has `label="Close"` and is announced by screen readers as "Close, button".
+
+As a developer, you are responsible for:
+
+- **Moving focus into the drawer when it opens** — the component does not trap focus automatically. When you call `show()`, move focus to the first interactive element inside the panel or to the panel itself so keyboard users can begin navigating immediately.
+- **Returning focus to the trigger when the drawer closes** — call `hide()` and then restore focus to the element that opened the drawer so keyboard users are not left disoriented.
+- **Providing a descriptive title** — the `aria-labelledby` attribute references the title slot. Screen readers announce this text when the dialog opens. An empty or generic title such as "Panel" makes the dialog purpose unclear.
+- **Avoid nesting focusable elements in the backdrop** — the backdrop does not receive focus; keep interactive content inside the panel.
+
+## API reference
+
+### Properties
+
+| Property | Attribute | Description | Type | Default |
+|---|---|---|---|---|
+| `closeOnClickOutside` | `close-on-click-outside` | If true, the drawer will not close when clicking outside the panel | `boolean` | `false` |
+| `closeOnEsc` | `close-on-esc` | If true, the drawer will not close when the `Esc` key is pressed | `boolean` | `false` |
+| `enableBackdrop` | `enable-backdrop` | If true, a backdrop overlay is shown when the drawer opens | `boolean` | `false` |
+| `open` | `open` | If true, the drawer is visible | `boolean` | `false` |
+| `position` | `position` | Defines the edge the drawer slides from | `'start' \| 'end'` | `'end'` |
+| `placement` | `placement` | **Deprecated.** Use `position` instead. Defines the edge the drawer slides from | `'left' \| 'right'` | `'right'` |
+
+### Methods
+
+| Method | Description | Signature |
+|---|---|---|
+| `show()` | Opens the drawer and emits `bqOpen` | `show() => Promise<void>` |
+| `hide()` | Closes the drawer and emits `bqClose` | `hide() => Promise<void>` |
+
+### Events
+
+| Event | Description | Type |
+|---|---|---|
+| `bqOpen` | Emitted when the drawer starts to open | `CustomEvent<void>` |
+| `bqAfterOpen` | Emitted after the open animation completes | `CustomEvent<void>` |
+| `bqClose` | Emitted when the drawer starts to close | `CustomEvent<void>` |
+| `bqAfterClose` | Emitted after the close animation completes | `CustomEvent<void>` |
+
+### Slots
+
+| Slot | Description |
+|---|---|
+| *(default)* | The main body content of the drawer |
+| `title` | The title displayed in the header |
+| `footer` | Footer content — typically action buttons; only rendered when content is present |
+| `button-close` | Custom content for the close button; defaults to a close icon |
+| `footer-divider` | Content placed in the divider between body and footer |
+
+### Shadow parts
+
+| Part | Description |
+|---|---|
+| `backdrop` | The `<div>` holding the backdrop overlay |
+| `panel` | The `<div>` holding the full drawer surface |
+| `header` | The `<header>` holding the title and close button |
+| `title` | The `<div>` that holds the title slot content |
+| `button-close` | The `bq-button` wrapper for the close button |
+| `button-close__btn` | The native `<button>` inside the close control |
+| `button-close__label` | The label `<span>` inside the close button |
+| `body` | The `<main>` holding the default slot content |
+| `footer` | The `<footer>` holding footer slot content |
+
+### CSS custom properties
+
+<Expandable title="CSS variables" defaultOpen={true}>
+
+| Variable | Description | Default |
+|---|---|---|
+| `--bq-drawer--backgroundBackdrop` | Background color of the backdrop overlay | `var(--bq-ui--overlay)` |
+| `--bq-drawer--gap` | Gap between the drawer panel and the viewport edge | `var(--bq-spacing-l)` |
+| `--bq-drawer--width` | Width of the drawer panel | `320px` |
+| `--bq-drawer--paddingX` | Inline (horizontal) padding of the panel | `var(--bq-spacing-l)` |
+| `--bq-drawer--paddingY` | Block (vertical) padding of the panel | `var(--bq-spacing-m)` |
+| `--bq-drawer--zIndex` | Z-index of the drawer component | `10` |
+
+</Expandable>
+
+<Tip>
+  Learn more about [styling with shadow parts](/theming/styles) and [CSS custom properties](/theming/global-css-variables).
+</Tip>
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card horizontal title="Interactive playground" icon="code" href="https://storybook.beeq.design/?path=/story/components-drawer--default">
+    Explore drawer variants and states in Storybook
+  </Card>
+  <Card horizontal title="Source code" icon="github" href="https://github.com/Endava/BEEQ/tree/main/packages/beeq/src/components/drawer">
+    View the component source on GitHub
+  </Card>
+</CardGroup>

--- a/apps/beeq-docs/components/slider.mdx
+++ b/apps/beeq-docs/components/slider.mdx
@@ -112,10 +112,21 @@ The default slider type. Drag the handle to select a single numeric value within
     }
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqSlider } from "@beeq/angular/standalone" -->
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqSlider } from "@beeq/angular/standalone";
 
-    <bq-slider value="30" (bqChange)="onSliderChange($event)"></bq-slider>
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqSlider],
+      template: `<bq-slider value="30" (bqChange)="onSliderChange($event)"></bq-slider>`,
+    })
+    export class AppComponent {
+      onSliderChange(event: CustomEvent<{ value: number }>) {
+        console.log("value:", event.detail.value);
+      }
+    }
     ```
 
     ```vue Vue icon="vuejs"
@@ -162,10 +173,21 @@ Set `type="range"` and pass a two-element array as `value` to let users select b
     }
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqSlider } from "@beeq/angular/standalone" -->
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqSlider } from "@beeq/angular/standalone";
 
-    <bq-slider type="range" value="[20,70]" (bqChange)="onRangeChange($event)"></bq-slider>
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqSlider],
+      template: `<bq-slider type="range" value="[20,70]" (bqChange)="onRangeChange($event)"></bq-slider>`,
+    })
+    export class AppComponent {
+      onRangeChange(event: CustomEvent<{ value: [number, number] }>) {
+        console.log("range:", event.detail.value);
+      }
+    }
     ```
 
     ```vue Vue icon="vuejs"
@@ -208,10 +230,17 @@ Add the `disabled` attribute to prevent interaction while still rendering the sl
     }
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqSlider } from "@beeq/angular/standalone" -->
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqSlider } from "@beeq/angular/standalone";
 
-    <bq-slider disabled type="range" value="[20,70]"></bq-slider>
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqSlider],
+      template: `<bq-slider disabled type="range" value="[20,70]"></bq-slider>`,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -250,10 +279,17 @@ Set `enable-value-indicator` to display the current numeric value as a label bes
     }
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqSlider } from "@beeq/angular/standalone" -->
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqSlider } from "@beeq/angular/standalone";
 
-    <bq-slider enable-value-indicator type="range" value="[20,70]"></bq-slider>
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqSlider],
+      template: `<bq-slider enable-value-indicator type="range" value="[20,70]"></bq-slider>`,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -296,10 +332,17 @@ Set `enable-tooltip` to show a tooltip above the active handle while dragging. T
     }
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqSlider } from "@beeq/angular/standalone" -->
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqSlider } from "@beeq/angular/standalone";
 
-    <bq-slider enable-tooltip gap="10" type="range" value="[30,70]"></bq-slider>
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqSlider],
+      template: `<bq-slider enable-tooltip gap="10" type="range" value="[30,70]"></bq-slider>`,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -342,10 +385,17 @@ Add `tooltip-always-visible` to keep the tooltip permanently visible rather than
     }
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqSlider } from "@beeq/angular/standalone" -->
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqSlider } from "@beeq/angular/standalone";
 
-    <bq-slider enable-tooltip tooltip-always-visible gap="10" type="range" value="[30,70]"></bq-slider>
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqSlider],
+      template: `<bq-slider enable-tooltip tooltip-always-visible gap="10" type="range" value="[30,70]"></bq-slider>`,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -384,10 +434,17 @@ Control the selectable range with `min` and `max` and the increment granularity 
     }
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqSlider } from "@beeq/angular/standalone" -->
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqSlider } from "@beeq/angular/standalone";
 
-    <bq-slider enable-value-indicator min="0" max="10" step="1.25" type="single" value="3"></bq-slider>
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqSlider],
+      template: `<bq-slider enable-value-indicator min="0" max="10" step="1.25" type="single" value="3"></bq-slider>`,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -426,10 +483,17 @@ Enable decimal increments by setting a fractional `step` value. This provides in
     }
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqSlider } from "@beeq/angular/standalone" -->
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqSlider } from "@beeq/angular/standalone";
 
-    <bq-slider enable-value-indicator min="0" max="1" step="0.05" type="range" value="[0.3,0.7]"></bq-slider>
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqSlider],
+      template: `<bq-slider enable-value-indicator min="0" max="1" step="0.05" type="range" value="[0.3,0.7]"></bq-slider>`,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -468,10 +532,17 @@ Use `gap` to set the minimum distance the two handles must maintain between each
     }
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqSlider } from "@beeq/angular/standalone" -->
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqSlider } from "@beeq/angular/standalone";
 
-    <bq-slider enable-value-indicator gap="10" step="5" type="range" value="[30,70]"></bq-slider>
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqSlider],
+      template: `<bq-slider enable-value-indicator gap="10" step="5" type="range" value="[30,70]"></bq-slider>`,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/slider.mdx
+++ b/apps/beeq-docs/components/slider.mdx
@@ -631,7 +631,7 @@ As a developer you are responsible for:
 ## Resources
 
 <CardGroup cols={2}>
-  <Card horizontal title="Interactive playground" icon="code" href="https://storybook.beeq.design/?path=/story/components-slider--single">
+  <Card horizontal title="Interactive playground" icon="code" href="https://storybook.beeq.design/?path=/story/components-slider--default">
     Explore slider variants and states in Storybook
   </Card>
   <Card horizontal title="Source code" icon="github" href="https://github.com/Endava/BEEQ/tree/main/packages/beeq/src/components/slider">

--- a/apps/beeq-docs/components/slider.mdx
+++ b/apps/beeq-docs/components/slider.mdx
@@ -1,0 +1,640 @@
+---
+title: Slider
+description: Sliders provide a visual way to select a value or range of values by dragging a handle along a horizontal track.
+---
+
+import { CodeLivePreview } from "/snippets/CodeLivePreview.jsx";
+
+<Frame className="px-4 py-4" caption="Slider component overview">
+  <img className="block dark:hidden" src="/components/images/slider/slider-overview-light.svg" alt="BEEQ Slider component overview" />
+  <img className="hidden dark:block" src="/components/images/slider/slider-overview-dark.svg" alt="BEEQ Slider component overview" />
+</Frame>
+
+`bq-slider` provides a visual representation of an adjustable value, enabling users to change settings by dragging a handle along a horizontal track. It supports both single-value and range selection, making it suitable for filters, settings panels, and any input where a numeric value within a bounded range is appropriate.
+
+## When to use
+
+<CardGroup cols={2}>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="thumbs-up" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Use slider when
+    </span>
+
+    - Users need to select a value or range within a continuous or stepped numeric scale
+    - Approximate values are acceptable — for example, adjusting volume, brightness, or a price filter
+    - Real-time visual feedback on the selected value adds meaningful context
+    - The range has a clear minimum and maximum that can be conveyed with a horizontal track
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="thumbs-down" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Do not use slider when
+    </span>
+
+    - Users must enter a precise value — prefer a number input instead
+    - The set of valid options is very small (1–3) — prefer a radio group or segmented control
+    - The interface is space-constrained and the track cannot be rendered with sufficient width
+    - Values are non-numeric, such as weekdays or named categories
+  </Card>
+</CardGroup>
+
+## Anatomy
+
+<Frame className="px-4 py-4" caption="Slider component anatomy">
+  <img className="block dark:hidden" src="/components/images/slider/slider-anatomy-light.svg" alt="BEEQ Slider component anatomy" />
+  <img className="hidden dark:block" src="/components/images/slider/slider-anatomy-dark.svg" alt="BEEQ Slider component anatomy" />
+</Frame>
+
+The slider consists of a horizontal track, a filled progress region that visualizes the selected value, a draggable handle (thumb), and optional value labels at each end.
+
+| Part | Element | Description |
+|---|---|---|
+| **1** | Value label | The start label showing the current value (or minimum for range); visible when `enable-value-indicator` is set |
+| **2** | Handle | The draggable thumb that sets the value |
+| **3** | Track | The full horizontal rail; the highlighted segment (progress area) shows the selected value or range |
+| **4** | Value label end | The end label showing the maximum for range type; only visible when `enable-value-indicator` and `type="range"` are both set |
+
+## Design guidelines
+
+### Type
+
+<Steps>
+  <Step title="Single (default)">
+    A single handle slides along the track to represent one value. Use this for individual settings such as volume, zoom level, or brightness — any scenario where one number is all that matters.
+  </Step>
+  <Step title="Range">
+    Two handles define a minimum and maximum. Use this when users need to select an interval — for example, a price range, a time window, or a quantity bracket.
+  </Step>
+</Steps>
+
+### States
+
+Every slider supports five states: **default**, **hover**, **focus**, **active**, and **disabled**. The handle enlarges slightly on hover and focus to provide a clear interactive target. The disabled state dims the track and handle and prevents all interaction — use it to display a read-only preset value.
+
+### Value feedback
+
+Use `enable-value-indicator` to show the numeric value beside the track at all times. This is appropriate when the exact number matters to the user, such as a temperature, percentage, or step count. Use `enable-tooltip` when you want feedback only while the user is actively dragging, keeping the interface clean at rest. Pair it with `tooltip-always-visible` to keep the tooltip permanently visible.
+
+### Width
+
+The slider fills its container's available width. Constrain the width of its parent container to control how large the track appears — a very short track makes precise selection difficult.
+
+## Usage
+
+### Single
+
+The default slider type. Drag the handle to select a single numeric value within the `min`–`max` range.
+
+<CodeLivePreview code={`
+  <style>
+    bq-slider { width: 100%; max-width: 400px; }
+  </style>
+
+  <bq-slider value="30"></bq-slider>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-slider value="30"></bq-slider>
+    ```
+
+    ```jsx React icon="react"
+    import { BqSlider } from "@beeq/react";
+
+    export default function App() {
+      return (
+        <BqSlider
+          value={30}
+          onBqChange={(e) => console.log("value:", e.detail.value)}
+        />
+      );
+    }
+    ```
+
+    ```html Angular icon="angular"
+    <!-- Standalone: import { BqSlider } from "@beeq/angular/standalone" -->
+
+    <bq-slider value="30" (bqChange)="onSliderChange($event)"></bq-slider>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqSlider } from "@beeq/vue";
+
+    const handleChange = (e: CustomEvent) => console.log("value:", e.detail.value);
+    </script>
+
+    <template>
+      <BqSlider :value="30" @bqChange="handleChange" />
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Range
+
+Set `type="range"` and pass a two-element array as `value` to let users select both a minimum and maximum simultaneously.
+
+<CodeLivePreview code={`
+  <style>
+    bq-slider { width: 100%; max-width: 400px; }
+  </style>
+
+  <bq-slider type="range" value="[20,70]"></bq-slider>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-slider type="range" value="[20,70]"></bq-slider>
+    ```
+
+    ```jsx React icon="react"
+    import { BqSlider } from "@beeq/react";
+
+    export default function App() {
+      return (
+        <BqSlider
+          type="range"
+          value={[20, 70]}
+          onBqChange={(e) => console.log("range:", e.detail.value)}
+        />
+      );
+    }
+    ```
+
+    ```html Angular icon="angular"
+    <!-- Standalone: import { BqSlider } from "@beeq/angular/standalone" -->
+
+    <bq-slider type="range" value="[20,70]" (bqChange)="onRangeChange($event)"></bq-slider>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqSlider } from "@beeq/vue";
+
+    const handleChange = (e: CustomEvent) => console.log("range:", e.detail.value);
+    </script>
+
+    <template>
+      <BqSlider type="range" :value="[20, 70]" @bqChange="handleChange" />
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+## Options
+
+### Disabled
+
+Add the `disabled` attribute to prevent interaction while still rendering the slider. Use this to display a preset or locked value that users cannot modify.
+
+<CodeLivePreview code={`
+  <style>
+    bq-slider { width: 100%; max-width: 400px; }
+  </style>
+
+  <bq-slider disabled type="range" value="[20,70]"></bq-slider>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-slider disabled type="range" value="[20,70]"></bq-slider>
+    ```
+
+    ```jsx React icon="react"
+    import { BqSlider } from "@beeq/react";
+
+    export default function App() {
+      return <BqSlider disabled type="range" value={[20, 70]} />;
+    }
+    ```
+
+    ```html Angular icon="angular"
+    <!-- Standalone: import { BqSlider } from "@beeq/angular/standalone" -->
+
+    <bq-slider disabled type="range" value="[20,70]"></bq-slider>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqSlider } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSlider disabled type="range" :value="[20, 70]" />
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Value indicator
+
+Set `enable-value-indicator` to display the current numeric value as a label beside the track. For range sliders both the minimum and maximum labels are shown — useful when the exact number is meaningful to the user.
+
+<CodeLivePreview code={`
+  <style>
+    bq-slider { width: 100%; max-width: 400px; }
+  </style>
+
+  <bq-slider enable-value-indicator type="range" value="[20,70]"></bq-slider>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-slider enable-value-indicator type="range" value="[20,70]"></bq-slider>
+    ```
+
+    ```jsx React icon="react"
+    import { BqSlider } from "@beeq/react";
+
+    export default function App() {
+      return <BqSlider enableValueIndicator type="range" value={[20, 70]} />;
+    }
+    ```
+
+    ```html Angular icon="angular"
+    <!-- Standalone: import { BqSlider } from "@beeq/angular/standalone" -->
+
+    <bq-slider enable-value-indicator type="range" value="[20,70]"></bq-slider>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqSlider } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSlider :enableValueIndicator="true" type="range" :value="[20, 70]" />
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Tooltip
+
+Set `enable-tooltip` to show a tooltip above the active handle while dragging. The tooltip hides again once the user releases the handle.
+
+<CodeLivePreview code={`
+  <style>
+    bq-slider { 
+        width: 100%; 
+        max-width: 400px; 
+        padding: var(--bq-spacing-xl);
+    }
+  </style>
+
+  <bq-slider enable-tooltip gap="10" type="range" value="[30,70]"></bq-slider>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-slider enable-tooltip gap="10" type="range" value="[30,70]"></bq-slider>
+    ```
+
+    ```jsx React icon="react"
+    import { BqSlider } from "@beeq/react";
+
+    export default function App() {
+      return <BqSlider enableTooltip gap={10} type="range" value={[30, 70]} />;
+    }
+    ```
+
+    ```html Angular icon="angular"
+    <!-- Standalone: import { BqSlider } from "@beeq/angular/standalone" -->
+
+    <bq-slider enable-tooltip gap="10" type="range" value="[30,70]"></bq-slider>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqSlider } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSlider :enableTooltip="true" :gap="10" type="range" :value="[30, 70]" />
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Tooltip always visible
+
+Add `tooltip-always-visible` to keep the tooltip permanently visible rather than only while dragging. This requires `enable-tooltip` to be set.
+
+<CodeLivePreview code={`
+  <style>
+    bq-slider { 
+        width: 100%; 
+        max-width: 400px; 
+        padding: var(--bq-spacing-xl);
+    }
+  </style>
+
+  <bq-slider enable-tooltip tooltip-always-visible gap="10" type="range" value="[30,70]"></bq-slider>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-slider enable-tooltip tooltip-always-visible gap="10" type="range" value="[30,70]"></bq-slider>
+    ```
+
+    ```jsx React icon="react"
+    import { BqSlider } from "@beeq/react";
+
+    export default function App() {
+      return <BqSlider enableTooltip tooltipAlwaysVisible gap={10} type="range" value={[30, 70]} />;
+    }
+    ```
+
+    ```html Angular icon="angular"
+    <!-- Standalone: import { BqSlider } from "@beeq/angular/standalone" -->
+
+    <bq-slider enable-tooltip tooltip-always-visible gap="10" type="range" value="[30,70]"></bq-slider>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqSlider } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSlider :enableTooltip="true" :tooltipAlwaysVisible="true" :gap="10" type="range" :value="[30, 70]" />
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Min, max, and step
+
+Control the selectable range with `min` and `max` and the increment granularity with `step`. All selected values are rounded to the nearest multiple of `step`.
+
+<CodeLivePreview code={`
+  <style>
+    bq-slider { width: 100%; max-width: 400px; }
+  </style>
+
+  <bq-slider enable-value-indicator min="0" max="10" step="1.25" type="single" value="3"></bq-slider>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-slider enable-value-indicator min="0" max="10" step="1.25" type="single" value="3"></bq-slider>
+    ```
+
+    ```jsx React icon="react"
+    import { BqSlider } from "@beeq/react";
+
+    export default function App() {
+      return <BqSlider enableValueIndicator min={0} max={10} step={1.25} type="single" value={3} />;
+    }
+    ```
+
+    ```html Angular icon="angular"
+    <!-- Standalone: import { BqSlider } from "@beeq/angular/standalone" -->
+
+    <bq-slider enable-value-indicator min="0" max="10" step="1.25" type="single" value="3"></bq-slider>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqSlider } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSlider :enableValueIndicator="true" :min="0" :max="10" :step="1.25" type="single" :value="3" />
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Decimal values
+
+Enable decimal increments by setting a fractional `step` value. This provides increased granularity for precise adjustments — useful when selecting specific percentages or fractional coefficients.
+
+<CodeLivePreview code={`
+  <style>
+    bq-slider { width: 100%; max-width: 400px; }
+  </style>
+
+  <bq-slider enable-value-indicator min="0" max="1" step="0.05" type="range" value="[0.3,0.7]"></bq-slider>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-slider enable-value-indicator min="0" max="1" step="0.05" type="range" value="[0.3,0.7]"></bq-slider>
+    ```
+
+    ```jsx React icon="react"
+    import { BqSlider } from "@beeq/react";
+
+    export default function App() {
+      return <BqSlider enableValueIndicator min={0} max={1} step={0.05} type="range" value={[0.3, 0.7]} />;
+    }
+    ```
+
+    ```html Angular icon="angular"
+    <!-- Standalone: import { BqSlider } from "@beeq/angular/standalone" -->
+
+    <bq-slider enable-value-indicator min="0" max="1" step="0.05" type="range" value="[0.3,0.7]"></bq-slider>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqSlider } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSlider :enableValueIndicator="true" :min="0" :max="1" :step="0.05" type="range" :value="[0.3, 0.7]" />
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Gap
+
+Use `gap` to set the minimum distance the two handles must maintain between each other. This is useful when the selected range must span at least a minimum interval — for example, ensuring a time window covers at least one hour.
+
+<CodeLivePreview code={`
+  <style>
+    bq-slider { width: 100%; max-width: 400px; }
+  </style>
+
+  <bq-slider enable-value-indicator gap="10" step="5" type="range" value="[30,70]"></bq-slider>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-slider enable-value-indicator gap="10" step="5" type="range" value="[30,70]"></bq-slider>
+    ```
+
+    ```jsx React icon="react"
+    import { BqSlider } from "@beeq/react";
+
+    export default function App() {
+      return <BqSlider enableValueIndicator gap={10} step={5} type="range" value={[30, 70]} />;
+    }
+    ```
+
+    ```html Angular icon="angular"
+    <!-- Standalone: import { BqSlider } from "@beeq/angular/standalone" -->
+
+    <bq-slider enable-value-indicator gap="10" step="5" type="range" value="[30,70]"></bq-slider>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqSlider } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSlider :enableValueIndicator="true" :gap="10" :step="5" type="range" :value="[30, 70]" />
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+## Best practices
+
+<CardGroup cols={2}>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Provide a clear, concise label that describes the purpose of the slider and the scale it represents — for example, "Volume" or "Price range".
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Use long or ambiguous labels. If users cannot tell what the slider controls at a glance, they may set incorrect values without realizing it.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Show the selected value alongside the slider using `enable-value-indicator` or `enable-tooltip` whenever the exact number matters to the user's decision.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Leave the slider without any value feedback when precision is important. Users cannot reliably read off an exact number from the handle position alone.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Choose `min`, `max`, and `step` values that reflect meaningful increments for the context — for example, steps of 5 or 10 for a percentage, or steps of 0.05 for a fractional coefficient.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Use ranges that result in very large step counts or non-discrete increments where the relationship between handle position and value is unclear to users.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Set `gap` on range sliders when the minimum and maximum handles must stay a meaningful distance apart — for example, when a time range must span at least one hour.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Use a slider for very narrow ranges (1–3 values). With only a few valid positions the drag interaction is awkward and a radio group or button group communicates the options more clearly.
+  </Card>
+</CardGroup>
+
+## Accessibility
+
+`bq-slider` renders native `<input type="range">` elements inside its shadow DOM (`input-min` and `input-max` shadow parts). This means the built-in browser keyboard and screen-reader support for range inputs is available out of the box:
+
+- **Keyboard navigation** — `ArrowLeft` / `ArrowDown` decreases the value by one step; `ArrowRight` / `ArrowUp` increases it. `Home` sets the value to `min`; `End` sets it to `max`.
+- **Screen reader announcement** — the browser announces the current numeric value and the min/max boundaries when the handle receives focus.
+- **`role="slider"`** — comes from the native `<input type="range">`.
+
+As a developer you are responsible for:
+
+- **Providing an accessible label** — wrap `bq-slider` in a `<label>` or use `aria-label` / `aria-labelledby` on the host element so screen readers can announce what the slider controls.
+- **Avoid using sliders for highly precise values** — drag interactions can be imprecise. When an exact value is critical, supplement the slider with a visible number input that reflects the same value.
+- **Range sliders and assistive technologies** — not all screen readers handle two-thumb range inputs equally well. Test with your target assistive technologies and consider providing a complementary text summary of the selected range.
+
+## API reference
+
+### Properties
+
+| Property | Attribute | Description | Type | Default |
+|---|---|---|---|---|
+| `debounceTime` | `debounce-time` | Time in milliseconds to wait before emitting `bqChange` after each value change | `number` | `0` |
+| `disabled` | `disabled` | If true, the slider is disabled and non-interactive | `boolean` | `false` |
+| `enableTooltip` | `enable-tooltip` | If true, a tooltip shows the current value while dragging | `boolean` | `false` |
+| `enableValueIndicator` | `enable-value-indicator` | If true, the current value is shown as a label beside the track | `boolean` | `false` |
+| `gap` | `gap` | Minimum distance to maintain between the two handles; only applies when `type="range"` | `number` | `0` |
+| `max` | `max` | Maximum selectable value | `number` | `100` |
+| `min` | `min` | Minimum selectable value | `number` | `0` |
+| `name` | `name` | Name of the form control, submitted with the form as a name/value pair | `string` | — |
+| `step` | `step` | Increment between selectable values; selected values are rounded to the nearest multiple of `step` | `number` | `1` |
+| `tooltipAlwaysVisible` | `tooltip-always-visible` | If true, the tooltip is permanently visible; requires `enable-tooltip` to be set | `boolean` | `false` |
+| `type` | `type` | Slider variant — `single` for one handle, `range` for two handles | `'single' \| 'range'` | `'single'` |
+| `value` | `value` | Current value. A number for `single` type (e.g. `30`); a two-element array string for `range` type (e.g. `"[20,70]"`). In React and Vue, pass the array directly: `value={[20, 70]}`. | `number \| [number, number] \| string` | — |
+
+### Events
+
+| Event | Description | Type |
+|---|---|---|
+| `bqBlur` | Emitted when the slider loses focus | `CustomEvent<HTMLBqSliderElement>` |
+| `bqChange` | Emitted when the slider value changes | `CustomEvent<{ value: number \| [number, number]; el: HTMLBqSliderElement }>` |
+| `bqFocus` | Emitted when the slider gains focus | `CustomEvent<HTMLBqSliderElement>` |
+
+### Slots
+
+| Slot | Description |
+|---|---|
+| *(none)* | This component has no public slots. |
+
+### Shadow parts
+
+| Part | Description |
+|---|---|
+| `base` | The component's base wrapper |
+| `container` | The container of the slider |
+| `track-area` | The full horizontal track rail |
+| `progress-area` | The highlighted progress segment between the handles |
+| `input-min` | The `<input type="range">` for the value (single) or minimum value (range) |
+| `input-max` | The `<input type="range">` for the maximum value (range only) |
+| `label-start` | The value label for the value (single) or minimum value (range); visible with `enable-value-indicator` |
+| `label-end` | The value label for the maximum value (range only); visible with `enable-value-indicator` |
+
+### CSS custom properties
+
+| Variable | Description | Default |
+|---|---|---|
+| `--bq-slider--size` | Height of the track and progress area | `4px` |
+| `--bq-slider--border-radius` | Border radius of the track and progress area | `var(--bq-radius--xs)` |
+| `--bq-slider--thumb-size` | Size of the draggable thumb on hover | `13px` |
+| `--bq-slider--progress-color` | Background color of the filled progress segment | `var(--bq-ui--brand)` |
+| `--bq-slider--trackarea-color` | Background color of the unfilled track area | `var(--bq-ui--secondary)` |
+
+<Tip>
+  Learn more about [styling with shadow parts](/theming/styles) and [CSS custom properties](/theming/global-css-variables).
+</Tip>
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card horizontal title="Interactive playground" icon="code" href="https://storybook.beeq.design/?path=/story/components-slider--single">
+    Explore slider variants and states in Storybook
+  </Card>
+  <Card horizontal title="Source code" icon="github" href="https://github.com/Endava/BEEQ/tree/main/packages/beeq/src/components/slider">
+    View the component source on GitHub
+  </Card>
+</CardGroup>

--- a/apps/beeq-docs/components/switch.mdx
+++ b/apps/beeq-docs/components/switch.mdx
@@ -104,8 +104,17 @@ The default switch provides a basic on/off toggle functionality, allowing users 
       <BqSwitch>Toggle me!</BqSwitch>
     );
     ```
-    ```html Angular
-    <bq-switch>Toggle me!</bq-switch>
+    ```ts Angular
+    import { Component } from "@angular/core";
+    import { BqSwitch } from "@beeq/angular/standalone";
+
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqSwitch],
+      template: `<bq-switch>Toggle me!</bq-switch>`,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue
     <script setup lang="ts">
@@ -141,8 +150,17 @@ Use the `checked` attribute to set the initial state of the toggle as ON. This i
       <BqSwitch checked>Toggle me!</BqSwitch>
     );
     ```
-    ```html Angular
-    <bq-switch checked>Toggle me!</bq-switch>
+    ```ts Angular
+    import { Component } from "@angular/core";
+    import { BqSwitch } from "@beeq/angular/standalone";
+
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqSwitch],
+      template: `<bq-switch checked>Toggle me!</bq-switch>`,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue
     <script setup lang="ts">
@@ -176,8 +194,17 @@ The disabled switch prevents user interaction, making it visually clear that the
       <BqSwitch disabled>Toggle me!</BqSwitch>
     );
     ```
-    ```html Angular
-    <bq-switch disabled>Toggle me!</bq-switch>
+    ```ts Angular
+    import { Component } from "@angular/core";
+    import { BqSwitch } from "@beeq/angular/standalone";
+
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqSwitch],
+      template: `<bq-switch disabled>Toggle me!</bq-switch>`,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue
     <script setup lang="ts">
@@ -209,8 +236,17 @@ Enhance user understanding by incorporating an inner label that provides context
       <BqSwitch innerLabel="icon">Toggle me!</BqSwitch>
     );
     ```
-    ```html Angular
-    <bq-switch inner-label="icon">Toggle me!</bq-switch>
+    ```ts Angular
+    import { Component } from "@angular/core";
+    import { BqSwitch } from "@beeq/angular/standalone";
+
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqSwitch],
+      template: `<bq-switch inner-label="icon">Toggle me!</bq-switch>`,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue
     <script setup lang="ts">
@@ -242,8 +278,17 @@ The reverse order switch alters the visual arrangement, placing the toggle on th
       <BqSwitch reverseOrder>Toggle me!</BqSwitch>
     );
     ```
-    ```html Angular
-    <bq-switch reverse-order>Toggle me!</bq-switch>
+    ```ts Angular
+    import { Component } from "@angular/core";
+    import { BqSwitch } from "@beeq/angular/standalone";
+
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqSwitch],
+      template: `<bq-switch reverse-order>Toggle me!</bq-switch>`,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue
     <script setup lang="ts">
@@ -411,50 +456,61 @@ Use `full-width` with `reverse-order` and `justify-content="space-between"` to b
       </>
     );
     ```
-    ```html Angular
-    <bq-switch
-      background-on-hover
-      full-width
-      justify-content="space-between"
-      name="bq-switch"
-      reverse-order
-      value="show-app-list"
-    >
-      Show app list in menu
-    </bq-switch>
-    <bq-switch
-      background-on-hover
-      checked
-      full-width
-      justify-content="space-between"
-      name="bq-switch"
-      reverse-order
-      value="show-recently-apps"
-    >
-      Show recently added apps
-    </bq-switch>
-    <bq-switch
-      background-on-hover
-      disabled
-      full-width
-      justify-content="space-between"
-      name="bq-switch"
-      reverse-order
-      value="show-used-apps"
-    >
-      Show most used apps
-    </bq-switch>
-    <bq-switch
-      background-on-hover
-      checked
-      full-width
-      justify-content="space-between"
-      name="bq-switch"
-      reverse-order
-      value="show-app-notifications"
-    >
-      Show app notifications
-    </bq-switch>
+    ```ts Angular
+    import { Component } from "@angular/core";
+    import { BqSwitch } from "@beeq/angular/standalone";
+
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqSwitch],
+      template: `
+        <bq-switch
+          background-on-hover
+          full-width
+          justify-content="space-between"
+          name="bq-switch"
+          reverse-order
+          value="show-app-list"
+        >
+          Show app list in menu
+        </bq-switch>
+        <bq-switch
+          background-on-hover
+          checked
+          full-width
+          justify-content="space-between"
+          name="bq-switch"
+          reverse-order
+          value="show-recently-apps"
+        >
+          Show recently added apps
+        </bq-switch>
+        <bq-switch
+          background-on-hover
+          disabled
+          full-width
+          justify-content="space-between"
+          name="bq-switch"
+          reverse-order
+          value="show-used-apps"
+        >
+          Show most used apps
+        </bq-switch>
+        <bq-switch
+          background-on-hover
+          checked
+          full-width
+          justify-content="space-between"
+          name="bq-switch"
+          reverse-order
+          value="show-app-notifications"
+        >
+          Show app notifications
+        </bq-switch>
+      `,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue
     <script setup lang="ts">

--- a/apps/beeq-docs/components/switch.mdx
+++ b/apps/beeq-docs/components/switch.mdx
@@ -1,0 +1,631 @@
+---
+title: Switch
+description: Switches are digital on/off toggles that give users immediate, visible control over a single binary setting without requiring form submission.
+---
+
+import { CodeLivePreview } from "/snippets/CodeLivePreview.jsx";
+
+<Frame className="px-4 py-4" caption="Switch component overview">
+  <img className="block dark:hidden" src="/components/images/switch/switch-overview-light.svg" alt="BEEQ Switch component overview" />
+  <img className="hidden dark:block" src="/components/images/switch/switch-overview-dark.svg" alt="BEEQ Switch component overview" />
+</Frame>
+
+A switch is a binary control that immediately toggles a setting on or off. Unlike checkboxes, a switch should trigger an instant change — no submit button needed. Use it for toggling preferences, enabling features, or activating modes where the result is visible right away.
+
+<Note>
+  Use a [Checkbox](/components/checkbox) when the choice is part of a form that requires explicit submission, or when multiple items can be selected at once. Use a Switch when the action takes immediate effect.
+</Note>
+
+## When to use
+
+<CardGroup cols={2}>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="thumbs-up" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Use a switch when
+    </span>
+    - Toggling a single setting that takes effect immediately
+    - The on/off state directly controls a feature, mode, or preference
+    - The action does not require a separate confirmation or form submission
+    - You need a compact, recognizable binary control
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="thumbs-down" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Do not use a switch when
+    </span>
+    - The setting only takes effect after the user clicks a Save or Submit button
+    - Multiple related options need to be selected together (use checkboxes)
+    - The action is irreversible and needs a confirmation step
+    - The label text does not clearly describe the result of toggling
+  </Card>
+</CardGroup>
+
+## Anatomy
+
+<Frame className="px-4 py-4" caption="Switch component anatomy">
+  <img className="block dark:hidden" src="/components/images/switch/switch-anatomy-light.svg" alt="BEEQ Switch component anatomy" />
+  <img className="hidden dark:block" src="/components/images/switch/switch-anatomy-dark.svg" alt="BEEQ Switch component anatomy" />
+</Frame>
+
+The switch is composed of a toggle control (track + dot) and an optional label. When `inner-label` is set to `icon`, check and X marks appear inside the track to reinforce the on/off state.
+
+| Part | Element | Description |
+|---|---|---|
+| **1** | Switch toggle | The rounded track and sliding dot that act as the toggle surface |
+| **2** | Icon | Optional icon inside the track to reinforce the on/off state (icon mode only) |
+| **3** | Label | Optional text describing what the switch controls |
+
+## Design guidelines
+
+### States
+
+A switch has four interactive states: **default** (off), **checked** (on), **focused**, and **disabled**. Hover adds a subtle background when `background-on-hover` is enabled. The disabled state prevents all interaction and dims the control to signal it is unavailable.
+
+<Note>
+  Always pair a switch with a visible text label unless the context makes the purpose unmistakably clear (for example, a dark-mode toggle adjacent to sun and moon icons). Unlabeled switches are inaccessible by default.
+</Note>
+
+### Inner label
+
+<Steps>
+  <Step title="Default (no inner label)">
+    The track contains only the sliding dot. This is the most compact presentation and works well in dense settings panels.
+  </Step>
+  <Step title="Icon inner label">
+    Set `inner-label="icon"` to show a check icon when ON and an X icon when OFF inside the track. This adds a secondary visual reinforcement of the state without relying on color alone.
+  </Step>
+  <Step title="Custom icon slots">
+    Replace the default icons by providing content to the `icon-on` and `icon-off` named slots alongside `inner-label="icon"`. Use this for domain-specific icons such as a moon/sun pair for a dark-mode toggle.
+  </Step>
+</Steps>
+
+### Label position
+
+By default, the label appears to the right of the control. Set `reverse-order` to move it to the left — useful in right-to-left layouts or when a consistent label-first alignment is required across a settings list.
+
+## Usage
+
+### Default
+
+The default switch provides a basic on/off toggle functionality, allowing users to control a binary state effortlessly.
+
+<CodeLivePreview
+  code={`<bq-switch>Toggle me!</bq-switch>`}
+>
+  <CodeGroup>
+    ```html HTML
+    <bq-switch>Toggle me!</bq-switch>
+    ```
+    ```tsx React
+    import { BqSwitch } from "@beeq/react";
+
+    export default () => (
+      <BqSwitch>Toggle me!</BqSwitch>
+    );
+    ```
+    ```html Angular
+    <bq-switch>Toggle me!</bq-switch>
+    ```
+    ```html Vue
+    <bq-switch>Toggle me!</bq-switch>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+<Tip>
+  You don't need to specify any additional property or attribute that uses its default value.
+</Tip>
+
+### Checked
+
+Use the `checked` attribute to set the initial state of the toggle as ON. This is ideal when you want the switch to start in an activated position.
+
+<CodeLivePreview
+  code={`<bq-switch checked>Toggle me!</bq-switch>`}
+>
+  <CodeGroup>
+    ```html HTML
+    <bq-switch checked>Toggle me!</bq-switch>
+    ```
+    ```tsx React
+    import { BqSwitch } from "@beeq/react";
+
+    export default () => (
+      <BqSwitch checked>Toggle me!</BqSwitch>
+    );
+    ```
+    ```html Angular
+    <bq-switch checked>Toggle me!</bq-switch>
+    ```
+    ```html Vue
+    <bq-switch checked>Toggle me!</bq-switch>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+## Options
+
+### Disabled
+
+The disabled switch prevents user interaction, making it visually clear that the toggle functionality is not currently available or applicable. Use the `disabled` attribute to enable this type of switch.
+
+<CodeLivePreview
+  code={`<bq-switch disabled>Toggle me!</bq-switch>`}
+>
+  <CodeGroup>
+    ```html HTML
+    <bq-switch disabled>Toggle me!</bq-switch>
+    ```
+    ```tsx React
+    import { BqSwitch } from "@beeq/react";
+
+    export default () => (
+      <BqSwitch disabled>Toggle me!</BqSwitch>
+    );
+    ```
+    ```html Angular
+    <bq-switch disabled>Toggle me!</bq-switch>
+    ```
+    ```html Vue
+    <bq-switch disabled>Toggle me!</bq-switch>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### With Inner Label
+
+Enhance user understanding by incorporating an inner label that provides context about the current state of the switch. Use the `inner-label="icon"` attribute to activate this variant.
+
+<CodeLivePreview
+  code={`<bq-switch inner-label="icon">Toggle me!</bq-switch>`}
+>
+  <CodeGroup>
+    ```html HTML
+    <bq-switch inner-label="icon">Toggle me!</bq-switch>
+    ```
+    ```tsx React
+    import { BqSwitch } from "@beeq/react";
+
+    export default () => (
+      <BqSwitch innerLabel="icon">Toggle me!</BqSwitch>
+    );
+    ```
+    ```html Angular
+    <bq-switch inner-label="icon">Toggle me!</bq-switch>
+    ```
+    ```html Vue
+    <bq-switch innerLabel="icon">Toggle me!</bq-switch>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Reverse Order
+
+The reverse order switch alters the visual arrangement, placing the toggle on the opposite side for a customizable user interface by adding the `reverse-order` attribute.
+
+<CodeLivePreview
+  code={`<bq-switch reverse-order>Toggle me!</bq-switch>`}
+>
+  <CodeGroup>
+    ```html HTML
+    <bq-switch reverse-order>Toggle me!</bq-switch>
+    ```
+    ```tsx React
+    import { BqSwitch } from "@beeq/react";
+
+    export default () => (
+      <BqSwitch reverseOrder>Toggle me!</BqSwitch>
+    );
+    ```
+    ```html Angular
+    <bq-switch reverse-order>Toggle me!</bq-switch>
+    ```
+    ```html Vue
+    <bq-switch reverseOrder>Toggle me!</bq-switch>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Full Width
+
+Use `full-width` with `reverse-order` and `justify-content="space-between"` to build standard settings-list rows where the label is on the left and the toggle sits flush to the right edge.
+
+<CodeLivePreview
+  code={`<style>
+  :host { flex-direction: column !important; align-items: stretch !important; max-width: 28rem; }
+</style>
+<bq-switch
+  background-on-hover
+  full-width
+  justify-content="space-between"
+  name="bq-switch"
+  reverse-order
+  value="show-app-list"
+>
+  Show app list in menu
+</bq-switch>
+<bq-switch
+  background-on-hover
+  checked
+  full-width
+  justify-content="space-between"
+  name="bq-switch"
+  reverse-order
+  value="show-recently-apps"
+>
+  Show recently added apps
+</bq-switch>
+<bq-switch
+  background-on-hover
+  disabled
+  full-width
+  justify-content="space-between"
+  name="bq-switch"
+  reverse-order
+  value="show-used-apps"
+>
+  Show most used apps
+</bq-switch>
+<bq-switch
+  background-on-hover
+  checked
+  full-width
+  justify-content="space-between"
+  name="bq-switch"
+  reverse-order
+  value="show-app-notifications"
+>
+  Show app notifications
+</bq-switch>`}
+>
+  <CodeGroup>
+    ```html HTML
+    <bq-switch
+      background-on-hover
+      full-width
+      justify-content="space-between"
+      name="bq-switch"
+      reverse-order
+      value="show-app-list"
+    >
+      Show app list in menu
+    </bq-switch>
+    <bq-switch
+      background-on-hover
+      checked
+      full-width
+      justify-content="space-between"
+      name="bq-switch"
+      reverse-order
+      value="show-recently-apps"
+    >
+      Show recently added apps
+    </bq-switch>
+    <bq-switch
+      background-on-hover
+      disabled
+      full-width
+      justify-content="space-between"
+      name="bq-switch"
+      reverse-order
+      value="show-used-apps"
+    >
+      Show most used apps
+    </bq-switch>
+    <bq-switch
+      background-on-hover
+      checked
+      full-width
+      justify-content="space-between"
+      name="bq-switch"
+      reverse-order
+      value="show-app-notifications"
+    >
+      Show app notifications
+    </bq-switch>
+    ```
+    ```tsx React
+    import { BqSwitch } from "@beeq/react";
+
+    export default () => (
+      <>
+        <BqSwitch
+          backgroundOnHover
+          fullWidth
+          justifyContent="space-between"
+          name="bq-switch"
+          reverseOrder
+          value="show-app-list"
+        >
+          Show app list in menu
+        </BqSwitch>
+        <BqSwitch
+          backgroundOnHover
+          checked
+          fullWidth
+          justifyContent="space-between"
+          name="bq-switch"
+          reverseOrder
+          value="show-recently-apps"
+        >
+          Show recently added apps
+        </BqSwitch>
+        <BqSwitch
+          backgroundOnHover
+          disabled
+          fullWidth
+          justifyContent="space-between"
+          name="bq-switch"
+          reverseOrder
+          value="show-used-apps"
+        >
+          Show most used apps
+        </BqSwitch>
+        <BqSwitch
+          backgroundOnHover
+          checked
+          fullWidth
+          justifyContent="space-between"
+          name="bq-switch"
+          reverseOrder
+          value="show-app-notifications"
+        >
+          Show app notifications
+        </BqSwitch>
+      </>
+    );
+    ```
+    ```html Angular
+    <bq-switch
+      background-on-hover
+      full-width
+      justify-content="space-between"
+      name="bq-switch"
+      reverse-order
+      value="show-app-list"
+    >
+      Show app list in menu
+    </bq-switch>
+    <bq-switch
+      background-on-hover
+      checked
+      full-width
+      justify-content="space-between"
+      name="bq-switch"
+      reverse-order
+      value="show-recently-apps"
+    >
+      Show recently added apps
+    </bq-switch>
+    <bq-switch
+      background-on-hover
+      disabled
+      full-width
+      justify-content="space-between"
+      name="bq-switch"
+      reverse-order
+      value="show-used-apps"
+    >
+      Show most used apps
+    </bq-switch>
+    <bq-switch
+      background-on-hover
+      checked
+      full-width
+      justify-content="space-between"
+      name="bq-switch"
+      reverse-order
+      value="show-app-notifications"
+    >
+      Show app notifications
+    </bq-switch>
+    ```
+    ```html Vue
+    <bq-switch
+      :backgroundOnHover="true"
+      :fullWidth="true"
+      justifyContent="space-between"
+      name="bq-switch"
+      :reverseOrder="true"
+      value="show-app-list"
+    >
+      Show app list in menu
+    </bq-switch>
+    <bq-switch
+      :backgroundOnHover="true"
+      checked
+      :fullWidth="true"
+      justifyContent="space-between"
+      name="bq-switch"
+      :reverseOrder="true"
+      value="show-recently-apps"
+    >
+      Show recently added apps
+    </bq-switch>
+    <bq-switch
+      :backgroundOnHover="true"
+      disabled
+      :fullWidth="true"
+      justifyContent="space-between"
+      name="bq-switch"
+      :reverseOrder="true"
+      value="show-used-apps"
+    >
+      Show most used apps
+    </bq-switch>
+    <bq-switch
+      :backgroundOnHover="true"
+      checked
+      :fullWidth="true"
+      justifyContent="space-between"
+      name="bq-switch"
+      :reverseOrder="true"
+      value="show-app-notifications"
+    >
+      Show app notifications
+    </bq-switch>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+<Tip>
+  Use a combination of `full-width`, `justify-content`, and `reverse-order`. Be creative!
+</Tip>
+
+## Best practices
+
+<CardGroup cols={2}>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Use concise, present-tense labels that clearly describe the result of the switch being on. "Enable notifications" or "Dark mode" communicate the outcome at a glance.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Use vague labels like "Toggle" or "On/Off". Users should not need to think about what the switch controls — the label must describe the setting itself.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Apply the switch's effect immediately without requiring a submit action. Use this pattern for preferences that take effect in real time — dark mode, notifications, or feature flags.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Use a switch when the change only takes effect after the user clicks a Save button. If the state is not immediately applied, use a checkbox inside a form instead.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Use `inner-label="icon"` to supplement the color change with a shape cue (check / X). This improves the control for users with color vision deficiencies who cannot rely on brand color alone.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Rely solely on the track color to communicate the ON state. Always ensure that at least one additional cue — dot position or icon — distinguishes the two states.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Place the label directly adjacent to the switch and keep the pairing stable across the list. Consistent label position helps users scan a settings panel without searching for the control.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Change the label text based on state (for example, "Enabled" when on and "Disabled" when off). The label should always describe the setting — the control itself communicates the current state.
+  </Card>
+</CardGroup>
+
+## Accessibility
+
+`bq-switch` renders a native `<input type="checkbox" role="switch">` inside its shadow DOM, which ensures that assistive technologies correctly announce the control as a switch with an on/off state.
+
+### Keyboard interaction
+
+| Key | Action |
+|---|---|
+| `Tab` | Moves focus to the switch |
+| `Space` | Toggles the switch on or off |
+
+### Developer responsibilities
+
+- Always provide a visible text label, either via the default slot or an external element associated through `aria-labelledby`. The switch derives its accessible name from the slotted label text.
+- Use the `name` attribute (required) to participate in form submissions and to give the control a machine-readable identifier.
+- When the switch is `disabled`, it is excluded from the tab order and will not respond to keyboard or pointer events. Make sure the reason for disabling is communicated through surrounding text.
+- The `bqChange` event is cancelable. Calling `event.preventDefault()` inside a `bqChange` handler prevents the switch from updating its visual state, which is useful when you need to confirm a change before applying it.
+- Use `vFocus()`, `vBlur()`, and `vClick()` instead of the global `element.focus()`, `element.blur()`, and `element.click()` to interact with the native input correctly across Shadow DOM boundaries.
+
+## API reference
+
+### Properties
+
+| Property | Attribute | Description | Type | Default |
+|---|---|---|---|---|
+| `backgroundOnHover` | `background-on-hover` | If `true`, a background is shown on hover | `boolean` | `false` |
+| `checked` | `checked` | If `true`, the switch starts in the ON state | `boolean` | `false` |
+| `disabled` | `disabled` | If `true`, the switch is disabled and non-interactive | `boolean` | `false` |
+| `formValidationMessage` | `form-validation-message` | Custom native form validation message | `string` | — |
+| `fullWidth` | `full-width` | If `true`, the switch expands to fill its container | `boolean` | `false` |
+| `innerLabel` | `inner-label` | How to display the on/off marks inside the control | `'default' \| 'icon'` | `'default'` |
+| `justifyContent` | `justify-content` | Space distribution between the control and label | `'start' \| 'end' \| 'center' \| 'space-between' \| 'space-around' \| 'space-evenly' \| ...` | `'start'` |
+| `name` | `name` | Form control name; submitted as part of a name/value pair | `string` | **required** |
+| `required` | `required` | If `true`, the switch must be ON before the form can be submitted | `boolean` | `false` |
+| `reverseOrder` | `reverse-order` | If `true`, the label appears before the control | `boolean` | `false` |
+| `value` | `value` | The value submitted with the form when the switch is ON | `string` | — |
+
+### Methods
+
+| Method | Description | Signature |
+|---|---|---|
+| `vBlur()` | Removes focus from the native `<input>` element | `Promise<void>` |
+| `vClick()` | Simulates a click on the native `<input>` element | `Promise<void>` |
+| `vFocus()` | Sets focus on the native `<input>` element | `Promise<void>` |
+
+### Events
+
+| Event | Description | Type |
+|---|---|---|
+| `bqBlur` | Emitted when the switch loses focus | `CustomEvent<HTMLBqSwitchElement>` |
+| `bqChange` | Emitted when the switch state changes; cancelable via `event.preventDefault()` | `CustomEvent<{ checked: boolean }>` |
+| `bqFocus` | Emitted when the switch gains focus | `CustomEvent<HTMLBqSwitchElement>` |
+
+### Slots
+
+| Slot | Description |
+|---|---|
+| *(default)* | The label text displayed next to the control |
+| `icon-on` | Custom icon shown inside the track when the switch is ON (requires `inner-label="icon"`) |
+| `icon-off` | Custom icon shown inside the track when the switch is OFF (requires `inner-label="icon"`) |
+
+### Shadow parts
+
+| Part | Description |
+|---|---|
+| `base` | The `<label>` root container element |
+| `control` | The `<div>` element that forms the toggle track |
+| `dot` | The `<div>` element that acts as the sliding indicator dot |
+| `icon-on` | The `<bq-icon>` element used as the ON mark (icon mode only) |
+| `icon-off` | The `<bq-icon>` element used as the OFF mark (icon mode only) |
+| `label` | The `<span>` element that holds the label text |
+
+### CSS custom properties
+
+| Variable | Description | Default |
+|---|---|---|
+| `--bq-switch--height` | Height of the switch track | `24px` |
+| `--bq-switch--width` | Width of the switch track | `44px` |
+| `--bq-switch--dot-size` | Diameter of the sliding dot | `calc(var(--bq-switch--height) - (var(--bq-spacing-xs2) * 2))` |
+| `--bq-switch--justify-content` | Space distribution between the control and label | `start` |
+
+<Tip>
+  Learn more about [styling with shadow parts](/theming/styles) and [CSS custom properties](/theming/global-css-variables).
+</Tip>
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card horizontal title="Interactive playground" icon="code" href="https://storybook.beeq.design/?path=/story/components-switch--default">
+    Explore switch variants and states in Storybook
+  </Card>
+  <Card horizontal title="Source code" icon="github" href="https://github.com/Endava/BEEQ/tree/main/packages/beeq/src/components/switch">
+    View the component source on GitHub
+  </Card>
+</CardGroup>

--- a/apps/beeq-docs/components/switch.mdx
+++ b/apps/beeq-docs/components/switch.mdx
@@ -107,8 +107,14 @@ The default switch provides a basic on/off toggle functionality, allowing users 
     ```html Angular
     <bq-switch>Toggle me!</bq-switch>
     ```
-    ```html Vue
-    <bq-switch>Toggle me!</bq-switch>
+    ```vue Vue
+    <script setup lang="ts">
+    import { BqSwitch } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSwitch>Toggle me!</BqSwitch>
+    </template>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -138,8 +144,14 @@ Use the `checked` attribute to set the initial state of the toggle as ON. This i
     ```html Angular
     <bq-switch checked>Toggle me!</bq-switch>
     ```
-    ```html Vue
-    <bq-switch checked>Toggle me!</bq-switch>
+    ```vue Vue
+    <script setup lang="ts">
+    import { BqSwitch } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSwitch checked>Toggle me!</BqSwitch>
+    </template>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -167,8 +179,14 @@ The disabled switch prevents user interaction, making it visually clear that the
     ```html Angular
     <bq-switch disabled>Toggle me!</bq-switch>
     ```
-    ```html Vue
-    <bq-switch disabled>Toggle me!</bq-switch>
+    ```vue Vue
+    <script setup lang="ts">
+    import { BqSwitch } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSwitch disabled>Toggle me!</BqSwitch>
+    </template>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -194,8 +212,14 @@ Enhance user understanding by incorporating an inner label that provides context
     ```html Angular
     <bq-switch inner-label="icon">Toggle me!</bq-switch>
     ```
-    ```html Vue
-    <bq-switch innerLabel="icon">Toggle me!</bq-switch>
+    ```vue Vue
+    <script setup lang="ts">
+    import { BqSwitch } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSwitch innerLabel="icon">Toggle me!</BqSwitch>
+    </template>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -221,8 +245,14 @@ The reverse order switch alters the visual arrangement, placing the toggle on th
     ```html Angular
     <bq-switch reverse-order>Toggle me!</bq-switch>
     ```
-    ```html Vue
-    <bq-switch reverseOrder>Toggle me!</bq-switch>
+    ```vue Vue
+    <script setup lang="ts">
+    import { BqSwitch } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSwitch reverseOrder>Toggle me!</BqSwitch>
+    </template>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -426,50 +456,56 @@ Use `full-width` with `reverse-order` and `justify-content="space-between"` to b
       Show app notifications
     </bq-switch>
     ```
-    ```html Vue
-    <bq-switch
-      :backgroundOnHover="true"
-      :fullWidth="true"
-      justifyContent="space-between"
-      name="bq-switch"
-      :reverseOrder="true"
-      value="show-app-list"
-    >
-      Show app list in menu
-    </bq-switch>
-    <bq-switch
-      :backgroundOnHover="true"
-      checked
-      :fullWidth="true"
-      justifyContent="space-between"
-      name="bq-switch"
-      :reverseOrder="true"
-      value="show-recently-apps"
-    >
-      Show recently added apps
-    </bq-switch>
-    <bq-switch
-      :backgroundOnHover="true"
-      disabled
-      :fullWidth="true"
-      justifyContent="space-between"
-      name="bq-switch"
-      :reverseOrder="true"
-      value="show-used-apps"
-    >
-      Show most used apps
-    </bq-switch>
-    <bq-switch
-      :backgroundOnHover="true"
-      checked
-      :fullWidth="true"
-      justifyContent="space-between"
-      name="bq-switch"
-      :reverseOrder="true"
-      value="show-app-notifications"
-    >
-      Show app notifications
-    </bq-switch>
+    ```vue Vue
+    <script setup lang="ts">
+    import { BqSwitch } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqSwitch
+        backgroundOnHover
+        fullWidth
+        justifyContent="space-between"
+        name="bq-switch"
+        reverseOrder
+        value="show-app-list"
+      >
+        Show app list in menu
+      </BqSwitch>
+      <BqSwitch
+        backgroundOnHover
+        checked
+        fullWidth
+        justifyContent="space-between"
+        name="bq-switch"
+        reverseOrder
+        value="show-recently-apps"
+      >
+        Show recently added apps
+      </BqSwitch>
+      <BqSwitch
+        backgroundOnHover
+        disabled
+        fullWidth
+        justifyContent="space-between"
+        name="bq-switch"
+        reverseOrder
+        value="show-used-apps"
+      >
+        Show most used apps
+      </BqSwitch>
+      <BqSwitch
+        backgroundOnHover
+        checked
+        fullWidth
+        justifyContent="space-between"
+        name="bq-switch"
+        reverseOrder
+        value="show-app-notifications"
+      >
+        Show app notifications
+      </BqSwitch>
+    </template>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -552,7 +588,7 @@ Use `full-width` with `reverse-order` and `justify-content="space-between"` to b
 
 ### Developer responsibilities
 
-- Always provide a visible text label, either via the default slot or an external element associated through `aria-labelledby`. The switch derives its accessible name from the slotted label text.
+- Always provide a visible text label via the default slot. The switch derives its accessible name from the `name` prop via `aria-label` on the native `<input>` — the visible slot text is not automatically wired to the control. If you want the visible label to serve as the accessible name, use `aria-labelledby` on the host element pointing to the associated label element.
 - Use the `name` attribute (required) to participate in form submissions and to give the control a machine-readable identifier.
 - When the switch is `disabled`, it is excluded from the tab order and will not respond to keyboard or pointer events. Make sure the reason for disabling is communicated through surrounding text.
 - The `bqChange` event is cancelable. Calling `event.preventDefault()` inside a `bqChange` handler prevents the switch from updating its visual state, which is useful when you need to confirm a change before applying it.
@@ -574,7 +610,7 @@ Use `full-width` with `reverse-order` and `justify-content="space-between"` to b
 | `name` | `name` | Form control name; submitted as part of a name/value pair | `string` | **required** |
 | `required` | `required` | If `true`, the switch must be ON before the form can be submitted | `boolean` | `false` |
 | `reverseOrder` | `reverse-order` | If `true`, the label appears before the control | `boolean` | `false` |
-| `value` | `value` | The value submitted with the form when the switch is ON | `string` | — |
+| `value` | `value` | Sets the underlying `<input>` value attribute. Note: the form submission value is the fixed string `'on'` when checked (via ElementInternals), regardless of this prop | `string` | — |
 
 ### Methods
 

--- a/apps/beeq-docs/components/switch.mdx
+++ b/apps/beeq-docs/components/switch.mdx
@@ -90,9 +90,9 @@ By default, the label appears to the right of the control. Set `reverse-order` t
 
 The default switch provides a basic on/off toggle functionality, allowing users to control a binary state effortlessly.
 
-<CodeLivePreview
-  code={`<bq-switch>Toggle me!</bq-switch>`}
->
+<CodeLivePreview code={`
+  <bq-switch>Toggle me!</bq-switch>
+`}>
   <CodeGroup>
     ```html HTML
     <bq-switch>Toggle me!</bq-switch>
@@ -121,9 +121,9 @@ The default switch provides a basic on/off toggle functionality, allowing users 
 
 Use the `checked` attribute to set the initial state of the toggle as ON. This is ideal when you want the switch to start in an activated position.
 
-<CodeLivePreview
-  code={`<bq-switch checked>Toggle me!</bq-switch>`}
->
+<CodeLivePreview code={`
+  <bq-switch checked>Toggle me!</bq-switch>
+`}>
   <CodeGroup>
     ```html HTML
     <bq-switch checked>Toggle me!</bq-switch>
@@ -150,9 +150,9 @@ Use the `checked` attribute to set the initial state of the toggle as ON. This i
 
 The disabled switch prevents user interaction, making it visually clear that the toggle functionality is not currently available or applicable. Use the `disabled` attribute to enable this type of switch.
 
-<CodeLivePreview
-  code={`<bq-switch disabled>Toggle me!</bq-switch>`}
->
+<CodeLivePreview code={`
+  <bq-switch disabled>Toggle me!</bq-switch>
+`}>
   <CodeGroup>
     ```html HTML
     <bq-switch disabled>Toggle me!</bq-switch>
@@ -177,9 +177,9 @@ The disabled switch prevents user interaction, making it visually clear that the
 
 Enhance user understanding by incorporating an inner label that provides context about the current state of the switch. Use the `inner-label="icon"` attribute to activate this variant.
 
-<CodeLivePreview
-  code={`<bq-switch inner-label="icon">Toggle me!</bq-switch>`}
->
+<CodeLivePreview code={`
+  <bq-switch inner-label="icon">Toggle me!</bq-switch>
+`}>
   <CodeGroup>
     ```html HTML
     <bq-switch inner-label="icon">Toggle me!</bq-switch>
@@ -204,9 +204,9 @@ Enhance user understanding by incorporating an inner label that provides context
 
 The reverse order switch alters the visual arrangement, placing the toggle on the opposite side for a customizable user interface by adding the `reverse-order` attribute.
 
-<CodeLivePreview
-  code={`<bq-switch reverse-order>Toggle me!</bq-switch>`}
->
+<CodeLivePreview code={`
+  <bq-switch reverse-order>Toggle me!</bq-switch>
+`}>
   <CodeGroup>
     ```html HTML
     <bq-switch reverse-order>Toggle me!</bq-switch>
@@ -231,54 +231,59 @@ The reverse order switch alters the visual arrangement, placing the toggle on th
 
 Use `full-width` with `reverse-order` and `justify-content="space-between"` to build standard settings-list rows where the label is on the left and the toggle sits flush to the right edge.
 
-<CodeLivePreview
-  code={`<style>
-  :host { flex-direction: column !important; align-items: stretch !important; max-width: 28rem; }
-</style>
-<bq-switch
-  background-on-hover
-  full-width
-  justify-content="space-between"
-  name="bq-switch"
-  reverse-order
-  value="show-app-list"
->
-  Show app list in menu
-</bq-switch>
-<bq-switch
-  background-on-hover
-  checked
-  full-width
-  justify-content="space-between"
-  name="bq-switch"
-  reverse-order
-  value="show-recently-apps"
->
-  Show recently added apps
-</bq-switch>
-<bq-switch
-  background-on-hover
-  disabled
-  full-width
-  justify-content="space-between"
-  name="bq-switch"
-  reverse-order
-  value="show-used-apps"
->
-  Show most used apps
-</bq-switch>
-<bq-switch
-  background-on-hover
-  checked
-  full-width
-  justify-content="space-between"
-  name="bq-switch"
-  reverse-order
-  value="show-app-notifications"
->
-  Show app notifications
-</bq-switch>`}
->
+<CodeLivePreview code={`
+  <style>
+    :host { 
+      flex-direction: column !important; 
+      align-items: stretch !important; 
+      max-width: 28rem; 
+    }
+  </style>
+
+  <bq-switch
+    background-on-hover
+    full-width
+    justify-content="space-between"
+    name="bq-switch"
+    reverse-order
+    value="show-app-list"
+  >
+    Show app list in menu
+  </bq-switch>
+  <bq-switch
+    background-on-hover
+    checked
+    full-width
+    justify-content="space-between"
+    name="bq-switch"
+    reverse-order
+    value="show-recently-apps"
+  >
+    Show recently added apps
+  </bq-switch>
+  <bq-switch
+    background-on-hover
+    disabled
+    full-width
+    justify-content="space-between"
+    name="bq-switch"
+    reverse-order
+    value="show-used-apps"
+  >
+    Show most used apps
+  </bq-switch>
+  <bq-switch
+    background-on-hover
+    checked
+    full-width
+    justify-content="space-between"
+    name="bq-switch"
+    reverse-order
+    value="show-app-notifications"
+  >
+    Show app notifications
+  </bq-switch>
+`}>
   <CodeGroup>
     ```html HTML
     <bq-switch

--- a/apps/beeq-docs/components/tab.mdx
+++ b/apps/beeq-docs/components/tab.mdx
@@ -1,0 +1,813 @@
+---
+title: Tab
+description: Tabs organize content into separate sections and let users switch between them without leaving the page.
+---
+
+import { CardTile } from "/snippets/CardTile.jsx";
+import { CodeLivePreview } from "/snippets/CodeLivePreview.jsx";
+
+<Frame className="px-4 py-4" caption="Tab component overview">
+  <img className="block dark:hidden" src="/components/images/tab/tab-overview-light.svg" alt="BEEQ Tab component overview" />
+  <img className="hidden dark:block" src="/components/images/tab/tab-overview-dark.svg" alt="BEEQ Tab component overview" />
+</Frame>
+
+Tabs let users navigate between related sections of content within the same page or view. Each tab reveals one panel at a time, keeping the interface clean while making multiple content sections available without navigation.
+
+<Note>
+  `bq-tab` must always be placed inside a `bq-tab-group`. The group manages tab state, keyboard navigation, and propagates `size`, `orientation`, and `placement` to all child tabs automatically.
+</Note>
+
+## When to use
+
+<CardGroup cols={2}>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="thumbs-up" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Use tabs when
+    </span>
+
+    - Content can be clearly organized into a small number of distinct, peer-level sections
+    - Users need to compare or switch between sections without losing page context
+    - Space is limited and displaying all sections at once would clutter the layout
+    - Each section can stand independently without requiring the user to read others first
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="thumbs-down" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Do not use tabs when
+    </span>
+
+    - The number of tabs exceeds seven — prefer a sidebar navigation or dropdown instead
+    - Content across sections is sequential and users must read them in order — prefer a stepper
+    - Sections contain very different content types that do not relate to the same subject
+    - The goal is to navigate to a new page or route — prefer anchor links or a navigation component
+  </Card>
+</CardGroup>
+
+## Anatomy
+
+<Frame className="px-4 py-4" caption="Tab component anatomy">
+  <img className="block dark:hidden" src="/components/images/tab/tab-anatomy-light.svg" alt="BEEQ Tab component anatomy" />
+  <img className="hidden dark:block" src="/components/images/tab/tab-anatomy-dark.svg" alt="BEEQ Tab component anatomy" />
+</Frame>
+
+The tab group renders a list of tab buttons inside a scrollable container. Each individual tab consists of an optional icon, a text label, and an active-state underline indicator.
+
+| Part | Element | Description |
+|---|---|---|
+| **1** | Active tab | The currently selected tab button, visually distinguished by brand color and the selected indicator |
+| **2** | Inactive tab | A tab button that is not currently selected; clicking it activates it and deactivates the previous tab |
+| **3** | Selected indicator | The underline beneath the active tab that marks the current selection; exposed as the `underline` shadow part |
+| **4** | Text label | The visible label inside each tab button; placed in the default slot and exposed as the `text` shadow part |
+
+## Design guidelines
+
+### Orientation
+
+<CardGroup cols={2}>
+  <CardTile
+    title="Horizontal"
+    imageLightSrc="/components/images/tab/tab-orientation-horizontal-light.svg"
+    imageDarkSrc="/components/images/tab/tab-orientation-horizontal-dark.svg"
+  >
+    The default orientation. Tabs are arranged in a row across the top of the content area. Best suited for most layouts.
+  </CardTile>
+  <CardTile
+    title="Vertical"
+    imageLightSrc="/components/images/tab/tab-orientation-vertical-light.svg"
+    imageDarkSrc="/components/images/tab/tab-orientation-vertical-dark.svg"
+  >
+    Tabs are stacked in a column to the left or right of the content area. Use when there are many tabs or when the layout is sidebar-based.
+  </CardTile>
+</CardGroup>
+
+### Size
+
+<Steps>
+  <Step title="small">Compact tabs with reduced padding. Use in dense interfaces or data-heavy views where space is constrained.</Step>
+  <Step title="medium">The default size. Appropriate for most applications and standard-density layouts.</Step>
+  <Step title="large">Prominent tabs with increased padding. Use when tabs are a primary navigation element or accessibility requires larger touch targets.</Step>
+</Steps>
+
+<Note>
+  Setting `size` on `bq-tab-group` propagates the value to all child `bq-tab` elements automatically. You do not need to set `size` on each tab individually.
+</Note>
+
+### Placement
+
+Use `placement="start"` (default) to left-align horizontal tabs or top-align vertical tabs. Use `placement="end"` to right-align horizontal tabs or bottom-align vertical tabs.
+
+## Usage
+
+### Default
+
+<CodeLivePreview code={`
+  <style>
+    :host {
+      flex-direction: column !important;
+      align-items: stretch !important;
+    }
+  </style>
+  <bq-tab-group value="5">
+    <bq-tab tab-id="1">Tab</bq-tab>
+    <bq-tab tab-id="2">Tab</bq-tab>
+    <bq-tab tab-id="3">Long Tab name</bq-tab>
+    <bq-tab tab-id="4" disabled>Tab</bq-tab>
+    <bq-tab tab-id="5">Tab</bq-tab>
+    <bq-tab tab-id="6">Tab</bq-tab>
+    <bq-tab tab-id="7">Tab</bq-tab>
+    <bq-tab tab-id="8">Tab</bq-tab>
+  </bq-tab-group>
+`}>
+</CodeLivePreview>
+
+<CodeGroup>
+```html HTML icon="html5"
+<bq-tab-group value="5">
+  <bq-tab tab-id="1">Tab</bq-tab>
+  <bq-tab tab-id="2">Tab</bq-tab>
+  <bq-tab tab-id="3">Long Tab name</bq-tab>
+  <bq-tab tab-id="4" disabled>Tab</bq-tab>
+  <bq-tab tab-id="5">Tab</bq-tab>
+  <bq-tab tab-id="6">Tab</bq-tab>
+  <bq-tab tab-id="7">Tab</bq-tab>
+  <bq-tab tab-id="8">Tab</bq-tab>
+</bq-tab-group>
+```
+```tsx React icon="react"
+import { BqTab, BqTabGroup } from "@beeq/react";
+
+export default () => (
+  <BqTabGroup value="5">
+    <BqTab tabId="1">Tab</BqTab>
+    <BqTab tabId="2">Tab</BqTab>
+    <BqTab tabId="3">Long Tab name</BqTab>
+    <BqTab tabId="4" disabled>Tab</BqTab>
+    <BqTab tabId="5">Tab</BqTab>
+    <BqTab tabId="6">Tab</BqTab>
+    <BqTab tabId="7">Tab</BqTab>
+    <BqTab tabId="8">Tab</BqTab>
+  </BqTabGroup>
+);
+```
+```html Angular icon="angular"
+<bq-tab-group value="5">
+  <bq-tab tab-id="1">Tab</bq-tab>
+  <bq-tab tab-id="2">Tab</bq-tab>
+  <bq-tab tab-id="3">Long Tab name</bq-tab>
+  <bq-tab tab-id="4" disabled>Tab</bq-tab>
+  <bq-tab tab-id="5">Tab</bq-tab>
+  <bq-tab tab-id="6">Tab</bq-tab>
+  <bq-tab tab-id="7">Tab</bq-tab>
+  <bq-tab tab-id="8">Tab</bq-tab>
+</bq-tab-group>
+```
+```vue Vue icon="vuejs"
+<template>
+  <BqTabGroup value="5">
+    <BqTab tabId="1">Tab</BqTab>
+    <BqTab tabId="2">Tab</BqTab>
+    <BqTab tabId="3">Long Tab name</BqTab>
+    <BqTab tabId="4" disabled>Tab</BqTab>
+    <BqTab tabId="5">Tab</BqTab>
+    <BqTab tabId="6">Tab</BqTab>
+    <BqTab tabId="7">Tab</BqTab>
+    <BqTab tabId="8">Tab</BqTab>
+  </BqTabGroup>
+</template>
+```
+</CodeGroup>
+
+## Options
+
+### With icons
+
+Tabs support an optional icon displayed before the label via the `icon` slot.
+
+<CodeLivePreview code={`
+  <style>
+    :host {
+      flex-direction: column !important;
+      align-items: stretch !important;
+    }
+  </style>
+  <bq-tab-group value="5" size="small">
+    <bq-tab tab-id="1">
+      <bq-icon name="pulse" slot="icon"></bq-icon>
+      Tab
+    </bq-tab>
+    <bq-tab tab-id="2">
+      <bq-icon name="bell" slot="icon"></bq-icon>
+      Tab
+    </bq-tab>
+    <bq-tab tab-id="3">
+      <bq-icon name="airplane-in-flight" slot="icon"></bq-icon>
+      Long Tab name
+    </bq-tab>
+    <bq-tab tab-id="4" disabled>
+      <bq-icon name="airplane-tilt" slot="icon"></bq-icon>
+      Tab
+    </bq-tab>
+    <bq-tab tab-id="5">
+      <bq-icon name="align-right-simple" slot="icon"></bq-icon>
+      Tab
+    </bq-tab>
+    <bq-tab tab-id="6">
+      <bq-icon name="anchor" slot="icon"></bq-icon>
+      Tab
+    </bq-tab>
+    <bq-tab tab-id="7">
+      <bq-icon name="android-logo" slot="icon"></bq-icon>
+      Tab
+    </bq-tab>
+  </bq-tab-group>
+`}>
+</CodeLivePreview>
+
+<CodeGroup>
+```html HTML icon="html5"
+<bq-tab-group value="5" size="small">
+  <bq-tab tab-id="1">
+    <bq-icon name="pulse" slot="icon"></bq-icon>
+    Tab
+  </bq-tab>
+  <bq-tab tab-id="2">
+    <bq-icon name="bell" slot="icon"></bq-icon>
+    Tab
+  </bq-tab>
+  <bq-tab tab-id="3">
+    <bq-icon name="airplane-in-flight" slot="icon"></bq-icon>
+    Long Tab name
+  </bq-tab>
+  <bq-tab tab-id="4" disabled>
+    <bq-icon name="airplane-tilt" slot="icon"></bq-icon>
+    Tab
+  </bq-tab>
+  <bq-tab tab-id="5">
+    <bq-icon name="align-right-simple" slot="icon"></bq-icon>
+    Tab
+  </bq-tab>
+  <bq-tab tab-id="6">
+    <bq-icon name="anchor" slot="icon"></bq-icon>
+    Tab
+  </bq-tab>
+  <bq-tab tab-id="7">
+    <bq-icon name="android-logo" slot="icon"></bq-icon>
+    Tab
+  </bq-tab>
+</bq-tab-group>
+```
+```tsx React icon="react"
+import { BqIcon, BqTab, BqTabGroup } from "@beeq/react";
+
+export default () => (
+  <BqTabGroup value="5" size="small">
+    <BqTab tabId="1">
+      <BqIcon name="pulse" slot="icon" />
+      Tab
+    </BqTab>
+    <BqTab tabId="2">
+      <BqIcon name="bell" slot="icon" />
+      Tab
+    </BqTab>
+    <BqTab tabId="3">
+      <BqIcon name="airplane-in-flight" slot="icon" />
+      Long Tab name
+    </BqTab>
+    <BqTab tabId="4" disabled>
+      <BqIcon name="airplane-tilt" slot="icon" />
+      Tab
+    </BqTab>
+    <BqTab tabId="5">
+      <BqIcon name="align-right-simple" slot="icon" />
+      Tab
+    </BqTab>
+    <BqTab tabId="6">
+      <BqIcon name="anchor" slot="icon" />
+      Tab
+    </BqTab>
+    <BqTab tabId="7">
+      <BqIcon name="android-logo" slot="icon" />
+      Tab
+    </BqTab>
+  </BqTabGroup>
+);
+```
+```html Angular icon="angular"
+<bq-tab-group value="5" size="small">
+  <bq-tab tab-id="1">
+    <bq-icon name="pulse" slot="icon"></bq-icon>
+    Tab
+  </bq-tab>
+  <bq-tab tab-id="2">
+    <bq-icon name="bell" slot="icon"></bq-icon>
+    Tab
+  </bq-tab>
+  <bq-tab tab-id="3">
+    <bq-icon name="airplane-in-flight" slot="icon"></bq-icon>
+    Long Tab name
+  </bq-tab>
+  <bq-tab tab-id="4" disabled>
+    <bq-icon name="airplane-tilt" slot="icon"></bq-icon>
+    Tab
+  </bq-tab>
+  <bq-tab tab-id="5">
+    <bq-icon name="align-right-simple" slot="icon"></bq-icon>
+    Tab
+  </bq-tab>
+  <bq-tab tab-id="6">
+    <bq-icon name="anchor" slot="icon"></bq-icon>
+    Tab
+  </bq-tab>
+  <bq-tab tab-id="7">
+    <bq-icon name="android-logo" slot="icon"></bq-icon>
+    Tab
+  </bq-tab>
+</bq-tab-group>
+```
+```vue Vue icon="vuejs"
+<template>
+  <BqTabGroup value="5" size="small">
+    <BqTab tabId="1">
+      <BqIcon name="pulse" slot="icon" />
+      Tab
+    </BqTab>
+    <BqTab tabId="2">
+      <BqIcon name="bell" slot="icon" />
+      Tab
+    </BqTab>
+    <BqTab tabId="3">
+      <BqIcon name="airplane-in-flight" slot="icon" />
+      Long Tab name
+    </BqTab>
+    <BqTab tabId="4" disabled>
+      <BqIcon name="airplane-tilt" slot="icon" />
+      Tab
+    </BqTab>
+    <BqTab tabId="5">
+      <BqIcon name="align-right-simple" slot="icon" />
+      Tab
+    </BqTab>
+    <BqTab tabId="6">
+      <BqIcon name="anchor" slot="icon" />
+      Tab
+    </BqTab>
+    <BqTab tabId="7">
+      <BqIcon name="android-logo" slot="icon" />
+      Tab
+    </BqTab>
+  </BqTabGroup>
+</template>
+```
+</CodeGroup>
+
+### Sizes
+
+<CodeLivePreview code={`
+  <style>
+    :host {
+      flex-direction: column !important;
+      align-items: stretch !important;
+      gap: var(--bq-spacing-m) !important;
+    }
+  </style>
+  <bq-tab-group size="small" value="1">
+    <bq-tab tab-id="1">Tab</bq-tab>
+    <bq-tab tab-id="2">Tab</bq-tab>
+    <bq-tab tab-id="3">Long Tab name</bq-tab>
+  </bq-tab-group>
+  <bq-tab-group size="medium" value="1">
+    <bq-tab tab-id="1">Tab</bq-tab>
+    <bq-tab tab-id="2">Tab</bq-tab>
+    <bq-tab tab-id="3">Long Tab name</bq-tab>
+  </bq-tab-group>
+  <bq-tab-group size="large" value="1">
+    <bq-tab tab-id="1">Tab</bq-tab>
+    <bq-tab tab-id="2">Tab</bq-tab>
+    <bq-tab tab-id="3">Long Tab name</bq-tab>
+  </bq-tab-group>
+`}>
+</CodeLivePreview>
+
+<CodeGroup>
+```html HTML icon="html5"
+<!-- Small -->
+<bq-tab-group size="small" value="1">
+  <bq-tab tab-id="1">Tab</bq-tab>
+  <bq-tab tab-id="2">Tab</bq-tab>
+  <bq-tab tab-id="3">Long Tab name</bq-tab>
+</bq-tab-group>
+
+<!-- Medium (default) -->
+<bq-tab-group size="medium" value="1">
+  <bq-tab tab-id="1">Tab</bq-tab>
+  <bq-tab tab-id="2">Tab</bq-tab>
+  <bq-tab tab-id="3">Long Tab name</bq-tab>
+</bq-tab-group>
+
+<!-- Large -->
+<bq-tab-group size="large" value="1">
+  <bq-tab tab-id="1">Tab</bq-tab>
+  <bq-tab tab-id="2">Tab</bq-tab>
+  <bq-tab tab-id="3">Long Tab name</bq-tab>
+</bq-tab-group>
+```
+```tsx React icon="react"
+import { BqTab, BqTabGroup } from "@beeq/react";
+
+export default () => (
+  <>
+    {/* Small */}
+    <BqTabGroup size="small" value="1">
+      <BqTab tabId="1">Tab</BqTab>
+      <BqTab tabId="2">Tab</BqTab>
+      <BqTab tabId="3">Long Tab name</BqTab>
+    </BqTabGroup>
+
+    {/* Medium (default) */}
+    <BqTabGroup size="medium" value="1">
+      <BqTab tabId="1">Tab</BqTab>
+      <BqTab tabId="2">Tab</BqTab>
+      <BqTab tabId="3">Long Tab name</BqTab>
+    </BqTabGroup>
+
+    {/* Large */}
+    <BqTabGroup size="large" value="1">
+      <BqTab tabId="1">Tab</BqTab>
+      <BqTab tabId="2">Tab</BqTab>
+      <BqTab tabId="3">Long Tab name</BqTab>
+    </BqTabGroup>
+  </>
+);
+```
+```html Angular icon="angular"
+<!-- Small -->
+<bq-tab-group size="small" value="1">
+  <bq-tab tab-id="1">Tab</bq-tab>
+  <bq-tab tab-id="2">Tab</bq-tab>
+  <bq-tab tab-id="3">Long Tab name</bq-tab>
+</bq-tab-group>
+
+<!-- Medium (default) -->
+<bq-tab-group size="medium" value="1">
+  <bq-tab tab-id="1">Tab</bq-tab>
+  <bq-tab tab-id="2">Tab</bq-tab>
+  <bq-tab tab-id="3">Long Tab name</bq-tab>
+</bq-tab-group>
+
+<!-- Large -->
+<bq-tab-group size="large" value="1">
+  <bq-tab tab-id="1">Tab</bq-tab>
+  <bq-tab tab-id="2">Tab</bq-tab>
+  <bq-tab tab-id="3">Long Tab name</bq-tab>
+</bq-tab-group>
+```
+```vue Vue icon="vuejs"
+<template>
+  <!-- Small -->
+  <BqTabGroup size="small" value="1">
+    <BqTab tabId="1">Tab</BqTab>
+    <BqTab tabId="2">Tab</BqTab>
+    <BqTab tabId="3">Long Tab name</BqTab>
+  </BqTabGroup>
+
+  <!-- Medium (default) -->
+  <BqTabGroup size="medium" value="1">
+    <BqTab tabId="1">Tab</BqTab>
+    <BqTab tabId="2">Tab</BqTab>
+    <BqTab tabId="3">Long Tab name</BqTab>
+  </BqTabGroup>
+
+  <!-- Large -->
+  <BqTabGroup size="large" value="1">
+    <BqTab tabId="1">Tab</BqTab>
+    <BqTab tabId="2">Tab</BqTab>
+    <BqTab tabId="3">Long Tab name</BqTab>
+  </BqTabGroup>
+</template>
+```
+</CodeGroup>
+
+### Vertical
+
+Set `orientation="vertical"` on `bq-tab-group` to stack tabs in a column beside the content area.
+
+<CodeLivePreview code={`
+  <style>
+    :host {
+      align-items: flex-start !important;
+    }
+  </style>
+  <bq-tab-group orientation="vertical" value="1">
+    <bq-tab tab-id="1">Tab</bq-tab>
+    <bq-tab tab-id="2">Tab</bq-tab>
+    <bq-tab tab-id="3">Long Tab name</bq-tab>
+    <bq-tab tab-id="4" disabled>Tab</bq-tab>
+  </bq-tab-group>
+`}>
+</CodeLivePreview>
+
+<CodeGroup>
+```html HTML icon="html5"
+<bq-tab-group orientation="vertical" value="1">
+  <bq-tab tab-id="1">Tab</bq-tab>
+  <bq-tab tab-id="2">Tab</bq-tab>
+  <bq-tab tab-id="3">Long Tab name</bq-tab>
+  <bq-tab tab-id="4" disabled>Tab</bq-tab>
+</bq-tab-group>
+```
+```tsx React icon="react"
+import { BqTab, BqTabGroup } from "@beeq/react";
+
+export default () => (
+  <BqTabGroup orientation="vertical" value="1">
+    <BqTab tabId="1">Tab</BqTab>
+    <BqTab tabId="2">Tab</BqTab>
+    <BqTab tabId="3">Long Tab name</BqTab>
+    <BqTab tabId="4" disabled>Tab</BqTab>
+  </BqTabGroup>
+);
+```
+```html Angular icon="angular"
+<bq-tab-group orientation="vertical" value="1">
+  <bq-tab tab-id="1">Tab</bq-tab>
+  <bq-tab tab-id="2">Tab</bq-tab>
+  <bq-tab tab-id="3">Long Tab name</bq-tab>
+  <bq-tab tab-id="4" disabled>Tab</bq-tab>
+</bq-tab-group>
+```
+```vue Vue icon="vuejs"
+<template>
+  <BqTabGroup orientation="vertical" value="1">
+    <BqTab tabId="1">Tab</BqTab>
+    <BqTab tabId="2">Tab</BqTab>
+    <BqTab tabId="3">Long Tab name</BqTab>
+    <BqTab tabId="4" disabled>Tab</BqTab>
+  </BqTabGroup>
+</template>
+```
+</CodeGroup>
+
+### No divider
+
+Use `disable-divider` to hide the underline separator between the tab list and the content area.
+
+<CodeLivePreview code={`
+  <style>
+    :host {
+      flex-direction: column !important;
+      align-items: stretch !important;
+    }
+  </style>
+  <bq-tab-group disable-divider value="1">
+    <bq-tab tab-id="1">Tab</bq-tab>
+    <bq-tab tab-id="2">Tab</bq-tab>
+    <bq-tab tab-id="3">Long Tab name</bq-tab>
+  </bq-tab-group>
+`}>
+</CodeLivePreview>
+
+<CodeGroup>
+```html HTML icon="html5"
+<bq-tab-group disable-divider value="1">
+  <bq-tab tab-id="1">Tab</bq-tab>
+  <bq-tab tab-id="2">Tab</bq-tab>
+  <bq-tab tab-id="3">Long Tab name</bq-tab>
+</bq-tab-group>
+```
+```tsx React icon="react"
+import { BqTab, BqTabGroup } from "@beeq/react";
+
+export default () => (
+  <BqTabGroup disableDivider value="1">
+    <BqTab tabId="1">Tab</BqTab>
+    <BqTab tabId="2">Tab</BqTab>
+    <BqTab tabId="3">Long Tab name</BqTab>
+  </BqTabGroup>
+);
+```
+```html Angular icon="angular"
+<bq-tab-group disable-divider value="1">
+  <bq-tab tab-id="1">Tab</bq-tab>
+  <bq-tab tab-id="2">Tab</bq-tab>
+  <bq-tab tab-id="3">Long Tab name</bq-tab>
+</bq-tab-group>
+```
+```vue Vue icon="vuejs"
+<template>
+  <BqTabGroup disableDivider value="1">
+    <BqTab tabId="1">Tab</BqTab>
+    <BqTab tabId="2">Tab</BqTab>
+    <BqTab tabId="3">Long Tab name</BqTab>
+  </BqTabGroup>
+</template>
+```
+</CodeGroup>
+
+## Best practices
+
+<CardGroup cols={2}>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Keep tab labels short and parallel — prefer noun phrases like "Overview", "Details", or "Settings" rather than full sentences.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Don't use tabs with only one or two items — a single visible section or a toggle is simpler and less visually heavy.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Always provide a `controls` attribute on each `bq-tab` pointing to the `id` of its associated panel element to meet ARIA requirements.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Don't mix tabs of different sizes in the same tab group. Set `size` on `bq-tab-group` and let it propagate uniformly.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Use consistent tab labels across your interface — if some tabs have icons, apply icons to all tabs in the same group.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Don't use tabs for actions or commands. Tabs are for navigation between content views, not for triggering operations like "Save" or "Delete".
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Choose the orientation that matches your layout — use horizontal tabs for top-of-content placement and vertical tabs for sidebar-style navigation.
+  </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Don't rely solely on the active-indicator underline for visual differentiation — ensure sufficient color contrast on the active tab label as well.
+  </Card>
+</CardGroup>
+
+## Accessibility
+
+`bq-tab-group` and `bq-tab` implement the [ARIA Tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/):
+
+- The tab list container has `role="tablist"`.
+- Each `bq-tab` renders as a `<button role="tab">` with `aria-selected` and `aria-disabled` set automatically.
+- The `controls` prop maps to `aria-controls`, linking each tab to its panel. Always provide a matching `id` on the panel element and `role="tabpanel"` for correct screen reader announcements.
+- Keyboard navigation is handled by the tab group:
+  - `ArrowRight` / `ArrowDown` — move focus to the next enabled tab
+  - `ArrowLeft` / `ArrowUp` — move focus to the previous enabled tab
+- Focus management follows the roving `tabindex` pattern: only the active tab is in the tab order; other tabs are reachable via arrow keys.
+- Disabled tabs have `aria-disabled="true"` and `disabled` set on the underlying button, removing them from interaction.
+
+**Your responsibilities:**
+- Provide a meaningful `controls` value on each `bq-tab` that matches the `id` of the corresponding panel.
+- Add `role="tabpanel"` to each panel element.
+- When using icons without a visible label, add a descriptive `aria-label` to the `bq-tab` so screen readers can identify the tab.
+
+## API reference
+
+### `bq-tab-group`
+
+#### Properties
+
+| Property | Attribute | Description | Type | Default |
+|---|---|---|---|---|
+| `debounceTime` | `debounce-time` | Delay in milliseconds before `bqChange` fires | `number` | `0` |
+| `disableDivider` | `disable-divider` | If true, the underline divider is hidden | `boolean` | `false` |
+| `orientation` | `orientation` | Layout direction of the tab list | `"horizontal" \| "vertical"` | `"horizontal"` |
+| `placement` | `placement` | Alignment of tabs within the group | `"start" \| "end"` | `"start"` |
+| `size` | `size` | Size applied to all child tabs | `"small" \| "medium" \| "large"` | `"medium"` |
+| `value` | `value` | The `tab-id` of the currently selected tab | `string` | — |
+
+#### Events
+
+| Event | Description | Type |
+|---|---|---|
+| `bqChange` | Fired when the selected tab changes | `CustomEvent<{ target: HTMLBqTabElement; value: string }>` |
+
+#### Slots
+
+| Slot | Description |
+|---|---|
+| *(default)* | The `bq-tab` items to render inside the group |
+
+#### Shadow parts
+
+| Part | Description |
+|---|---|
+| `base` | The outer `<div>` wrapper |
+| `tabs` | The `<div role="tablist">` holding all tab buttons |
+
+---
+
+### `bq-tab`
+
+#### Properties
+
+| Property | Attribute | Description | Type | Default |
+|---|---|---|---|---|
+| `active` | `active` | If true, the tab is rendered in its active state | `boolean` | `false` |
+| `controls` *(required)* | `controls` | The `id` of the panel element this tab controls | `string` | — |
+| `disabled` | `disabled` | If true, the tab is non-interactive | `boolean` | `false` |
+| `orientation` | `orientation` | Layout direction — propagated automatically by `bq-tab-group` | `"horizontal" \| "vertical"` | `"horizontal"` |
+| `placement` | `placement` | Alignment — propagated automatically by `bq-tab-group` | `"start" \| "end"` | `"start"` |
+| `size` | `size` | Size — propagated automatically by `bq-tab-group` | `"small" \| "medium" \| "large"` | `"medium"` |
+| `tabId` *(required)* | `tab-id` | Unique identifier used to match the tab to its panel | `string` | — |
+
+#### Events
+
+| Event | Description | Type |
+|---|---|---|
+| `bqClick` | Fired when the tab is clicked or activated | `CustomEvent<HTMLBqTabElement>` |
+| `bqFocus` | Fired when the tab receives focus | `CustomEvent<HTMLBqTabElement>` |
+| `bqBlur` | Fired when the tab loses focus | `CustomEvent<HTMLBqTabElement>` |
+| `bqKeyDown` | Fired when a key is pressed while the tab is focused | `CustomEvent<KeyboardEvent>` |
+
+#### Methods
+
+| Method | Description |
+|---|---|
+| `vClick() => Promise<void>` | Simulates a click on the underlying `<button>` element |
+| `vFocus() => Promise<void>` | Sets focus on the underlying `<button>` element |
+| `vBlur() => Promise<void>` | Removes focus from the underlying `<button>` element |
+
+#### Slots
+
+| Slot | Description |
+|---|---|
+| *(default)* | The tab label text |
+| `icon` | An optional icon to display before the label |
+
+#### Shadow parts
+
+| Part | Description |
+|---|---|
+| `base` | The `<button>` element |
+| `content` | The `<div>` wrapping the icon and text |
+| `icon` | The `<div>` holding the slotted icon |
+| `text` | The `<div>` holding the slotted label text |
+| `underline` | The element that renders the active-state underline indicator |
+
+#### CSS custom properties
+
+<Expandable title="CSS variables" defaultOpen={true}>
+
+| Variable | Description | Default |
+|---|---|---|
+| `--bq-tab--font-size` | Font size of the tab label | `var(--bq-font-size--m)` |
+| `--bq-tab--font-weight` | Font weight of the tab label | `var(--bq-font-weight--medium)` |
+| `--bq-tab--line-height` | Line height of the tab label | `var(--bq-font-line-height--regular)` |
+| `--bq-tab--label-icon-gap` | Gap between the icon and the label | `var(--bq-spacing-xs)` |
+| `--bq-tab--padding-vertical-small` | Vertical padding for the small size | `var(--bq-spacing-xs2)` |
+| `--bq-tab--padding-horizontal-small` | Horizontal padding for the small size | `var(--bq-spacing-m)` |
+| `--bq-tab--padding-vertical-medium` | Vertical padding for the medium size | `var(--bq-spacing-xs)` |
+| `--bq-tab--padding-horizontal-medium` | Horizontal padding for the medium size | `var(--bq-spacing-l)` |
+| `--bq-tab--padding-vertical-large` | Vertical padding for the large size | `var(--bq-spacing-s)` |
+| `--bq-tab--padding-horizontal-large` | Horizontal padding for the large size | `var(--bq-spacing-l)` |
+| `--bq-tab--icon-size-small` | Icon size for the small variant | `20px` |
+| `--bq-tab--icon-size-medium` | Icon size for the medium variant | `24px` |
+| `--bq-tab--icon-size-large` | Icon size for the large variant | `24px` |
+
+</Expandable>
+
+<Tip>
+  Learn more about [styling with shadow parts](/theming/styles) and [CSS custom properties](/theming/global-css-variables).
+</Tip>
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card horizontal title="Interactive playground" icon="code" href="https://storybook.beeq.design/?path=/story/components-tabs--default">
+    Explore Tab variants and states in Storybook
+  </Card>
+  <Card horizontal title="Source code" icon="github" href="https://github.com/Endava/BEEQ/tree/main/packages/beeq/src/components/tab">
+    View the component source on GitHub
+  </Card>
+</CardGroup>

--- a/apps/beeq-docs/components/tab.mdx
+++ b/apps/beeq-docs/components/tab.mdx
@@ -164,6 +164,10 @@ export default () => (
 </bq-tab-group>
 ```
 ```vue Vue icon="vuejs"
+<script setup lang="ts">
+import { BqTab, BqTabGroup } from "@beeq/vue";
+</script>
+
 <template>
   <BqTabGroup value="5">
     <BqTab tabId="1">Tab</BqTab>
@@ -327,6 +331,10 @@ export default () => (
 </bq-tab-group>
 ```
 ```vue Vue icon="vuejs"
+<script setup lang="ts">
+import { BqIcon, BqTab, BqTabGroup } from "@beeq/vue";
+</script>
+
 <template>
   <BqTabGroup value="5" size="small">
     <BqTab tabId="1">
@@ -464,6 +472,10 @@ export default () => (
 </bq-tab-group>
 ```
 ```vue Vue icon="vuejs"
+<script setup lang="ts">
+import { BqTab, BqTabGroup } from "@beeq/vue";
+</script>
+
 <template>
   <!-- Small -->
   <BqTabGroup size="small" value="1">
@@ -538,6 +550,10 @@ export default () => (
 </bq-tab-group>
 ```
 ```vue Vue icon="vuejs"
+<script setup lang="ts">
+import { BqTab, BqTabGroup } from "@beeq/vue";
+</script>
+
 <template>
   <BqTabGroup orientation="vertical" value="1">
     <BqTab tabId="1">Tab</BqTab>
@@ -595,6 +611,10 @@ export default () => (
 </bq-tab-group>
 ```
 ```vue Vue icon="vuejs"
+<script setup lang="ts">
+import { BqTab, BqTabGroup } from "@beeq/vue";
+</script>
+
 <template>
   <BqTabGroup disableDivider value="1">
     <BqTab tabId="1">Tab</BqTab>
@@ -752,11 +772,11 @@ export default () => (
 
 #### Methods
 
-| Method | Description |
-|---|---|
-| `vClick() => Promise<void>` | Simulates a click on the underlying `<button>` element |
-| `vFocus() => Promise<void>` | Sets focus on the underlying `<button>` element |
-| `vBlur() => Promise<void>` | Removes focus from the underlying `<button>` element |
+| Method | Description | Signature |
+|---|---|---|
+| `vClick()` | Simulates a click on the underlying `<button>` element | `vClick() => Promise<void>` |
+| `vFocus()` | Sets focus on the underlying `<button>` element | `vFocus() => Promise<void>` |
+| `vBlur()` | Removes focus from the underlying `<button>` element | `vBlur() => Promise<void>` |
 
 #### Slots
 

--- a/apps/beeq-docs/components/tab.mdx
+++ b/apps/beeq-docs/components/tab.mdx
@@ -120,9 +120,7 @@ Use `placement="start"` (default) to left-align horizontal tabs or top-align ver
     <bq-tab tab-id="8">Tab</bq-tab>
   </bq-tab-group>
 `}>
-</CodeLivePreview>
-
-<CodeGroup>
+  <CodeGroup>
 ```html HTML icon="html5"
 <bq-tab-group value="5">
   <bq-tab tab-id="1">Tab</bq-tab>
@@ -151,17 +149,28 @@ export default () => (
   </BqTabGroup>
 );
 ```
-```html Angular icon="angular"
-<bq-tab-group value="5">
-  <bq-tab tab-id="1">Tab</bq-tab>
-  <bq-tab tab-id="2">Tab</bq-tab>
-  <bq-tab tab-id="3">Long Tab name</bq-tab>
-  <bq-tab tab-id="4" disabled>Tab</bq-tab>
-  <bq-tab tab-id="5">Tab</bq-tab>
-  <bq-tab tab-id="6">Tab</bq-tab>
-  <bq-tab tab-id="7">Tab</bq-tab>
-  <bq-tab tab-id="8">Tab</bq-tab>
-</bq-tab-group>
+```ts Angular icon="angular"
+import { Component } from "@angular/core";
+import { BqTab, BqTabGroup } from "@beeq/angular/standalone";
+
+@Component({
+  selector: "app-root",
+  standalone: true,
+  imports: [BqTab, BqTabGroup],
+  template: `
+    <bq-tab-group value="5">
+      <bq-tab tab-id="1">Tab</bq-tab>
+      <bq-tab tab-id="2">Tab</bq-tab>
+      <bq-tab tab-id="3">Long Tab name</bq-tab>
+      <bq-tab tab-id="4" disabled>Tab</bq-tab>
+      <bq-tab tab-id="5">Tab</bq-tab>
+      <bq-tab tab-id="6">Tab</bq-tab>
+      <bq-tab tab-id="7">Tab</bq-tab>
+      <bq-tab tab-id="8">Tab</bq-tab>
+    </bq-tab-group>
+  `,
+})
+export class AppComponent {}
 ```
 ```vue Vue icon="vuejs"
 <script setup lang="ts">
@@ -181,7 +190,8 @@ import { BqTab, BqTabGroup } from "@beeq/vue";
   </BqTabGroup>
 </template>
 ```
-</CodeGroup>
+  </CodeGroup>
+</CodeLivePreview>
 
 ## Options
 
@@ -227,9 +237,7 @@ Tabs support an optional icon displayed before the label via the `icon` slot.
     </bq-tab>
   </bq-tab-group>
 `}>
-</CodeLivePreview>
-
-<CodeGroup>
+  <CodeGroup>
 ```html HTML icon="html5"
 <bq-tab-group value="5" size="small">
   <bq-tab tab-id="1">
@@ -298,37 +306,48 @@ export default () => (
   </BqTabGroup>
 );
 ```
-```html Angular icon="angular"
-<bq-tab-group value="5" size="small">
-  <bq-tab tab-id="1">
-    <bq-icon name="pulse" slot="icon"></bq-icon>
-    Tab
-  </bq-tab>
-  <bq-tab tab-id="2">
-    <bq-icon name="bell" slot="icon"></bq-icon>
-    Tab
-  </bq-tab>
-  <bq-tab tab-id="3">
-    <bq-icon name="airplane-in-flight" slot="icon"></bq-icon>
-    Long Tab name
-  </bq-tab>
-  <bq-tab tab-id="4" disabled>
-    <bq-icon name="airplane-tilt" slot="icon"></bq-icon>
-    Tab
-  </bq-tab>
-  <bq-tab tab-id="5">
-    <bq-icon name="align-right-simple" slot="icon"></bq-icon>
-    Tab
-  </bq-tab>
-  <bq-tab tab-id="6">
-    <bq-icon name="anchor" slot="icon"></bq-icon>
-    Tab
-  </bq-tab>
-  <bq-tab tab-id="7">
-    <bq-icon name="android-logo" slot="icon"></bq-icon>
-    Tab
-  </bq-tab>
-</bq-tab-group>
+```ts Angular icon="angular"
+import { Component } from "@angular/core";
+import { BqIcon, BqTab, BqTabGroup } from "@beeq/angular/standalone";
+
+@Component({
+  selector: "app-root",
+  standalone: true,
+  imports: [BqIcon, BqTab, BqTabGroup],
+  template: `
+    <bq-tab-group value="5" size="small">
+      <bq-tab tab-id="1">
+        <bq-icon name="pulse" slot="icon"></bq-icon>
+        Tab
+      </bq-tab>
+      <bq-tab tab-id="2">
+        <bq-icon name="bell" slot="icon"></bq-icon>
+        Tab
+      </bq-tab>
+      <bq-tab tab-id="3">
+        <bq-icon name="airplane-in-flight" slot="icon"></bq-icon>
+        Long Tab name
+      </bq-tab>
+      <bq-tab tab-id="4" disabled>
+        <bq-icon name="airplane-tilt" slot="icon"></bq-icon>
+        Tab
+      </bq-tab>
+      <bq-tab tab-id="5">
+        <bq-icon name="align-right-simple" slot="icon"></bq-icon>
+        Tab
+      </bq-tab>
+      <bq-tab tab-id="6">
+        <bq-icon name="anchor" slot="icon"></bq-icon>
+        Tab
+      </bq-tab>
+      <bq-tab tab-id="7">
+        <bq-icon name="android-logo" slot="icon"></bq-icon>
+        Tab
+      </bq-tab>
+    </bq-tab-group>
+  `,
+})
+export class AppComponent {}
 ```
 ```vue Vue icon="vuejs"
 <script setup lang="ts">
@@ -368,7 +387,8 @@ import { BqIcon, BqTab, BqTabGroup } from "@beeq/vue";
   </BqTabGroup>
 </template>
 ```
-</CodeGroup>
+  </CodeGroup>
+</CodeLivePreview>
 
 ### Sizes
 
@@ -396,9 +416,7 @@ import { BqIcon, BqTab, BqTabGroup } from "@beeq/vue";
     <bq-tab tab-id="3">Long Tab name</bq-tab>
   </bq-tab-group>
 `}>
-</CodeLivePreview>
-
-<CodeGroup>
+  <CodeGroup>
 ```html HTML icon="html5"
 <!-- Small -->
 <bq-tab-group size="small" value="1">
@@ -449,27 +467,35 @@ export default () => (
   </>
 );
 ```
-```html Angular icon="angular"
-<!-- Small -->
-<bq-tab-group size="small" value="1">
-  <bq-tab tab-id="1">Tab</bq-tab>
-  <bq-tab tab-id="2">Tab</bq-tab>
-  <bq-tab tab-id="3">Long Tab name</bq-tab>
-</bq-tab-group>
+```ts Angular icon="angular"
+import { Component } from "@angular/core";
+import { BqTab, BqTabGroup } from "@beeq/angular/standalone";
 
-<!-- Medium (default) -->
-<bq-tab-group size="medium" value="1">
-  <bq-tab tab-id="1">Tab</bq-tab>
-  <bq-tab tab-id="2">Tab</bq-tab>
-  <bq-tab tab-id="3">Long Tab name</bq-tab>
-</bq-tab-group>
+@Component({
+  selector: "app-root",
+  standalone: true,
+  imports: [BqTab, BqTabGroup],
+  template: `
+    <bq-tab-group size="small" value="1">
+      <bq-tab tab-id="1">Tab</bq-tab>
+      <bq-tab tab-id="2">Tab</bq-tab>
+      <bq-tab tab-id="3">Long Tab name</bq-tab>
+    </bq-tab-group>
 
-<!-- Large -->
-<bq-tab-group size="large" value="1">
-  <bq-tab tab-id="1">Tab</bq-tab>
-  <bq-tab tab-id="2">Tab</bq-tab>
-  <bq-tab tab-id="3">Long Tab name</bq-tab>
-</bq-tab-group>
+    <bq-tab-group size="medium" value="1">
+      <bq-tab tab-id="1">Tab</bq-tab>
+      <bq-tab tab-id="2">Tab</bq-tab>
+      <bq-tab tab-id="3">Long Tab name</bq-tab>
+    </bq-tab-group>
+
+    <bq-tab-group size="large" value="1">
+      <bq-tab tab-id="1">Tab</bq-tab>
+      <bq-tab tab-id="2">Tab</bq-tab>
+      <bq-tab tab-id="3">Long Tab name</bq-tab>
+    </bq-tab-group>
+  `,
+})
+export class AppComponent {}
 ```
 ```vue Vue icon="vuejs"
 <script setup lang="ts">
@@ -499,7 +525,8 @@ import { BqTab, BqTabGroup } from "@beeq/vue";
   </BqTabGroup>
 </template>
 ```
-</CodeGroup>
+  </CodeGroup>
+</CodeLivePreview>
 
 ### Vertical
 
@@ -518,9 +545,7 @@ Set `orientation="vertical"` on `bq-tab-group` to stack tabs in a column beside 
     <bq-tab tab-id="4" disabled>Tab</bq-tab>
   </bq-tab-group>
 `}>
-</CodeLivePreview>
-
-<CodeGroup>
+  <CodeGroup>
 ```html HTML icon="html5"
 <bq-tab-group orientation="vertical" value="1">
   <bq-tab tab-id="1">Tab</bq-tab>
@@ -541,13 +566,24 @@ export default () => (
   </BqTabGroup>
 );
 ```
-```html Angular icon="angular"
-<bq-tab-group orientation="vertical" value="1">
-  <bq-tab tab-id="1">Tab</bq-tab>
-  <bq-tab tab-id="2">Tab</bq-tab>
-  <bq-tab tab-id="3">Long Tab name</bq-tab>
-  <bq-tab tab-id="4" disabled>Tab</bq-tab>
-</bq-tab-group>
+```ts Angular icon="angular"
+import { Component } from "@angular/core";
+import { BqTab, BqTabGroup } from "@beeq/angular/standalone";
+
+@Component({
+  selector: "app-root",
+  standalone: true,
+  imports: [BqTab, BqTabGroup],
+  template: `
+    <bq-tab-group orientation="vertical" value="1">
+      <bq-tab tab-id="1">Tab</bq-tab>
+      <bq-tab tab-id="2">Tab</bq-tab>
+      <bq-tab tab-id="3">Long Tab name</bq-tab>
+      <bq-tab tab-id="4" disabled>Tab</bq-tab>
+    </bq-tab-group>
+  `,
+})
+export class AppComponent {}
 ```
 ```vue Vue icon="vuejs"
 <script setup lang="ts">
@@ -563,7 +599,8 @@ import { BqTab, BqTabGroup } from "@beeq/vue";
   </BqTabGroup>
 </template>
 ```
-</CodeGroup>
+  </CodeGroup>
+</CodeLivePreview>
 
 ### No divider
 
@@ -582,9 +619,7 @@ Use `disable-divider` to hide the underline separator between the tab list and t
     <bq-tab tab-id="3">Long Tab name</bq-tab>
   </bq-tab-group>
 `}>
-</CodeLivePreview>
-
-<CodeGroup>
+  <CodeGroup>
 ```html HTML icon="html5"
 <bq-tab-group disable-divider value="1">
   <bq-tab tab-id="1">Tab</bq-tab>
@@ -603,12 +638,23 @@ export default () => (
   </BqTabGroup>
 );
 ```
-```html Angular icon="angular"
-<bq-tab-group disable-divider value="1">
-  <bq-tab tab-id="1">Tab</bq-tab>
-  <bq-tab tab-id="2">Tab</bq-tab>
-  <bq-tab tab-id="3">Long Tab name</bq-tab>
-</bq-tab-group>
+```ts Angular icon="angular"
+import { Component } from "@angular/core";
+import { BqTab, BqTabGroup } from "@beeq/angular/standalone";
+
+@Component({
+  selector: "app-root",
+  standalone: true,
+  imports: [BqTab, BqTabGroup],
+  template: `
+    <bq-tab-group disable-divider value="1">
+      <bq-tab tab-id="1">Tab</bq-tab>
+      <bq-tab tab-id="2">Tab</bq-tab>
+      <bq-tab tab-id="3">Long Tab name</bq-tab>
+    </bq-tab-group>
+  `,
+})
+export class AppComponent {}
 ```
 ```vue Vue icon="vuejs"
 <script setup lang="ts">
@@ -623,7 +669,8 @@ import { BqTab, BqTabGroup } from "@beeq/vue";
   </BqTabGroup>
 </template>
 ```
-</CodeGroup>
+  </CodeGroup>
+</CodeLivePreview>
 
 ## Best practices
 

--- a/apps/beeq-docs/components/textarea.mdx
+++ b/apps/beeq-docs/components/textarea.mdx
@@ -1,0 +1,1014 @@
+---
+title: Textarea
+description: The Textarea component is a multi-line text input control used in forms to collect longer user input such as comments, messages, or descriptions.
+---
+
+import { CodeLivePreview } from "/snippets/CodeLivePreview.jsx";
+
+<Frame className="px-4 py-4" caption="Textarea component overview">
+  <img className="block dark:hidden" src="/components/images/textarea/textarea-overview-light.svg" alt="BEEQ Textarea component overview" />
+  <img className="hidden dark:block" src="/components/images/textarea/textarea-overview-dark.svg" alt="BEEQ Textarea component overview" />
+</Frame>
+
+A textarea is a multi-line text input control. Use it when users need to provide longer pieces of text such as comments, messages, or descriptions where a single-line input would be too limiting.
+
+<Note>
+  Use an [Input](/components/input) when users only need to enter a short, single-line value. Use a Textarea when the expected content spans multiple lines.
+</Note>
+
+## When to use
+
+<CardGroup cols={2}>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="thumbs-up" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Use a textarea when
+    </span>
+    - Users need to enter multiple lines of text such as a comment, review, or description
+    - The expected input length varies and may be long
+    - Free-form text entry is required without a predefined set of values
+    - Context makes the textarea purpose clear through a visible label
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="thumbs-down" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Do not use a textarea when
+    </span>
+    - The expected input is a short single-line value — use an Input instead
+    - Users must choose from a fixed set of options — use a Select or Radio
+    - The field value is meant to be read-only in the final UI — use plain text
+    - Rich formatting or markdown editing is required — consider a dedicated editor
+  </Card>
+</CardGroup>
+
+## Anatomy
+
+<Frame className="px-4 py-4" caption="Textarea component anatomy">
+  <img className="block dark:hidden" src="/components/images/textarea/textarea-anatomy-light.svg" alt="BEEQ Textarea component anatomy" />
+  <img className="hidden dark:block" src="/components/images/textarea/textarea-anatomy-dark.svg" alt="BEEQ Textarea component anatomy" />
+</Frame>
+
+The textarea is composed of a label area, an input container, and an optional helper area. Each part can carry additional icons and text to guide users through data entry.
+
+| Part | Element | Description |
+|---|---|---|
+| **1** | Optional label | Secondary descriptive text displayed alongside the main label |
+| **2** | Text | The value or placeholder text inside the control |
+| **3** | Label icon | Optional icon displayed next to the label |
+| **4** | Label | The primary field label rendered via the `label` slot |
+| **5** | Leading icon | Optional icon displayed at the start of the input container |
+| **6** | Container | The outer border and background wrapper of the textarea |
+| **7** | Validation icon | Icon shown when `validation-status` is set (error, warning, success) |
+| **8** | Helper text | Optional guidance or error text rendered via the `helper-text` slot |
+| **9** | Character counter | Shown automatically when `maxlength` is set |
+| **10** | Trailing icon | Optional icon displayed at the end of the input container |
+
+## Design guidelines
+
+### States
+
+A textarea supports five interactive states: **default**, **focused**, **disabled**, **read-only**, and **validation** (error, warning, success). The focused state shows a colored ring. The disabled state dims the control and blocks all interaction. The read-only state displays the value but prevents editing.
+
+<Note>
+  Always pair a textarea with a visible `label` slot. An unlabeled textarea has no accessible name and is inaccessible by default.
+</Note>
+
+### Resize behavior
+
+By default, users can drag the bottom-right corner to resize the textarea vertically. Set `disable-resize` to prevent resizing — useful when you want to maintain a consistent layout height. Alternatively, set `auto-grow` to let the textarea expand automatically as the user types, eliminating the need for manual resizing.
+
+### Character counter
+
+When `maxlength` is set to a value greater than zero, a character counter appears in the helper area below the textarea. It shows the current character count against the limit and helps users stay within bounds. The counter truncates input automatically when the limit is reached.
+
+### Validation
+
+Set `validation-status` to `error`, `warning`, or `success` to communicate the state of the field. Pair each state with a descriptive `helper-text` message so users know what went wrong and how to fix it. Use `error` for critical blocking issues, `warning` for non-blocking concerns, and `success` to confirm valid input.
+
+## Usage
+
+### Default
+
+Use the default textarea when you need a standard multi-line text input. Provide a `label` slot for the field name and a `helper-text` slot for any additional guidance.
+
+<CodeLivePreview code={`
+  <style>
+    span {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+  </style>
+
+  <bq-textarea placeholder="Placeholder...">
+    <label slot="label">Label</label>
+    <span slot="helper-text">
+      <bq-icon name="star"></bq-icon>
+      Helper text
+    </span>
+  </bq-textarea>
+`}>
+  <CodeGroup>
+    ```html HTML
+    <bq-textarea placeholder="Placeholder...">
+      <label slot="label">Label</label>
+      <span slot="helper-text">
+        <bq-icon name="star"></bq-icon>
+        Helper text
+      </span>
+    </bq-textarea>
+    ```
+    ```tsx React
+    import { BqIcon, BqTextarea } from "@beeq/react";
+
+    export default () => (
+      <BqTextarea placeholder="Placeholder...">
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <BqIcon name="star" />
+          Helper text
+        </span>
+      </BqTextarea>
+    );
+    ```
+    ```html Angular
+    <bq-textarea placeholder="Placeholder...">
+      <label slot="label">Label</label>
+      <span slot="helper-text">
+        <bq-icon name="star"></bq-icon>
+        Helper text
+      </span>
+    </bq-textarea>
+    ```
+    ```html Vue
+    <bq-textarea placeholder="Placeholder...">
+      <label slot="label">Label</label>
+      <span slot="helper-text">
+        <bq-icon name="star"></bq-icon>
+        Helper text
+      </span>
+    </bq-textarea>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Initial Value
+
+Pre-populate your textarea with an initial `value` attribute to streamline user interactions and provide a helpful starting point.
+
+<CodeLivePreview code={`
+  <style>
+    span {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+  </style>
+
+  <bq-textarea
+    placeholder="Placeholder..."
+    value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
+  >
+    <label slot="label">Label</label>
+    <span slot="helper-text">
+      <bq-icon name="star"></bq-icon>
+      Helper text
+    </span>
+  </bq-textarea>
+`}>
+  <CodeGroup>
+    ```html HTML
+    <bq-textarea
+      placeholder="Placeholder..."
+      value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
+    >
+      <label slot="label">Label</label>
+      <span slot="helper-text">
+        <bq-icon name="star"></bq-icon>
+        Helper text
+      </span>
+    </bq-textarea>
+    ```
+    ```tsx React
+    import { BqIcon, BqTextarea } from "@beeq/react";
+
+    export default () => (
+      <BqTextarea
+        placeholder="Placeholder..."
+        value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
+      >
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <BqIcon name="star" />
+          Helper text
+        </span>
+      </BqTextarea>
+    );
+    ```
+    ```html Angular
+    <bq-textarea
+      placeholder="Placeholder..."
+      value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
+    >
+      <label slot="label">Label</label>
+      <span slot="helper-text">
+        <bq-icon name="star"></bq-icon>
+        Helper text
+      </span>
+    </bq-textarea>
+    ```
+    ```html Vue
+    <bq-textarea
+      placeholder="Placeholder..."
+      value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
+    >
+      <label slot="label">Label</label>
+      <span slot="helper-text">
+        <bq-icon name="star"></bq-icon>
+        Helper text
+      </span>
+    </bq-textarea>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+## Options
+
+### Disabled
+
+Set `disabled` when the field is not currently available for interaction. Use it to present non-editable content in a form context. Always communicate why the field is disabled through surrounding text or a tooltip.
+
+<CodeLivePreview code={`
+  <style>
+    span {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+  </style>
+
+  <bq-textarea
+    disabled
+    placeholder="Placeholder..."
+    value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
+  >
+    <label slot="label">Label</label>
+    <span slot="helper-text">
+      <bq-icon name="star"></bq-icon>
+      Helper text
+    </span>
+  </bq-textarea>
+`}>
+  <CodeGroup>
+    ```html HTML
+    <bq-textarea
+      disabled
+      placeholder="Placeholder..."
+      value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
+    >
+      <label slot="label">Label</label>
+      <span slot="helper-text">
+        <bq-icon name="star"></bq-icon>
+        Helper text
+      </span>
+    </bq-textarea>
+    ```
+    ```tsx React
+    import { BqIcon, BqTextarea } from "@beeq/react";
+
+    export default () => (
+      <BqTextarea
+        disabled
+        placeholder="Placeholder..."
+        value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
+      >
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <BqIcon name="star" />
+          Helper text
+        </span>
+      </BqTextarea>
+    );
+    ```
+    ```html Angular
+    <bq-textarea
+      disabled
+      placeholder="Placeholder..."
+      value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
+    >
+      <label slot="label">Label</label>
+      <span slot="helper-text">
+        <bq-icon name="star"></bq-icon>
+        Helper text
+      </span>
+    </bq-textarea>
+    ```
+    ```html Vue
+    <bq-textarea
+      disabled
+      placeholder="Placeholder..."
+      value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
+    >
+      <label slot="label">Label</label>
+      <span slot="helper-text">
+        <bq-icon name="star"></bq-icon>
+        Helper text
+      </span>
+    </bq-textarea>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Disable Resize
+
+Add `disable-resize` to prevent users from resizing the textarea. This is useful when you need a stable layout with a consistent textarea height.
+
+<CodeLivePreview code={`
+  <style>
+    .textarea--resize-group {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0px, 1fr));
+      gap: var(--bq-spacing-m);
+    }
+    span {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+  </style>
+
+  <div class="textarea--resize-group">
+    <bq-textarea placeholder="Resize is enabled">
+      <label slot="label">Label</label>
+      <span slot="helper-text">
+        <bq-icon name="star"></bq-icon>
+        Helper text
+      </span>
+    </bq-textarea>
+    <bq-textarea disable-resize placeholder="Resize is disabled">
+      <label slot="label">Label</label>
+      <span slot="helper-text">
+        <bq-icon name="star"></bq-icon>
+        Helper text
+      </span>
+    </bq-textarea>
+  </div>
+`}>
+  <CodeGroup>
+    ```html HTML
+    <div class="textarea--resize-group">
+      <bq-textarea placeholder="Resize is enabled">
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <bq-icon name="star"></bq-icon>
+          Helper text
+        </span>
+      </bq-textarea>
+      <bq-textarea disable-resize placeholder="Resize is disabled">
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <bq-icon name="star"></bq-icon>
+          Helper text
+        </span>
+      </bq-textarea>
+    </div>
+    ```
+    ```tsx React
+    import { BqIcon, BqTextarea } from "@beeq/react";
+
+    export default () => (
+      <>
+        <BqTextarea placeholder="Resize is enabled">
+          <label slot="label">Label</label>
+          <span slot="helper-text">
+            <BqIcon name="star" />
+            Helper text
+          </span>
+        </BqTextarea>
+        <BqTextarea disableResize placeholder="Resize is disabled">
+          <label slot="label">Label</label>
+          <span slot="helper-text">
+            <BqIcon name="star" />
+            Helper text
+          </span>
+        </BqTextarea>
+      </>
+    );
+    ```
+    ```html Angular
+    <div class="textarea--resize-group">
+      <bq-textarea placeholder="Resize is enabled">
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <bq-icon name="star"></bq-icon>
+          Helper text
+        </span>
+      </bq-textarea>
+      <bq-textarea disable-resize placeholder="Resize is disabled">
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <bq-icon name="star"></bq-icon>
+          Helper text
+        </span>
+      </bq-textarea>
+    </div>
+    ```
+    ```html Vue
+    <div class="textarea--resize-group">
+      <bq-textarea placeholder="Resize is enabled">
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <bq-icon name="star"></bq-icon>
+          Helper text
+        </span>
+      </bq-textarea>
+      <bq-textarea disableResize placeholder="Resize is disabled">
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <bq-icon name="star"></bq-icon>
+          Helper text
+        </span>
+      </bq-textarea>
+    </div>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+<Tip>
+  Maintain a consistent layout by preventing users from resizing.
+</Tip>
+
+### Max Length
+
+Set `maxlength` to limit the number of characters users can enter. A character counter appears automatically below the textarea to show progress toward the limit. Input is truncated once the limit is reached.
+
+<CodeLivePreview code={`
+  <style>
+    span {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+  </style>
+
+  <bq-textarea
+    maxlength="100"
+    placeholder="Placeholder..."
+    value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+  >
+    <label slot="label">Label</label>
+    <span slot="helper-text">
+      <bq-icon name="star"></bq-icon>
+      Helper text
+    </span>
+  </bq-textarea>
+`}>
+  <CodeGroup>
+    ```html HTML
+    <bq-textarea
+      maxlength="100"
+      placeholder="Placeholder..."
+      value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+    >
+      <label slot="label">Label</label>
+      <span slot="helper-text">
+        <bq-icon name="star"></bq-icon>
+        Helper text
+      </span>
+    </bq-textarea>
+    ```
+    ```tsx React
+    import { BqIcon, BqTextarea } from "@beeq/react";
+
+    export default () => (
+      <BqTextarea
+        maxlength={100}
+        placeholder="Placeholder..."
+        value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+      >
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <BqIcon name="star" />
+          Helper text
+        </span>
+      </BqTextarea>
+    );
+    ```
+    ```html Angular
+    <bq-textarea
+      maxlength="100"
+      placeholder="Placeholder..."
+      value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+    >
+      <label slot="label">Label</label>
+      <span slot="helper-text">
+        <bq-icon name="star"></bq-icon>
+        Helper text
+      </span>
+    </bq-textarea>
+    ```
+    ```html Vue
+    <bq-textarea
+      :maxlength="100"
+      placeholder="Placeholder..."
+      value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+    >
+      <label slot="label">Label</label>
+      <span slot="helper-text">
+        <bq-icon name="star"></bq-icon>
+        Helper text
+      </span>
+    </bq-textarea>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Read Only
+
+Set `readonly` to display the value without allowing edits. Unlike `disabled`, a read-only textarea is still focusable and its value is submitted with the form.
+
+<CodeLivePreview code={`
+  <style>
+    span {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+  </style>
+
+  <bq-textarea
+    placeholder="Placeholder..."
+    readonly
+    value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
+  >
+    <label slot="label">Label</label>
+    <span slot="helper-text">
+      <bq-icon name="star"></bq-icon>
+      Helper text
+    </span>
+  </bq-textarea>
+`}>
+  <CodeGroup>
+    ```html HTML
+    <bq-textarea
+      placeholder="Placeholder..."
+      readonly
+      value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
+    >
+      <label slot="label">Label</label>
+      <span slot="helper-text">
+        <bq-icon name="star"></bq-icon>
+        Helper text
+      </span>
+    </bq-textarea>
+    ```
+    ```tsx React
+    import { BqIcon, BqTextarea } from "@beeq/react";
+
+    export default () => (
+      <BqTextarea
+        placeholder="Placeholder..."
+        readonly
+        value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
+      >
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <BqIcon name="star" />
+          Helper text
+        </span>
+      </BqTextarea>
+    );
+    ```
+    ```html Angular
+    <bq-textarea
+      placeholder="Placeholder..."
+      readonly
+      value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
+    >
+      <label slot="label">Label</label>
+      <span slot="helper-text">
+        <bq-icon name="star"></bq-icon>
+        Helper text
+      </span>
+    </bq-textarea>
+    ```
+    ```html Vue
+    <bq-textarea
+      placeholder="Placeholder..."
+      readonly
+      value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
+    >
+      <label slot="label">Label</label>
+      <span slot="helper-text">
+        <bq-icon name="star"></bq-icon>
+        Helper text
+      </span>
+    </bq-textarea>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Validation
+
+Set `validation-status` to `error`, `warning`, or `success` to communicate the state of the field. Always pair a validation status with a descriptive `helper-text` message so users understand the issue and how to resolve it.
+
+<CodeLivePreview code={`
+  <style>
+    .textarea--validation-group {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0px, 1fr));
+      gap: var(--bq-spacing-m);
+    }
+    span {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+  </style>
+
+  <div class="textarea--validation-group">
+    <bq-textarea
+      maxlength="100"
+      placeholder="Placeholder..."
+      validation-status="error"
+      value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+    >
+      <label slot="label">Label</label>
+      <span slot="helper-text">
+        <bq-icon name="star"></bq-icon>
+        Helper text
+      </span>
+    </bq-textarea>
+    <bq-textarea
+      maxlength="100"
+      placeholder="Placeholder..."
+      validation-status="warning"
+      value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+    >
+      <label slot="label">Label</label>
+      <span slot="helper-text">
+        <bq-icon name="star"></bq-icon>
+        Helper text
+      </span>
+    </bq-textarea>
+    <bq-textarea
+      maxlength="100"
+      placeholder="Placeholder..."
+      validation-status="success"
+      value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+    >
+      <label slot="label">Label</label>
+      <span slot="helper-text">
+        <bq-icon name="star"></bq-icon>
+        Helper text
+      </span>
+    </bq-textarea>
+  </div>
+`}>
+  <CodeGroup>
+    ```html HTML
+    <div class="textarea--validation-group">
+      <bq-textarea
+        maxlength="100"
+        placeholder="Placeholder..."
+        validation-status="error"
+        value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+      >
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <bq-icon name="star"></bq-icon>
+          Helper text
+        </span>
+      </bq-textarea>
+      <bq-textarea
+        maxlength="100"
+        placeholder="Placeholder..."
+        validation-status="warning"
+        value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+      >
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <bq-icon name="star"></bq-icon>
+          Helper text
+        </span>
+      </bq-textarea>
+      <bq-textarea
+        maxlength="100"
+        placeholder="Placeholder..."
+        validation-status="success"
+        value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+      >
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <bq-icon name="star"></bq-icon>
+          Helper text
+        </span>
+      </bq-textarea>
+    </div>
+    ```
+    ```tsx React
+    import { BqIcon, BqTextarea } from "@beeq/react";
+
+    export default () => (
+      <>
+        <BqTextarea
+          maxlength={100}
+          placeholder="Placeholder..."
+          validationStatus="error"
+          value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+        >
+          <label slot="label">Label</label>
+          <span slot="helper-text">
+            <BqIcon name="star" />
+            Helper text
+          </span>
+        </BqTextarea>
+        <BqTextarea
+          maxlength={100}
+          placeholder="Placeholder..."
+          validationStatus="warning"
+          value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+        >
+          <label slot="label">Label</label>
+          <span slot="helper-text">
+            <BqIcon name="star" />
+            Helper text
+          </span>
+        </BqTextarea>
+        <BqTextarea
+          maxlength={100}
+          placeholder="Placeholder..."
+          validationStatus="success"
+          value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+        >
+          <label slot="label">Label</label>
+          <span slot="helper-text">
+            <BqIcon name="star" />
+            Helper text
+          </span>
+        </BqTextarea>
+      </>
+    );
+    ```
+    ```html Angular
+    <div class="textarea--validation-group">
+      <bq-textarea
+        maxlength="100"
+        placeholder="Placeholder..."
+        validation-status="error"
+        value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+      >
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <bq-icon name="star"></bq-icon>
+          Helper text
+        </span>
+      </bq-textarea>
+      <bq-textarea
+        maxlength="100"
+        placeholder="Placeholder..."
+        validation-status="warning"
+        value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+      >
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <bq-icon name="star"></bq-icon>
+          Helper text
+        </span>
+      </bq-textarea>
+      <bq-textarea
+        maxlength="100"
+        placeholder="Placeholder..."
+        validation-status="success"
+        value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+      >
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <bq-icon name="star"></bq-icon>
+          Helper text
+        </span>
+      </bq-textarea>
+    </div>
+    ```
+    ```html Vue
+    <div class="textarea--validation-group">
+      <bq-textarea
+        :maxlength="100"
+        placeholder="Placeholder..."
+        validationStatus="error"
+        value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+      >
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <bq-icon name="star"></bq-icon>
+          Helper text
+        </span>
+      </bq-textarea>
+      <bq-textarea
+        :maxlength="100"
+        placeholder="Placeholder..."
+        validationStatus="warning"
+        value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+      >
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <bq-icon name="star"></bq-icon>
+          Helper text
+        </span>
+      </bq-textarea>
+      <bq-textarea
+        :maxlength="100"
+        placeholder="Placeholder..."
+        validationStatus="success"
+        value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+      >
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <bq-icon name="star"></bq-icon>
+          Helper text
+        </span>
+      </bq-textarea>
+    </div>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+<Tip>
+  Use validation feedback to provide context on the textarea's status based on user input.
+</Tip>
+
+## Best practices
+
+<CardGroup cols={2}>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Always provide a visible label via the `label` slot. An unlabeled textarea has no accessible name and relies entirely on context, which screen readers cannot infer.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Use placeholder text as a substitute for a label. Placeholder text disappears as soon as the user starts typing, leaving the field without any visible description.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Write validation error messages with a user-centric approach — explain what went wrong and how to fix it, not just that the input was invalid.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Show vague error messages like "Invalid input". Users need actionable guidance to correct their input, not a generic error label.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Use `maxlength` for inputs where length matters — tweet-like comments, SMS text, or short descriptions. The character counter gives users clear progress feedback.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Set `maxlength` on open-ended fields like detailed feedback forms or long descriptions where an arbitrary limit would frustrate users.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Do
+    </span>
+    Use a textarea only when the expected input is long or variable in length. This sets the right expectation for users about how much text they should provide.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+    Use a textarea when a short single-line response is expected. An oversized input creates confusion and wastes space — use an Input component instead.
+  </Card>
+</CardGroup>
+
+## Accessibility
+
+`bq-textarea` renders a native `<textarea>` element inside its shadow DOM. The `label` slot renders as a `<label>` element that is linked to the `<textarea>` via an `id`/`for` relationship automatically, giving assistive technologies a correct accessible name.
+
+### Keyboard interaction
+
+| Key | Action |
+|---|---|
+| `Tab` | Moves focus to the textarea |
+| `Shift + Tab` | Moves focus away from the textarea |
+| Arrow keys | Navigate the cursor through the text |
+| `Enter` | Inserts a new line in the text |
+
+### Developer responsibilities
+
+- Always provide content in the `label` slot. The label is the primary source of the accessible name for the textarea. Do not rely on `placeholder` — it disappears once the user starts typing.
+- When using `validation-status`, pair it with a `helper-text` message that explains the issue. Screen readers announce the helper text to users so they know what to correct.
+- When the textarea is `disabled`, it is removed from the tab order and excluded from form submission. Communicate the reason for disabling through surrounding text.
+- A `readonly` textarea remains focusable and its value is included in form submissions. Use it when you want users to see but not edit a value.
+- The `bqChange` event fires when the user changes the value and then blurs the field. The `bqInput` event fires on every keystroke. Use `debounce-time` to throttle `bqInput` for performance-sensitive scenarios such as live search.
+
+## API reference
+
+### Properties
+
+| Property | Attribute | Description | Type | Default |
+|---|---|---|---|---|
+| `autocapitalize` | `autocapitalize` | Controls how the textarea value is capitalized | `'off' \| 'on' \| 'sentences' \| 'words' \| 'characters'` | `'off'` |
+| `autocomplete` | `autocomplete` | Specifies whether autocomplete is enabled | `string` | `'off'` |
+| `autofocus` | `autofocus` | If `true`, the textarea is focused on render | `boolean` | `false` |
+| `autoGrow` | `auto-grow` | If `true`, the textarea grows and shrinks to fit its contents | `boolean` | `false` |
+| `debounceTime` | `debounce-time` | Milliseconds to wait before emitting `bqInput` after a value change | `number` | `0` |
+| `disabled` | `disabled` | If `true`, the user cannot interact with the textarea | `boolean` | `false` |
+| `disableResize` | `disable-resize` | If `true`, the user cannot resize the textarea | `boolean` | `false` |
+| `form` | `form` | The ID of the form the textarea belongs to | `string` | — |
+| `formValidationMessage` | `form-validation-message` | Custom native form validation message | `string` | — |
+| `maxlength` | `maxlength` | Maximum number of characters (`0` means no limit); enables the character counter | `number` | — |
+| `name` | `name` | Name of the form control; submitted with the form | `string` | **required** |
+| `placeholder` | `placeholder` | Placeholder text shown when the textarea has no value | `string` | **required** |
+| `readonly` | `readonly` | If `true`, the value cannot be modified but remains focusable and submitted | `boolean` | `false` |
+| `required` | `required` | If `true`, the textarea must have a value before the form can be submitted | `boolean` | `false` |
+| `rows` | `rows` | Number of visible text lines | `number` | `5` |
+| `spellcheck` | `spellcheck` | If `true`, the content may be checked for spelling errors | `boolean` | `false` |
+| `validationStatus` | `validation-status` | Validation state of the textarea | `'none' \| 'error' \| 'warning' \| 'success'` | `'none'` |
+| `value` | `value` | The current value of the textarea | `string` | — |
+| `wrap` | `wrap` | How text is wrapped when the form is submitted | `'soft' \| 'hard' \| 'off'` | `'soft'` |
+
+### Events
+
+| Event | Description | Type |
+|---|---|---|
+| `bqBlur` | Emitted when the textarea loses focus | `CustomEvent<HTMLBqTextareaElement>` |
+| `bqChange` | Emitted when the value changes and the textarea loses focus | `CustomEvent<{ value: string; el: HTMLBqTextareaElement }>` |
+| `bqClear` | Emitted when the textarea value is cleared | `CustomEvent<HTMLBqTextareaElement>` |
+| `bqFocus` | Emitted when the textarea receives focus | `CustomEvent<HTMLBqTextareaElement>` |
+| `bqInput` | Emitted on every value change (keystroke or paste) | `CustomEvent<{ value: string; el: HTMLBqTextareaElement }>` |
+
+### Slots
+
+| Slot | Description |
+|---|---|
+| `label` | The textarea label displayed above the control |
+| `helper-text` | Optional helper text or icon shown below the control |
+
+### Shadow parts
+
+| Part | Description |
+|---|---|
+| `base` | The component's base wrapper |
+| `input` | The native `<textarea>` element |
+| `label` | The `<label>` element |
+| `helper-info` | The helper info container below the textarea |
+| `helper-text` | The helper text element |
+| `helper-counter` | The character counter element |
+
+### CSS custom properties
+
+<Expandable title="CSS variables" defaultOpen={true}>
+  | Variable | Description | Default |
+  |---|---|---|
+  | `--bq-textarea--background-color` | Textarea background color | `transparent` |
+  | `--bq-textarea--border-color` | Textarea border color | `var(--bq-stroke--tertiary)` |
+  | `--bq-textarea--border-color-focus` | Textarea border color on focus | `var(--bq-stroke--brand)` |
+  | `--bq-textarea--border-radius` | Textarea border radius | `var(--bq-radius--s)` |
+  | `--bq-textarea--border-width` | Textarea border width | `var(--bq-stroke-s)` |
+  | `--bq-textarea--border-style` | Textarea border style | `solid` |
+  | `--bq-textarea--helper-margin-top` | Helper text margin top | `var(--bq-spacing-xs)` |
+  | `--bq-textarea--helper-text-color` | Helper text color | `var(--bq-text--primary)` |
+  | `--bq-textarea--helper-text-size` | Helper text font size | `var(--bq-font-size--s)` |
+  | `--bq-textarea--label-margin-bottom` | Label margin bottom | `var(--bq-spacing-xs)` |
+  | `--bq-textarea--label-text-color` | Label text color | `var(--bq-text--primary)` |
+  | `--bq-textarea--label-text-size` | Label text font size | `var(--bq-font-size--s)` |
+  | `--bq-textarea--paddingY` | Textarea vertical padding | `var(--bq-spacing-s)` |
+  | `--bq-textarea--padding-start` | Textarea start padding | `var(--bq-spacing-m)` |
+  | `--bq-textarea--padding-end` | Textarea end padding | `var(--bq-spacing-m)` |
+  | `--bq-textarea--text-color` | Textarea text color | `var(--bq-text--primary)` |
+  | `--bq-textarea--text-size` | Textarea text font size | `var(--bq-font-size--m)` |
+  | `--bq-textarea--text-placeholder-color` | Placeholder text color | `var(--bq-text--secondary)` |
+</Expandable>
+
+<Tip>
+  Learn more about [styling with shadow parts](/theming/styles) and [CSS custom properties](/theming/global-css-variables).
+</Tip>
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card horizontal title="Interactive playground" icon="code" href="https://storybook.beeq.design/?path=/story/components-textarea--default">
+    Explore textarea variants and states in Storybook
+  </Card>
+  <Card horizontal title="Source code" icon="github" href="https://github.com/Endava/BEEQ/tree/main/packages/beeq/src/components/textarea">
+    View the component source on GitHub
+  </Card>
+</CardGroup>

--- a/apps/beeq-docs/components/textarea.mdx
+++ b/apps/beeq-docs/components/textarea.mdx
@@ -131,14 +131,25 @@ Use the default textarea when you need a standard multi-line text input. Provide
       </BqTextarea>
     );
     ```
-    ```html Angular
-    <bq-textarea placeholder="Placeholder...">
-      <label slot="label">Label</label>
-      <span slot="helper-text">
-        <bq-icon name="star"></bq-icon>
-        Helper text
-      </span>
-    </bq-textarea>
+    ```ts Angular
+    import { Component } from "@angular/core";
+    import { BqIcon, BqTextarea } from "@beeq/angular/standalone";
+
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqIcon, BqTextarea],
+      template: `
+        <bq-textarea placeholder="Placeholder...">
+          <label slot="label">Label</label>
+          <span slot="helper-text">
+            <bq-icon name="star"></bq-icon>
+            Helper text
+          </span>
+        </bq-textarea>
+      `,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue
     <script setup lang="ts">
@@ -211,17 +222,28 @@ Pre-populate your textarea with an initial `value` attribute to streamline user 
       </BqTextarea>
     );
     ```
-    ```html Angular
-    <bq-textarea
-      placeholder="Placeholder..."
-      value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
-    >
-      <label slot="label">Label</label>
-      <span slot="helper-text">
-        <bq-icon name="star"></bq-icon>
-        Helper text
-      </span>
-    </bq-textarea>
+    ```ts Angular
+    import { Component } from "@angular/core";
+    import { BqIcon, BqTextarea } from "@beeq/angular/standalone";
+
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqIcon, BqTextarea],
+      template: `
+        <bq-textarea
+          placeholder="Placeholder..."
+          value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
+        >
+          <label slot="label">Label</label>
+          <span slot="helper-text">
+            <bq-icon name="star"></bq-icon>
+            Helper text
+          </span>
+        </bq-textarea>
+      `,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue
     <script setup lang="ts">
@@ -302,18 +324,29 @@ Set `disabled` when the field is not currently available for interaction. Use it
       </BqTextarea>
     );
     ```
-    ```html Angular
-    <bq-textarea
-      disabled
-      placeholder="Placeholder..."
-      value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
-    >
-      <label slot="label">Label</label>
-      <span slot="helper-text">
-        <bq-icon name="star"></bq-icon>
-        Helper text
-      </span>
-    </bq-textarea>
+    ```ts Angular
+    import { Component } from "@angular/core";
+    import { BqIcon, BqTextarea } from "@beeq/angular/standalone";
+
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqIcon, BqTextarea],
+      template: `
+        <bq-textarea
+          disabled
+          placeholder="Placeholder..."
+          value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
+        >
+          <label slot="label">Label</label>
+          <span slot="helper-text">
+            <bq-icon name="star"></bq-icon>
+            Helper text
+          </span>
+        </bq-textarea>
+      `,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue
     <script setup lang="ts">
@@ -413,23 +446,34 @@ Add `disable-resize` to prevent users from resizing the textarea. This is useful
       </>
     );
     ```
-    ```html Angular
-    <div class="textarea--resize-group">
-      <bq-textarea placeholder="Resize is enabled">
-        <label slot="label">Label</label>
-        <span slot="helper-text">
-          <bq-icon name="star"></bq-icon>
-          Helper text
-        </span>
-      </bq-textarea>
-      <bq-textarea disable-resize placeholder="Resize is disabled">
-        <label slot="label">Label</label>
-        <span slot="helper-text">
-          <bq-icon name="star"></bq-icon>
-          Helper text
-        </span>
-      </bq-textarea>
-    </div>
+    ```ts Angular
+    import { Component } from "@angular/core";
+    import { BqIcon, BqTextarea } from "@beeq/angular/standalone";
+
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqIcon, BqTextarea],
+      template: `
+        <div class="textarea--resize-group">
+          <bq-textarea placeholder="Resize is enabled">
+            <label slot="label">Label</label>
+            <span slot="helper-text">
+              <bq-icon name="star"></bq-icon>
+              Helper text
+            </span>
+          </bq-textarea>
+          <bq-textarea disable-resize placeholder="Resize is disabled">
+            <label slot="label">Label</label>
+            <span slot="helper-text">
+              <bq-icon name="star"></bq-icon>
+              Helper text
+            </span>
+          </bq-textarea>
+        </div>
+      `,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue
     <script setup lang="ts">
@@ -518,18 +562,29 @@ Set `maxlength` to limit the number of characters users can enter. A character c
       </BqTextarea>
     );
     ```
-    ```html Angular
-    <bq-textarea
-      maxlength="100"
-      placeholder="Placeholder..."
-      value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
-    >
-      <label slot="label">Label</label>
-      <span slot="helper-text">
-        <bq-icon name="star"></bq-icon>
-        Helper text
-      </span>
-    </bq-textarea>
+    ```ts Angular
+    import { Component } from "@angular/core";
+    import { BqIcon, BqTextarea } from "@beeq/angular/standalone";
+
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqIcon, BqTextarea],
+      template: `
+        <bq-textarea
+          maxlength="100"
+          placeholder="Placeholder..."
+          value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+        >
+          <label slot="label">Label</label>
+          <span slot="helper-text">
+            <bq-icon name="star"></bq-icon>
+            Helper text
+          </span>
+        </bq-textarea>
+      `,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue
     <script setup lang="ts">
@@ -609,18 +664,29 @@ Set `readonly` to display the value without allowing edits. Unlike `disabled`, a
       </BqTextarea>
     );
     ```
-    ```html Angular
-    <bq-textarea
-      placeholder="Placeholder..."
-      readonly
-      value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
-    >
-      <label slot="label">Label</label>
-      <span slot="helper-text">
-        <bq-icon name="star"></bq-icon>
-        Helper text
-      </span>
-    </bq-textarea>
+    ```ts Angular
+    import { Component } from "@angular/core";
+    import { BqIcon, BqTextarea } from "@beeq/angular/standalone";
+
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqIcon, BqTextarea],
+      template: `
+        <bq-textarea
+          placeholder="Placeholder..."
+          readonly
+          value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
+        >
+          <label slot="label">Label</label>
+          <span slot="helper-text">
+            <bq-icon name="star"></bq-icon>
+            Helper text
+          </span>
+        </bq-textarea>
+      `,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue
     <script setup lang="ts">
@@ -786,45 +852,56 @@ Set `validation-status` to `error`, `warning`, or `success` to communicate the s
       </>
     );
     ```
-    ```html Angular
-    <div class="textarea--validation-group">
-      <bq-textarea
-        maxlength="100"
-        placeholder="Placeholder..."
-        validation-status="error"
-        value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
-      >
-        <label slot="label">Label</label>
-        <span slot="helper-text">
-          <bq-icon name="star"></bq-icon>
-          Helper text
-        </span>
-      </bq-textarea>
-      <bq-textarea
-        maxlength="100"
-        placeholder="Placeholder..."
-        validation-status="warning"
-        value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
-      >
-        <label slot="label">Label</label>
-        <span slot="helper-text">
-          <bq-icon name="star"></bq-icon>
-          Helper text
-        </span>
-      </bq-textarea>
-      <bq-textarea
-        maxlength="100"
-        placeholder="Placeholder..."
-        validation-status="success"
-        value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
-      >
-        <label slot="label">Label</label>
-        <span slot="helper-text">
-          <bq-icon name="star"></bq-icon>
-          Helper text
-        </span>
-      </bq-textarea>
-    </div>
+    ```ts Angular
+    import { Component } from "@angular/core";
+    import { BqIcon, BqTextarea } from "@beeq/angular/standalone";
+
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqIcon, BqTextarea],
+      template: `
+        <div class="textarea--validation-group">
+          <bq-textarea
+            maxlength="100"
+            placeholder="Placeholder..."
+            validation-status="error"
+            value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+          >
+            <label slot="label">Label</label>
+            <span slot="helper-text">
+              <bq-icon name="star"></bq-icon>
+              Helper text
+            </span>
+          </bq-textarea>
+          <bq-textarea
+            maxlength="100"
+            placeholder="Placeholder..."
+            validation-status="warning"
+            value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+          >
+            <label slot="label">Label</label>
+            <span slot="helper-text">
+              <bq-icon name="star"></bq-icon>
+              Helper text
+            </span>
+          </bq-textarea>
+          <bq-textarea
+            maxlength="100"
+            placeholder="Placeholder..."
+            validation-status="success"
+            value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+          >
+            <label slot="label">Label</label>
+            <span slot="helper-text">
+              <bq-icon name="star"></bq-icon>
+              Helper text
+            </span>
+          </bq-textarea>
+        </div>
+      `,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue
     <script setup lang="ts">

--- a/apps/beeq-docs/components/textarea.mdx
+++ b/apps/beeq-docs/components/textarea.mdx
@@ -140,14 +140,20 @@ Use the default textarea when you need a standard multi-line text input. Provide
       </span>
     </bq-textarea>
     ```
-    ```html Vue
-    <bq-textarea placeholder="Placeholder...">
-      <label slot="label">Label</label>
-      <span slot="helper-text">
-        <bq-icon name="star"></bq-icon>
-        Helper text
-      </span>
-    </bq-textarea>
+    ```vue Vue
+    <script setup lang="ts">
+    import { BqIcon, BqTextarea } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqTextarea placeholder="Placeholder...">
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <BqIcon name="star" />
+          Helper text
+        </span>
+      </BqTextarea>
+    </template>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -217,17 +223,23 @@ Pre-populate your textarea with an initial `value` attribute to streamline user 
       </span>
     </bq-textarea>
     ```
-    ```html Vue
-    <bq-textarea
-      placeholder="Placeholder..."
-      value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
-    >
-      <label slot="label">Label</label>
-      <span slot="helper-text">
-        <bq-icon name="star"></bq-icon>
-        Helper text
-      </span>
-    </bq-textarea>
+    ```vue Vue
+    <script setup lang="ts">
+    import { BqIcon, BqTextarea } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqTextarea
+        placeholder="Placeholder..."
+        value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
+      >
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <BqIcon name="star" />
+          Helper text
+        </span>
+      </BqTextarea>
+    </template>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -303,18 +315,24 @@ Set `disabled` when the field is not currently available for interaction. Use it
       </span>
     </bq-textarea>
     ```
-    ```html Vue
-    <bq-textarea
-      disabled
-      placeholder="Placeholder..."
-      value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
-    >
-      <label slot="label">Label</label>
-      <span slot="helper-text">
-        <bq-icon name="star"></bq-icon>
-        Helper text
-      </span>
-    </bq-textarea>
+    ```vue Vue
+    <script setup lang="ts">
+    import { BqIcon, BqTextarea } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqTextarea
+        disabled
+        placeholder="Placeholder..."
+        value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
+      >
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <BqIcon name="star" />
+          Helper text
+        </span>
+      </BqTextarea>
+    </template>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -413,23 +431,29 @@ Add `disable-resize` to prevent users from resizing the textarea. This is useful
       </bq-textarea>
     </div>
     ```
-    ```html Vue
-    <div class="textarea--resize-group">
-      <bq-textarea placeholder="Resize is enabled">
-        <label slot="label">Label</label>
-        <span slot="helper-text">
-          <bq-icon name="star"></bq-icon>
-          Helper text
-        </span>
-      </bq-textarea>
-      <bq-textarea disableResize placeholder="Resize is disabled">
-        <label slot="label">Label</label>
-        <span slot="helper-text">
-          <bq-icon name="star"></bq-icon>
-          Helper text
-        </span>
-      </bq-textarea>
-    </div>
+    ```vue Vue
+    <script setup lang="ts">
+    import { BqIcon, BqTextarea } from "@beeq/vue";
+    </script>
+
+    <template>
+      <div class="textarea--resize-group">
+        <BqTextarea placeholder="Resize is enabled">
+          <label slot="label">Label</label>
+          <span slot="helper-text">
+            <BqIcon name="star" />
+            Helper text
+          </span>
+        </BqTextarea>
+        <BqTextarea :disableResize="true" placeholder="Resize is disabled">
+          <label slot="label">Label</label>
+          <span slot="helper-text">
+            <BqIcon name="star" />
+            Helper text
+          </span>
+        </BqTextarea>
+      </div>
+    </template>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -507,18 +531,24 @@ Set `maxlength` to limit the number of characters users can enter. A character c
       </span>
     </bq-textarea>
     ```
-    ```html Vue
-    <bq-textarea
-      :maxlength="100"
-      placeholder="Placeholder..."
-      value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
-    >
-      <label slot="label">Label</label>
-      <span slot="helper-text">
-        <bq-icon name="star"></bq-icon>
-        Helper text
-      </span>
-    </bq-textarea>
+    ```vue Vue
+    <script setup lang="ts">
+    import { BqIcon, BqTextarea } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqTextarea
+        :maxlength="100"
+        placeholder="Placeholder..."
+        value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+      >
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <BqIcon name="star" />
+          Helper text
+        </span>
+      </BqTextarea>
+    </template>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -592,18 +622,24 @@ Set `readonly` to display the value without allowing edits. Unlike `disabled`, a
       </span>
     </bq-textarea>
     ```
-    ```html Vue
-    <bq-textarea
-      placeholder="Placeholder..."
-      readonly
-      value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
-    >
-      <label slot="label">Label</label>
-      <span slot="helper-text">
-        <bq-icon name="star"></bq-icon>
-        Helper text
-      </span>
-    </bq-textarea>
+    ```vue Vue
+    <script setup lang="ts">
+    import { BqIcon, BqTextarea } from "@beeq/vue";
+    </script>
+
+    <template>
+      <BqTextarea
+        placeholder="Placeholder..."
+        readonly
+        value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
+      >
+        <label slot="label">Label</label>
+        <span slot="helper-text">
+          <BqIcon name="star" />
+          Helper text
+        </span>
+      </BqTextarea>
+    </template>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -790,45 +826,51 @@ Set `validation-status` to `error`, `warning`, or `success` to communicate the s
       </bq-textarea>
     </div>
     ```
-    ```html Vue
-    <div class="textarea--validation-group">
-      <bq-textarea
-        :maxlength="100"
-        placeholder="Placeholder..."
-        validationStatus="error"
-        value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
-      >
-        <label slot="label">Label</label>
-        <span slot="helper-text">
-          <bq-icon name="star"></bq-icon>
-          Helper text
-        </span>
-      </bq-textarea>
-      <bq-textarea
-        :maxlength="100"
-        placeholder="Placeholder..."
-        validationStatus="warning"
-        value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
-      >
-        <label slot="label">Label</label>
-        <span slot="helper-text">
-          <bq-icon name="star"></bq-icon>
-          Helper text
-        </span>
-      </bq-textarea>
-      <bq-textarea
-        :maxlength="100"
-        placeholder="Placeholder..."
-        validationStatus="success"
-        value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
-      >
-        <label slot="label">Label</label>
-        <span slot="helper-text">
-          <bq-icon name="star"></bq-icon>
-          Helper text
-        </span>
-      </bq-textarea>
-    </div>
+    ```vue Vue
+    <script setup lang="ts">
+    import { BqIcon, BqTextarea } from "@beeq/vue";
+    </script>
+
+    <template>
+      <div class="textarea--validation-group">
+        <BqTextarea
+          :maxlength="100"
+          placeholder="Placeholder..."
+          validationStatus="error"
+          value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+        >
+          <label slot="label">Label</label>
+          <span slot="helper-text">
+            <BqIcon name="star" />
+            Helper text
+          </span>
+        </BqTextarea>
+        <BqTextarea
+          :maxlength="100"
+          placeholder="Placeholder..."
+          validationStatus="warning"
+          value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+        >
+          <label slot="label">Label</label>
+          <span slot="helper-text">
+            <BqIcon name="star" />
+            Helper text
+          </span>
+        </BqTextarea>
+        <BqTextarea
+          :maxlength="100"
+          placeholder="Placeholder..."
+          validationStatus="success"
+          value="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+        >
+          <label slot="label">Label</label>
+          <span slot="helper-text">
+            <BqIcon name="star" />
+            Helper text
+          </span>
+        </BqTextarea>
+      </div>
+    </template>
     ```
   </CodeGroup>
 </CodeLivePreview>


### PR DESCRIPTION
## Description

This PR expands the Mintlify documentation site with a new batch of migrated component pages, aligning them with the documentation structure established by earlier migrations.

Included in this PR:
- migrate `Drawer` docs to Mintlify
- migrate `Slider` docs to Mintlify
- migrate `Switch` docs to Mintlify
- migrate `Textarea` docs to Mintlify
- migrate `Tag` docs to Mintlify

## Documentation

All changes are documentation-only. No component source code was modified.

- `apps/beeq-docs/components/drawer.mdx`
- `apps/beeq-docs/components/slider.mdx`
- `apps/beeq-docs/components/switch.mdx`
- `apps/beeq-docs/components/tab.mdx`
- `apps/beeq-docs/components/tag.mdx`
- `apps/beeq-docs/components/textarea.mdx`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [ ] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes

- ❌ SVG assets (overview, anatomy, design guideline images) are still pending for all pages in this batch — placeholder `<Frame>` image paths are in place and will be replaced once assets are delivered.