### PR TITLE
docs: migrate docs theming (overview, global-css-variable, styles, custom-theme) to Mintlify

### DIFF
--- a/apps/beeq-docs/docs.json
+++ b/apps/beeq-docs/docs.json
@@ -80,7 +80,7 @@
             "pages": [
               "theming/themes-and-modes",
               "theming/global-css-variables",
-              "theming/styles",
+              "theming/component-css-variables",
               "theming/custom-theme"
             ]
           }

--- a/apps/beeq-docs/docs.json
+++ b/apps/beeq-docs/docs.json
@@ -78,7 +78,7 @@
           {
             "group": "Theming & customization",
             "pages": [
-              "theming/overview",
+              "theming/themes-and-modes",
               "theming/global-css-variables",
               "theming/styles",
               "theming/custom-theme"

--- a/apps/beeq-docs/getting-started/for-designers.mdx
+++ b/apps/beeq-docs/getting-started/for-designers.mdx
@@ -137,7 +137,7 @@ To change them: open the **Theme Collection** in Figma Variables, find the brand
 If a project requires more than just color changes — say, a rounder button corner radius — you can add custom tokens to the Theme Collection. Create a token (e.g., `button-roundness`), assign different values per theme, then replace the default token on the component. The same pattern works for other properties like spacing and shadow.
 
 <Tip>
-  The **[Theming overview](/theming/overview)** and **[Global CSS Variables](/theming/global-css-variables)** pages explain how the token system works across both Figma and code — useful reading if you're working closely with a developer on a custom theme.
+  The **[Theming overview](/theming/themes-and-modes)** and **[Global CSS Variables](/theming/global-css-variables)** pages explain how the token system works across both Figma and code — useful reading if you're working closely with a developer on a custom theme.
 </Tip>
 
 ---
@@ -190,6 +190,6 @@ The BEEQ visual language — colors, type, spacing, and the rest — is document
 ## What to do next
 
 - Browse **[Components](/components/overview)** to see all available building blocks, with interactive examples and usage guidelines.
-- Explore **[Theming](/theming/overview)** to understand how customization works beyond the basics.
+- Explore **[Theming](/theming/themes-and-modes)** to understand how customization works beyond the basics.
 - Review recent changes in the **[Changelog](/releases/changelog)** to stay up to date.
 - Reach out at [beeq@endava.com](mailto:beeq@endava.com) or open a discussion on [GitHub](https://github.com/Endava/BEEQ/issues) if you get stuck or have a question.

--- a/apps/beeq-docs/getting-started/for-developers.mdx
+++ b/apps/beeq-docs/getting-started/for-developers.mdx
@@ -42,4 +42,4 @@ BEEQ supports multiple integration paths depending on your stack and rendering m
 - Start with [Installation](/getting-started/installation) to understand shared setup requirements.
 - Open the framework guide that matches your stack.
 - Explore the [Components overview](/components/overview) once your setup is ready.
-- Review [Theming](/theming/overview) if your project needs customization.
+- Review [Theming](/theming/themes-and-modes) if your project needs customization.

--- a/apps/beeq-docs/guides/frameworks/react.mdx
+++ b/apps/beeq-docs/guides/frameworks/react.mdx
@@ -468,7 +468,7 @@ Use explicit event types when:
   <Card title="Explore components" href="/components/button" icon="boxes-stacked" iconType="duotone">
     Start with a real component page to see props, events, slots, and framework examples.
   </Card>
-  <Card title="Customize the theme" href="/theming/overview" icon="palette" iconType="duotone">
+  <Card title="Customize the theme" href="/theming/themes-and-modes" icon="palette" iconType="duotone">
     Review theming options if your product needs brand customization.
   </Card>
   <Card title="Open Storybook" href="https://storybook.beeq.design" icon="book" iconType="duotone">

--- a/apps/beeq-docs/index.mdx
+++ b/apps/beeq-docs/index.mdx
@@ -936,7 +936,7 @@ import { CodeLivePreview } from "/snippets/CodeLivePreview.jsx";
       <Card title="Component Library" icon="puzzle-piece" href="/components/overview">
         Browse all 37 production-ready components with live examples.
       </Card>
-      <Card title="Theming" icon="palette" href="/theming/overview">
+      <Card title="Theming" icon="palette" href="/theming/themes-and-modes">
         Learn how to fully customize BEEQ with CSS tokens for your brand.
       </Card>
       <Card title="GitHub" icon="github" href="https://github.com/Endava/BEEQ">

--- a/apps/beeq-docs/theming/component-css-variables.mdx
+++ b/apps/beeq-docs/theming/component-css-variables.mdx
@@ -79,7 +79,7 @@ Applies the custom styles to every `bq-badge` in the application.
       flex-direction: row !important;
       flex-wrap: wrap !important;
     }
-    
+
     bq-badge {
       --bq-badge--background-color: var(--bq-green-400);
       --bq-badge--box-shadow: var(--bq-box-shadow--l);
@@ -94,7 +94,7 @@ Applies the custom styles to every `bq-badge` in the application.
     <bq-badge>99+</bq-badge>
 `}>
   <CodeGroup>
-    ```css CSS icon="css3"
+    ```css CSS icon="css"
     bq-badge {
       --bq-badge--background-color: var(--bq-green-400);
       --bq-badge--box-shadow: var(--bq-box-shadow--l);
@@ -113,7 +113,7 @@ Applies the custom styles to every `bq-badge` in the application.
 
     ```jsx React icon="react"
     import { BqBadge } from "@beeq/react";
-    // Import the CSS override in your global stylesheet (see CSS tab)
+    // Import the CSS override in your global stylesheet
 
     <BqBadge size="small" />
     <BqBadge size="medium" />
@@ -124,8 +124,9 @@ Applies the custom styles to every `bq-badge` in the application.
     import { Component } from "@angular/core";
     import { BqBadge } from "@beeq/angular/standalone";
 
+    // Import the CSS override in your global stylesheet
+
     @Component({
-      selector: "app-root",
       standalone: true,
       imports: [BqBadge],
       template: `
@@ -134,13 +135,13 @@ Applies the custom styles to every `bq-badge` in the application.
         <bq-badge>99+</bq-badge>
       `,
     })
-    export class AppComponent {}
+    export class BadgeGlobalOverrideExample {}
     ```
 
     ```vue Vue icon="vuejs"
     <script setup lang="ts">
     import { BqBadge } from "@beeq/vue";
-    // Import the CSS override in your global stylesheet (see CSS tab)
+    // Import the CSS override in your global stylesheet
     </script>
 
     <template>
@@ -162,7 +163,7 @@ Only the `bq-badge` elements with the matching CSS class will have the overridde
       flex-direction: row !important;
       flex-wrap: wrap !important;
     }
-    
+
     bq-badge.success {
       --bq-badge--background-color: var(--bq-green-400);
       --bq-badge--box-shadow: var(--bq-box-shadow--l);
@@ -179,7 +180,7 @@ Only the `bq-badge` elements with the matching CSS class will have the overridde
   <bq-badge class="success">completed</bq-badge>
 `}>
   <CodeGroup>
-    ```css CSS icon="css3"
+    ```css CSS icon="css"
     bq-badge.success {
       --bq-badge--background-color: var(--bq-green-400);
       --bq-badge--box-shadow: var(--bq-box-shadow--l);
@@ -199,7 +200,7 @@ Only the `bq-badge` elements with the matching CSS class will have the overridde
 
     ```jsx React icon="react"
     import { BqBadge } from "@beeq/react";
-    // Import the CSS override in your global stylesheet (see CSS tab)
+    // Import the CSS override in your global stylesheet
 
     <BqBadge size="small" />
     <BqBadge size="medium" />
@@ -211,8 +212,9 @@ Only the `bq-badge` elements with the matching CSS class will have the overridde
     import { Component } from "@angular/core";
     import { BqBadge } from "@beeq/angular/standalone";
 
+    // Import the CSS override in your global stylesheet
+
     @Component({
-      selector: "app-root",
       standalone: true,
       imports: [BqBadge],
       template: `
@@ -222,13 +224,13 @@ Only the `bq-badge` elements with the matching CSS class will have the overridde
         <bq-badge class="success">completed</bq-badge>
       `,
     })
-    export class AppComponent {}
+    export class BadgeTargetedOverrideExample {}
     ```
 
     ```vue Vue icon="vuejs"
     <script setup lang="ts">
     import { BqBadge } from "@beeq/vue";
-    // Import the CSS override in your global stylesheet (see CSS tab)
+    // Import the CSS override in your global stylesheet
     </script>
 
     <template>
@@ -249,43 +251,72 @@ Only the `bq-badge` elements with the matching CSS class will have the overridde
   <Card>
     <span className="flex items-center mr-2 text-lg font-medium" role="heading">
       <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
-      Use semantic tokens
+      Do
     </span>
-    Prefer declarative color variables (`--bq-background--primary`) over primitive values (`--bq-grey-100`) in your custom themes for better consistency and automatic mode switching.
+
+    Prefer declarative color variables (`--bq-background--primary`) over primitive values (`--bq-grey-100`) in your custom themes for better consistency and automatic light/dark mode switching.
   </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+
+    Do not hardcode raw hex values (e.g. `#ffffff`, `#1f2937`) in component overrides — they will not adapt to theme or mode changes automatically.
+  </Card>
+
   <Card>
     <span className="flex items-center mr-2 text-lg font-medium" role="heading">
       <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
-      Test both modes
+      Do
     </span>
-    Always test your custom theme in both light and dark modes to ensure proper contrast and readability.
+
+    Use CSS classes or component selectors to scope component overrides to specific instances and avoid unintended side effects elsewhere in the app.
   </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+
+    Do not apply a global component override (e.g. `bq-badge { ... }`) unless you intentionally want it to affect every instance across the entire application.
+  </Card>
+
   <Card>
     <span className="flex items-center mr-2 text-lg font-medium" role="heading">
       <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
-      Scope component overrides
+      Do
     </span>
-    When customizing individual components, use CSS classes or component selectors to scope your changes and avoid unintended side effects.
+
+    Always test your component overrides in both light and dark modes to verify proper contrast, readability, and visual consistency.
   </Card>
+
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
+    </span>
+
+    Do not skip contrast validation. WCAG 2.1 Level AA requires a 4.5:1 ratio for normal text and 3:1 for large text — overriding colors without checking can fail these requirements.
+  </Card>
+
   <Card>
     <span className="flex items-center mr-2 text-lg font-medium" role="heading">
       <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
-      Maintain accessibility
+      Do
     </span>
-    Ensure sufficient color contrast ratios. WCAG 2.1 Level AA requires 4.5:1 for normal text and 3:1 for large text.
+
+    Use the [primitive color palette](/foundations/colors#primitive-color-scales) as the source for custom theme colors. It includes blue, coral, cyan, gold, green, indigo, iris, lime, magenta, orange, purple, red, sky, teal, volcano, and yellow — each with 10 shades (100–1000).
   </Card>
+
   <Card>
     <span className="flex items-center mr-2 text-lg font-medium" role="heading">
-      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
-      Use CSS variables for flexibility
+      <Icon className="mr-2" icon="xmark" iconType="solid" size={20} color="var(--bq-stroke--danger)" />
+      Don't
     </span>
-    Expose your own CSS variables if you are building reusable component patterns on top of BEEQ.
-  </Card>
-  <Card>
-    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
-      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
-      Leverage primitive colors
-    </span>
-    Use the extensive [primitive color palette](/foundations/colors) when defining theme colors. It includes blue, coral, cyan, gold, green, indigo, iris, lime, magenta, orange, purple, red, sky, teal, volcano, and yellow — each with 10 shades (100–1000).
+
+    Do not invent arbitrary color values outside the palette. Random hex colors break visual harmony and make future theme maintenance much harder.
   </Card>
 </CardGroup>

--- a/apps/beeq-docs/theming/custom-theme.mdx
+++ b/apps/beeq-docs/theming/custom-theme.mdx
@@ -327,7 +327,7 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
       background: var(--bq-background--primary) !important;
       color: var(--bq-text--primary);
       font-family: var(--bq-font-family);
-      padding: var(--bq-spacing-m);
+      padding: var(--bq-spacing-m) !important;
     }
 
     .toolbar {
@@ -655,64 +655,90 @@ export function TechFlowDemo() {
 }
 ```
 
-```html Angular icon="angular"
-<!-- app.component.html -->
-<!-- Standalone: import { BqTabGroup, BqTab, BqIcon, BqButton, BqInput } from "@beeq/angular/standalone" -->
-<!-- Modules: components are available after importing BeeQModule -->
-<!-- Apply the TechFlow theme in main.ts (import styles.css separately): -->
-<!-- document.documentElement.setAttribute('bq-theme', 'techflow'); -->
-<!-- document.documentElement.setAttribute('bq-mode', 'dark'); -->
+```ts Angular icon="angular"
+import { Component } from "@angular/core";
+import type { BqTabGroupCustomEvent } from "@beeq/core";
+import { BqButton, BqIcon, BqInput, BqTab, BqTabGroup } from "@beeq/angular/standalone";
 
-<div class="toolbar">
-  <bq-button size="small" appearance="ghost" (bqClick)="toggleTheme()">
-    <bq-icon [attr.name]="isDark ? 'sun' : 'moon'" slot="prefix"></bq-icon>
-    {{ isDark ? 'Light mode' : 'Dark mode' }}
-  </bq-button>
-</div>
+@Component({
+  selector: "app-root",
+  standalone: true,
+  imports: [BqButton, BqIcon, BqInput, BqTab, BqTabGroup],
+  template: `
+    <div class="toolbar">
+      <bq-button size="small" appearance="ghost" (bqClick)="toggleTheme()">
+        <bq-icon [attr.name]="isDark ? 'sun' : 'moon'" slot="prefix"></bq-icon>
+        {{ isDark ? 'Light mode' : 'Dark mode' }}
+      </bq-button>
+    </div>
 
-<bq-tab-group value="home" (bqChange)="onTabChange($event)">
-  <bq-tab tab-id="home">
-    <bq-icon name="house-line" slot="icon"></bq-icon>
-    Home
-  </bq-tab>
-  <bq-tab tab-id="profile">
-    <bq-icon name="user" slot="icon"></bq-icon>
-    Profile
-  </bq-tab>
-  <bq-tab tab-id="settings">
-    <bq-icon name="gear" slot="icon"></bq-icon>
-    Settings
-  </bq-tab>
-</bq-tab-group>
+    <bq-tab-group value="home" (bqChange)="onTabChange($event)">
+      <bq-tab tab-id="home">
+        <bq-icon name="house-line" slot="icon"></bq-icon>
+        Home
+      </bq-tab>
+      <bq-tab tab-id="profile">
+        <bq-icon name="user" slot="icon"></bq-icon>
+        Profile
+      </bq-tab>
+      <bq-tab tab-id="settings">
+        <bq-icon name="gear" slot="icon"></bq-icon>
+        Settings
+      </bq-tab>
+    </bq-tab-group>
 
-<section *ngIf="activeTab === 'home'">
-  <h1>Hello BEEQ(ers)!</h1>
-  <p>
-    This is an example of how to integrate the
-    <a class="bq-link" href="https://beeq.design/" target="_blank" rel="noopener noreferrer">
-      BEEQ component library
-    </a>
-    with HTML/TypeScript while using Vite as the bundler.
-  </p>
-  <section style="margin-block-start: var(--bq-spacing-l);">
-    <h2>Buttons</h2>
-    <bq-button appearance="primary">Primary Button</bq-button>
-    <bq-button appearance="secondary">Secondary Button</bq-button>
-    <bq-button variant="danger">Delete</bq-button>
-    <bq-button variant="ghost">Ghost</bq-button>
-  </section>
-  <section style="margin-block-start: var(--bq-spacing-l);">
-    <h2>Input</h2>
-    <bq-input placeholder="Placeholder">
-      <label slot="label">Input label</label>
-    </bq-input>
-  </section>
-</section>
-<section *ngIf="activeTab === 'profile'">
-  <h1>Profile tab!</h1>
-  <span>You can check the logic added to the Tab component in the <code>index.ts</code> file.</span>
-</section>
-<h1 *ngIf="activeTab === 'settings'">Settings tab!</h1>
+    @if (activeTab === "home") {
+      <section>
+        <h1>Hello BEEQ(ers)!</h1>
+        <p>
+          This is an example of how to integrate the
+          <a class="bq-link" href="https://beeq.design/" target="_blank" rel="noopener noreferrer">
+            BEEQ component library
+          </a>
+          with HTML/TypeScript while using Vite as the bundler.
+        </p>
+        <section style="margin-block-start: var(--bq-spacing-l);">
+          <h2>Buttons</h2>
+          <bq-button appearance="primary">Primary Button</bq-button>
+          <bq-button appearance="secondary">Secondary Button</bq-button>
+          <bq-button variant="danger">Delete</bq-button>
+          <bq-button variant="ghost">Ghost</bq-button>
+        </section>
+        <section style="margin-block-start: var(--bq-spacing-l);">
+          <h2>Input</h2>
+          <bq-input placeholder="Placeholder">
+            <label slot="label">Input label</label>
+          </bq-input>
+        </section>
+      </section>
+    }
+
+    @if (activeTab === "profile") {
+      <section>
+        <h1>Profile tab!</h1>
+        <span>You can check the logic added to the Tab component in the <code>index.ts</code> file.</span>
+      </section>
+    }
+
+    @if (activeTab === "settings") {
+      <h1>Settings tab!</h1>
+    }
+  `,
+})
+export class AppComponent {
+  activeTab = "home";
+  isDark = true;
+
+  onTabChange(event: BqTabGroupCustomEvent<{ value: string }>) {
+    this.activeTab = event.detail.value;
+  }
+
+  toggleTheme() {
+    const next = this.isDark ? "light" : "dark";
+    document.documentElement.setAttribute("bq-mode", next);
+    this.isDark = !this.isDark;
+  }
+}
 ```
 
 ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/theming/custom-theme.mdx
+++ b/apps/beeq-docs/theming/custom-theme.mdx
@@ -46,8 +46,17 @@ To create a custom theme, define your own set of CSS variables that override the
       --bq-warning: var(--bq-gold-600);
       --bq-info:    var(--bq-blue-600);
       --bq-focus:   var(--bq-blue-600);
+
+      /* Interactive state overlays */
+      --bq-state--hover:  rgba(0, 0, 0, 0.08);  /* Subtle hover overlay (light mode) */
+      --bq-state--active: rgba(0, 0, 0, 0.12); /* Pressed state overlay (light mode) */
     }
     ```
+
+    <Tip>
+      Override `--bq-state--hover` and `--bq-state--active` for each mode. In dark mode, use light
+      overlays (e.g. `rgba(255, 255, 255, 0.1)`) instead of dark ones.
+    </Tip>
   </Step>
 
   <Step title="Define light mode theme">
@@ -189,6 +198,10 @@ To create a custom theme, define your own set of CSS variables that override the
   <Step title="Apply your custom theme">
     Include your custom theme CSS file in your project and set the `bq-theme` and `bq-mode` attributes on the `<html>` element:
 
+    <Note>
+      Always load `beeq.css` **before** your custom theme CSS so that your variables correctly override the defaults.
+    </Note>
+
     ```html
     <!DOCTYPE html>
     <html lang="en" bq-theme="my-custom-theme" bq-mode="light">
@@ -209,15 +222,13 @@ To create a custom theme, define your own set of CSS variables that override the
     <html lang="en" bq-theme="my-custom-theme" bq-mode="dark">
     ```
 
-    <Tip>
-      You can also use CSS classes instead of HTML attributes:
+    You can also use CSS classes instead of HTML attributes:
 
-      ```html
-      <body class="my-custom-theme light"> ... </body>
-      <!-- or -->
-      <body class="my-custom-theme dark"> ... </body>
-      ```
-    </Tip>
+    ```html
+    <body class="my-custom-theme light"> ... </body>
+    <!-- or -->
+    <body class="my-custom-theme dark"> ... </body>
+    ```
   </Step>
 </Steps>
 
@@ -229,8 +240,9 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
 
 <CodeLivePreview code={`
   <style>
+    /* TechFlow — Base variables */
+
     :host {
-      /* TechFlow — Base variables */
       --bq-font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
       --bq-radius--none: 0;
       --bq-radius--xs2: 0.0625rem;
@@ -239,27 +251,36 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
       --bq-radius--m: 0.5rem;
       --bq-radius--l: 1rem;
       --bq-radius--full: 9999px;
+
       --bq-brand-light: #a8f0e6;
-      --bq-brand: #00d9c4;
-      --bq-brand-dark: #009b88;
+      --bq-brand: #00836e;
+      --bq-brand-dark: #005a4f;
+
       --bq-accent-light: #e8d5f2;
       --bq-accent: #9d4edd;
       --bq-accent-dark: #5a189a;
+
       --bq-success-light: #a1e4cb;
       --bq-success: #05b981;
       --bq-success-dark: #047857;
+
       --bq-danger-light: #fecaca;
       --bq-danger: #ef4444;
       --bq-danger-dark: #991b1b;
+
       --bq-warning-light: #fef3c7;
       --bq-warning: #f59e0b;
       --bq-warning-dark: #92400e;
+
       --bq-info-light: #bfdbfe;
       --bq-info: #3b82f6;
       --bq-info-dark: #1e3a8a;
+
       --bq-focus: #00d9c4;
+
       --bq-white: #ffffff;
       --bq-black: #000000;
+
       --bq-neutral-50: #f9fafb;
       --bq-neutral-100: #f3f4f6;
       --bq-neutral-200: #e5e7eb;
@@ -272,7 +293,13 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
       --bq-neutral-900: #111827;
       --bq-neutral-950: #0f172a;
       --bq-neutral-1000: #030712;
-      /* TechFlow — Dark mode declarative tokens */
+    }
+
+    /* TechFlow — Light mode declarative tokens */
+
+    :host([bq-theme="techflow"]),
+    :host(.techflow) {
+
       --bq-background--primary: #030712;
       --bq-background--secondary: #0f172a;
       --bq-background--tertiary: #1f2937;
@@ -280,6 +307,7 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
       --bq-background--inverse: #f9fafb;
       --bq-background--brand: #009b88;
       --bq-background--overlay: rgba(0, 0, 0, 0.7);
+
       --bq-icon--primary: #f3f4f6;
       --bq-icon--secondary: #9ca3af;
       --bq-icon--inverse: #1f2937;
@@ -289,6 +317,7 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
       --bq-icon--success: #34d399;
       --bq-icon--warning: #fbbf24;
       --bq-icon--danger: #f87171;
+
       --bq-stroke--primary: #374151;
       --bq-stroke--secondary: #4b5563;
       --bq-stroke--tertiary: #9ca3af;
@@ -298,6 +327,7 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
       --bq-stroke--success: #34d399;
       --bq-stroke--warning: #fbbf24;
       --bq-stroke--danger: #f87171;
+
       --bq-text--primary: #f9fafb;
       --bq-text--secondary: #9ca3af;
       --bq-text--inverse: #1f2937;
@@ -307,6 +337,7 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
       --bq-text--success: #34d399;
       --bq-text--warning: #fbbf24;
       --bq-text--danger: #f87171;
+
       --bq-ui--primary: #1f2937;
       --bq-ui--secondary: #374151;
       --bq-ui--tertiary: #4b5563;
@@ -320,32 +351,15 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
       --bq-ui--warning-alt: #f59e0b;
       --bq-ui--danger: #f87171;
       --bq-ui--danger-alt: #ef4444;
+
       --bq-state--hover: rgba(255, 255, 255, 0.1);
       --bq-state--active: rgba(255, 255, 255, 0.15);
-      flex-direction: column !important;
-      align-items: stretch !important;
-      background: var(--bq-background--primary) !important;
-      color: var(--bq-text--primary);
-      font-family: var(--bq-font-family);
-      padding: var(--bq-spacing-m) !important;
     }
 
-    .toolbar {
-      display: flex;
-      justify-content: flex-end;
-      margin-block-end: var(--bq-spacing-m);
-    }
+    /* TechFlow — Dark mode declarative tokens */
 
-    .tab-panel {
-      display: none;
-      padding: var(--bq-spacing-l);
-    }
-
-    .tab-panel.active {
-      display: block;
-    }
-
-    :host(.light) {
+    :host([bq-theme="techflow"][bq-mode="dark"]),
+    :host(.techflow.dark) {
       --bq-background--primary: #ffffff;
       --bq-background--secondary: #f9fafb;
       --bq-background--tertiary: #f3f4f6;
@@ -353,33 +367,37 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
       --bq-background--inverse: #111827;
       --bq-background--brand: #a8f0e6;
       --bq-background--overlay: rgba(0, 0, 0, 0.5);
+
       --bq-icon--primary: #1f2937;
       --bq-icon--secondary: #6b7280;
       --bq-icon--inverse: #f9fafb;
-      --bq-icon--brand: #00d9c4;
+      --bq-icon--brand: #00836e;
       --bq-icon--alt: #ffffff;
-      --bq-icon--info: #3b82f6;
-      --bq-icon--success: #05b981;
-      --bq-icon--warning: #f59e0b;
-      --bq-icon--danger: #ef4444;
+      --bq-icon--info: #1d4ed8;
+      --bq-icon--success: #047857;
+      --bq-icon--warning: #92400e;
+      --bq-icon--danger: #b91c1c;
+
       --bq-stroke--primary: #e5e7eb;
       --bq-stroke--secondary: #d1d5db;
       --bq-stroke--tertiary: #9ca3af;
       --bq-stroke--inverse: #ffffff;
-      --bq-stroke--brand: #00d9c4;
+      --bq-stroke--brand: #00836e;
       --bq-stroke--alt: #f3f4f6;
-      --bq-stroke--success: #05b981;
-      --bq-stroke--warning: #f59e0b;
-      --bq-stroke--danger: #ef4444;
+      --bq-stroke--success: #047857;
+      --bq-stroke--warning: #92400e;
+      --bq-stroke--danger: #b91c1c;
+
       --bq-text--primary: #111827;
       --bq-text--secondary: #6b7280;
       --bq-text--inverse: #f9fafb;
-      --bq-text--brand: #00d9c4;
+      --bq-text--brand: #00836e;
       --bq-text--alt: #ffffff;
-      --bq-text--info: #3b82f6;
-      --bq-text--success: #05b981;
-      --bq-text--warning: #f59e0b;
-      --bq-text--danger: #ef4444;
+      --bq-text--info: #1d4ed8;
+      --bq-text--success: #047857;
+      --bq-text--warning: #92400e;
+      --bq-text--danger: #b91c1c;
+
       --bq-ui--primary: #ffffff;
       --bq-ui--secondary: #f3f4f6;
       --bq-ui--tertiary: #e5e7eb;
@@ -393,15 +411,47 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
       --bq-ui--warning-alt: #fef3c7;
       --bq-ui--danger: #ef4444;
       --bq-ui--danger-alt: #fecaca;
+
       --bq-state--hover: rgba(0, 0, 0, 0.08);
       --bq-state--active: rgba(0, 0, 0, 0.12);
+    }
+
+    :host {
+      align-items: stretch !important;
+      flex-direction: column !important;
+      flex-flow: column nowrap !important;
+
+      color: var(--bq-text--primary);
+    }
+
+    .toolbar {
+      display: flex;
+      justify-content: flex-end;
+      margin-block-end: var(--bq-spacing-m);
+    }
+
+    .tab-panel {
+      display: none;
+      padding: var(--bq-spacing-l);
+
+      &.active {
+        display: block;
+      }
+
+      section {
+        margin-block-start: var(--bq-spacing-l);
+      }
+
+      section h1,
+      section h2 {
+        margin-block-end: var(--bq-spacing-m);
+      }
     }
   </style>
 
   <div class="toolbar">
-    <bq-button size="small" appearance="ghost" id="theme-toggle">
-      <bq-icon id="toggle-icon" name="sun" slot="prefix"></bq-icon>
-      <span id="toggle-label">Light mode</span>
+    <bq-button id="theme-toggle" appearance="secondary" label="Toggle theme" only-icon>
+      <bq-icon id="toggle-icon" name="sun"></bq-icon>
     </bq-button>
   </div>
 
@@ -423,20 +473,21 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
   <div class="tab-panel active" id="home">
     <h1>Hello BEEQ(ers)!</h1>
     <p>
-      This is an example of how to integrate the
+      This example shows how to create and apply a custom theme to
       <a class="bq-link" href="https://beeq.design/" target="_blank" rel="noopener noreferrer">
-        BEEQ component library
+        BEEQ components
       </a>
-      with HTML/TypeScript while using Vite as the bundler.
+      using CSS variables.
+      Try toggling the theme and switching between tabs to see how the colors adapt across components and modes.
     </p>
-    <section style="margin-block-start: var(--bq-spacing-l);">
+    <section>
       <h2>Buttons</h2>
       <bq-button appearance="primary">Primary Button</bq-button>
       <bq-button appearance="secondary">Secondary Button</bq-button>
       <bq-button variant="danger">Delete</bq-button>
       <bq-button variant="ghost">Ghost</bq-button>
     </section>
-    <section style="margin-block-start: var(--bq-spacing-l);">
+    <section>
       <h2>Input</h2>
       <bq-input placeholder="Placeholder">
         <label slot="label">Input label</label>
@@ -458,17 +509,23 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
 
   <script>
     (() => {
+      const hostBody = previewRoot.host;
+      hostBody.setAttribute('bq-theme', 'techflow');
+      hostBody.setAttribute('bq-mode', 'dark');
+
       const TAB_ACTIVE_CLASS = 'active';
       const bqTabElem = previewRoot.querySelector('bq-tab-group');
       const tabPanels = previewRoot.querySelectorAll('.tab-panel');
+
       const toggleBtn = previewRoot.querySelector('#theme-toggle');
       const toggleIcon = previewRoot.querySelector('#toggle-icon');
-      const toggleLabel = previewRoot.querySelector('#toggle-label');
 
       bqTabElem?.addEventListener('bqChange', (event) => {
         if (!tabPanels.length) return;
+
         const activeTab = event.detail.value;
         if (!activeTab) return;
+
         tabPanels.forEach((tabPanel) => {
           tabPanel.classList.remove(TAB_ACTIVE_CLASS);
           if (tabPanel.id === activeTab) tabPanel.classList.add(TAB_ACTIVE_CLASS);
@@ -476,131 +533,460 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
       });
 
       toggleBtn?.addEventListener('bqClick', () => {
-        const isLight = previewRoot.host.classList.toggle('light');
-        if (toggleIcon) toggleIcon.setAttribute('name', isLight ? 'moon' : 'sun');
-        if (toggleLabel) toggleLabel.textContent = isLight ? 'Dark mode' : 'Light mode';
+        const isDark = hostBody.getAttribute('bq-mode') === 'dark';
+        hostBody.setAttribute('bq-mode', isDark ? 'light' : 'dark');
+
+        if (!toggleIcon) return;
+
+        toggleIcon.setAttribute('name', isDark ? 'moon' : 'sun');
       });
     })();
   </script>
 `}>
-<CodeGroup>
-```html HTML icon="html5"
-<!DOCTYPE html>
-<html lang="en" bq-theme="techflow" bq-mode="dark">
-  <head>
-    <link rel="stylesheet" href="path/to/beeq.css">
-    <link rel="stylesheet" href="styles.css">
-  </head>
-  <body>
-    <div class="toolbar">
-      <bq-button size="small" appearance="ghost" id="theme-toggle">
-        <bq-icon id="toggle-icon" name="sun" slot="prefix"></bq-icon>
-        Light mode
-      </bq-button>
-    </div>
+  <CodeGroup>
+    ```css CSS icon="css" expandable
+    /* -------------------------------------------------------------------------- */
+    /* BASE THEME VARIABLES                                                       */
+    /* -------------------------------------------------------------------------- */
+    [bq-theme="techflow"],
+    .techflow {
+      --bq-font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      --bq-brand-light: #a8f0e6;
+      --bq-brand:       #00836e;
+      --bq-brand-dark:  #005a4f;
+      --bq-accent-light: #e8d5f2;
+      --bq-accent:       #9d4edd;
+      --bq-accent-dark:  #5a189a;
+      --bq-success-light: #a1e4cb;
+      --bq-success:       #05b981;
+      --bq-success-dark:  #047857;
+      --bq-danger-light:  #fecaca;
+      --bq-danger:        #ef4444;
+      --bq-danger-dark:   #991b1b;
+      --bq-warning-light: #fef3c7;
+      --bq-warning:       #f59e0b;
+      --bq-warning-dark:  #92400e;
+      --bq-info-light:    #bfdbfe;
+      --bq-info:          #3b82f6;
+      --bq-info-dark:     #1e3a8a;
+      --bq-focus:         #00836e;
+      --bq-white:         #ffffff;
+      --bq-black:         #000000;
+      --bq-neutral-50:    #f9fafb;
+      --bq-neutral-100:   #f3f4f6;
+      --bq-neutral-200:   #e5e7eb;
+      --bq-neutral-300:   #d1d5db;
+      --bq-neutral-400:   #9ca3af;
+      --bq-neutral-500:   #6b7280;
+      --bq-neutral-600:   #4b5563;
+      --bq-neutral-700:   #374151;
+      --bq-neutral-800:   #1f2937;
+      --bq-neutral-900:   #111827;
+      --bq-neutral-950:   #0f172a;
+      --bq-neutral-1000:  #030712;
+    }
 
-    <bq-tab-group value="home" id="tabs">
-      <bq-tab tab-id="home">
-        <bq-icon name="house-line" slot="icon"></bq-icon>
-        Home
-      </bq-tab>
-      <bq-tab tab-id="profile">
-        <bq-icon name="user" slot="icon"></bq-icon>
-        Profile
-      </bq-tab>
-      <bq-tab tab-id="settings">
-        <bq-icon name="gear" slot="icon"></bq-icon>
-        Settings
-      </bq-tab>
-    </bq-tab-group>
+    /* -------------------------------------------------------------------------- */
+    /* LIGHT MODE                                                                 */
+    /* -------------------------------------------------------------------------- */
+    [bq-theme="techflow"]:not([bq-mode]),
+    [bq-theme="techflow"][bq-mode="light"],
+    .techflow:not([bq-mode]),
+    .techflow.light {
+      --bq-background--primary:   #ffffff;
+      --bq-background--secondary: #f9fafb;
+      --bq-background--tertiary:  #f3f4f6;
+      --bq-background--alt:       #e5e7eb;
+      --bq-background--inverse:   #111827;
+      --bq-background--brand:     #a8f0e6;
+      --bq-background--overlay:   rgba(0, 0, 0, 0.5);
+      --bq-icon--primary:   #1f2937;
+      --bq-icon--secondary: #6b7280;
+      --bq-icon--inverse:   #f9fafb;
+      --bq-icon--brand:     #00836e;
+      --bq-icon--alt:       #ffffff;
+      --bq-icon--info:      #1d4ed8;
+      --bq-icon--success:   #047857;
+      --bq-icon--warning:   #92400e;
+      --bq-icon--danger:    #b91c1c;
+      --bq-stroke--primary:   #e5e7eb;
+      --bq-stroke--secondary: #d1d5db;
+      --bq-stroke--tertiary:  #9ca3af;
+      --bq-stroke--inverse:   #ffffff;
+      --bq-stroke--brand:     #00836e;
+      --bq-stroke--alt:       #f3f4f6;
+      --bq-stroke--success:   #047857;
+      --bq-stroke--warning:   #92400e;
+      --bq-stroke--danger:    #b91c1c;
+      --bq-text--primary:   #111827;
+      --bq-text--secondary: #6b7280;
+      --bq-text--inverse:   #f9fafb;
+      --bq-text--brand:     #00836e;
+      --bq-text--alt:       #ffffff;
+      --bq-text--info:      #1d4ed8;
+      --bq-text--success:   #047857;
+      --bq-text--warning:   #92400e;
+      --bq-text--danger:    #b91c1c;
+      --bq-ui--primary:     #ffffff;
+      --bq-ui--secondary:   #f3f4f6;
+      --bq-ui--tertiary:    #e5e7eb;
+      --bq-ui--inverse:     #111827;
+      --bq-ui--brand:       #00836e;
+      --bq-ui--brand-alt:   #a8f0e6;
+      --bq-ui--alt:         #f9fafb;
+      --bq-ui--success:     #047857;
+      --bq-ui--success-alt: #a1e4cb;
+      --bq-ui--warning:     #92400e;
+      --bq-ui--warning-alt: #fef3c7;
+      --bq-ui--danger:      #b91c1c;
+      --bq-ui--danger-alt:  #fecaca;
+      --bq-state--hover:    rgba(0, 0, 0, 0.08);
+      --bq-state--active:   rgba(0, 0, 0, 0.12);
+    }
 
-    <div class="tab-panel active" id="home">
-      <h1>Hello BEEQ(ers)!</h1>
-      <p>
-        This is an example of how to integrate the
-        <a class="bq-link" href="https://beeq.design/" target="_blank" rel="noopener noreferrer">
-          BEEQ component library
-        </a>
-        with HTML/TypeScript while using Vite as the bundler.
-      </p>
-      <section style="margin-block-start: var(--bq-spacing-l);">
-        <h2>Buttons</h2>
-        <bq-button appearance="primary">Primary Button</bq-button>
-        <bq-button appearance="secondary">Secondary Button</bq-button>
-        <bq-button variant="danger">Delete</bq-button>
-        <bq-button variant="ghost">Ghost</bq-button>
-      </section>
-      <section style="margin-block-start: var(--bq-spacing-l);">
-        <h2>Input</h2>
-        <bq-input placeholder="Placeholder">
-          <label slot="label">Input label</label>
-        </bq-input>
-      </section>
-    </div>
-    <div class="tab-panel" id="profile">
-      <h1>Profile tab!</h1>
-      <span>You can check the logic added to the Tab component in the <code>index.ts</code> file.</span>
-    </div>
-    <div class="tab-panel" id="settings">
-      <h1>Settings tab!</h1>
-    </div>
+    /* -------------------------------------------------------------------------- */
+    /* DARK MODE                                                                  */
+    /* -------------------------------------------------------------------------- */
+    [bq-theme="techflow"][bq-mode="dark"],
+    .techflow.dark {
+      --bq-background--primary:   #030712;
+      --bq-background--secondary: #0f172a;
+      --bq-background--tertiary:  #1f2937;
+      --bq-background--alt:       #374151;
+      --bq-background--inverse:   #f9fafb;
+      --bq-background--brand:     #009b88;
+      --bq-background--overlay:   rgba(0, 0, 0, 0.7);
+      --bq-icon--primary:   #f3f4f6;
+      --bq-icon--secondary: #9ca3af;
+      --bq-icon--inverse:   #1f2937;
+      --bq-icon--brand:     #00d9c4;
+      --bq-icon--alt:       #ffffff;
+      --bq-icon--info:      #60a5fa;
+      --bq-icon--success:   #34d399;
+      --bq-icon--warning:   #fbbf24;
+      --bq-icon--danger:    #f87171;
+      --bq-stroke--primary:   #374151;
+      --bq-stroke--secondary: #4b5563;
+      --bq-stroke--tertiary:  #9ca3af;
+      --bq-stroke--inverse:   #0f172a;
+      --bq-stroke--brand:     #00d9c4;
+      --bq-stroke--alt:       #1f2937;
+      --bq-stroke--success:   #34d399;
+      --bq-stroke--warning:   #fbbf24;
+      --bq-stroke--danger:    #f87171;
+      --bq-text--primary:   #f9fafb;
+      --bq-text--secondary: #9ca3af;
+      --bq-text--inverse:   #1f2937;
+      --bq-text--brand:     #00d9c4;
+      --bq-text--alt:       #ffffff;
+      --bq-text--info:      #60a5fa;
+      --bq-text--success:   #34d399;
+      --bq-text--warning:   #fbbf24;
+      --bq-text--danger:    #f87171;
+      --bq-ui--primary:     #1f2937;
+      --bq-ui--secondary:   #374151;
+      --bq-ui--tertiary:    #4b5563;
+      --bq-ui--inverse:     #f9fafb;
+      --bq-ui--brand:       #00d9c4;
+      --bq-ui--brand-alt:   #009b88;
+      --bq-ui--alt:         #0f172a;
+      --bq-ui--success:     #34d399;
+      --bq-ui--success-alt: #10b981;
+      --bq-ui--warning:     #fbbf24;
+      --bq-ui--warning-alt: #f59e0b;
+      --bq-ui--danger:      #f87171;
+      --bq-ui--danger-alt:  #ef4444;
+      --bq-state--hover:    rgba(255, 255, 255, 0.10);
+      --bq-state--active:   rgba(255, 255, 255, 0.15);
+    }
+    ```
 
-    <script type="module">
-      const TAB_ACTIVE_CLASS = 'active';
-      const bqTabElem = document.getElementById('tabs');
-      const tabPanels = document.querySelectorAll('.tab-panel');
-      const toggleBtn = document.getElementById('theme-toggle');
-      const toggleIcon = document.getElementById('toggle-icon');
+    ```html HTML icon="html5" expandable
+    <!DOCTYPE html>
+    <html lang="en" bq-theme="techflow" bq-mode="dark">
+      <head>
+        <link rel="stylesheet" href="path/to/beeq.css">
+        <link rel="stylesheet" href="styles.css">
+      </head>
+      <body>
+        <div class="toolbar">
+          <bq-button appearance="secondary" label="Toggle theme" only-icon id="theme-toggle">
+            <bq-icon id="toggle-icon" name="sun"></bq-icon>
+          </bq-button>
+        </div>
 
-      bqTabElem?.addEventListener('bqChange', (event) => {
-        const activeTab = event.detail.value;
-        tabPanels.forEach((panel) => {
-          panel.classList.toggle(TAB_ACTIVE_CLASS, panel.id === activeTab);
-        });
-      });
+        <bq-tab-group value="home" id="tabs">
+          <bq-tab tab-id="home">
+            <bq-icon name="house-line" slot="icon"></bq-icon>
+            Home
+          </bq-tab>
+          <bq-tab tab-id="profile">
+            <bq-icon name="user" slot="icon"></bq-icon>
+            Profile
+          </bq-tab>
+          <bq-tab tab-id="settings">
+            <bq-icon name="gear" slot="icon"></bq-icon>
+            Settings
+          </bq-tab>
+        </bq-tab-group>
 
-      toggleBtn?.addEventListener('bqClick', () => {
-        const isNowLight = document.documentElement.getAttribute('bq-mode') !== 'light';
-        document.documentElement.setAttribute('bq-mode', isNowLight ? 'light' : 'dark');
-        toggleIcon?.setAttribute('name', isNowLight ? 'moon' : 'sun');
-        if (toggleBtn.lastChild) toggleBtn.lastChild.textContent = isNowLight ? ' Dark mode' : ' Light mode';
-      });
+        <div class="tab-panel active" id="home">
+          <h1>Hello BEEQ(ers)!</h1>
+          <p>
+            This is an example of how to integrate the
+            <a class="bq-link" href="https://beeq.design/" target="_blank" rel="noopener noreferrer">
+              BEEQ component library
+            </a>
+            with HTML/TypeScript while using Vite as the bundler.
+          </p>
+          <section style="margin-block-start: var(--bq-spacing-l);">
+            <h2>Buttons</h2>
+            <bq-button appearance="primary">Primary Button</bq-button>
+            <bq-button appearance="secondary">Secondary Button</bq-button>
+            <bq-button variant="danger">Delete</bq-button>
+            <bq-button variant="ghost">Ghost</bq-button>
+          </section>
+          <section style="margin-block-start: var(--bq-spacing-l);">
+            <h2>Input</h2>
+            <bq-input placeholder="Placeholder">
+              <label slot="label">Input label</label>
+            </bq-input>
+          </section>
+        </div>
+        <div class="tab-panel" id="profile">
+          <h1>Profile tab!</h1>
+          <span>You can check the logic added to the Tab component in the <code>index.ts</code> file.</span>
+        </div>
+        <div class="tab-panel" id="settings">
+          <h1>Settings tab!</h1>
+        </div>
+
+        <script type="module">
+          const TAB_ACTIVE_CLASS = 'active';
+          const bqTabElem = document.getElementById('tabs');
+          const tabPanels = document.querySelectorAll('.tab-panel');
+          const toggleBtn = document.getElementById('theme-toggle');
+          const toggleIcon = document.getElementById('toggle-icon');
+
+          bqTabElem?.addEventListener('bqChange', (event) => {
+            const activeTab = event.detail.value;
+            tabPanels.forEach((panel) => {
+              panel.classList.toggle(TAB_ACTIVE_CLASS, panel.id === activeTab);
+            });
+          });
+
+          toggleBtn?.addEventListener('bqClick', () => {
+            const isNowLight = document.documentElement.getAttribute('bq-mode') !== 'light';
+            document.documentElement.setAttribute('bq-mode', isNowLight ? 'light' : 'dark');
+            if (toggleIcon) toggleIcon.setAttribute('name', isNowLight ? 'moon' : 'sun');
+          });
+        </script>
+      </body>
+    </html>
+    ```
+
+    ```jsx React icon="react" expandable
+    import { useState } from "react";
+    import { BqTabGroup, BqTab, BqIcon, BqButton, BqInput } from "@beeq/react";
+
+    // In main.tsx, apply the TechFlow theme (import styles.css separately):
+    // document.documentElement.setAttribute('bq-theme', 'techflow');
+    // document.documentElement.setAttribute('bq-mode', 'dark');
+
+    export function TechFlowDemo() {
+      const [activeTab, setActiveTab] = useState("home");
+      const [isDark, setIsDark] = useState(true);
+
+      function toggleTheme() {
+        const next = isDark ? "light" : "dark";
+        document.documentElement.setAttribute("bq-mode", next);
+        setIsDark(!isDark);
+      }
+
+      return (
+        <>
+          <div className="toolbar">
+            <BqButton appearance="secondary" label="Toggle theme" onlyIcon onBqClick={toggleTheme}>
+              <BqIcon name={isDark ? "sun" : "moon"} />
+            </BqButton>
+          </div>
+
+          <BqTabGroup
+            value="home"
+            onBqChange={(e: CustomEvent<{ value: string }>) => setActiveTab(e.detail.value)}
+          >
+            <BqTab tabId="home">
+              <BqIcon name="house-line" slot="icon" />
+              Home
+            </BqTab>
+            <BqTab tabId="profile">
+              <BqIcon name="user" slot="icon" />
+              Profile
+            </BqTab>
+            <BqTab tabId="settings">
+              <BqIcon name="gear" slot="icon" />
+              Settings
+            </BqTab>
+          </BqTabGroup>
+
+          {activeTab === "home" && (
+            <section>
+              <h1>Hello BEEQ(ers)!</h1>
+              <p>
+                This is an example of how to integrate the{" "}
+                <a className="bq-link" href="https://beeq.design/" target="_blank" rel="noopener noreferrer">
+                  BEEQ component library
+                </a>{" "}
+                with HTML/TypeScript while using Vite as the bundler.
+              </p>
+              <section style={{ marginBlockStart: "var(--bq-spacing-l)" }}>
+                <h2>Buttons</h2>
+                <BqButton appearance="primary">Primary Button</BqButton>
+                <BqButton appearance="secondary">Secondary Button</BqButton>
+                <BqButton variant="danger">Delete</BqButton>
+                <BqButton variant="ghost">Ghost</BqButton>
+              </section>
+              <section style={{ marginBlockStart: "var(--bq-spacing-l)" }}>
+                <h2>Input</h2>
+                <BqInput placeholder="Placeholder">
+                  <label slot="label">Input label</label>
+                </BqInput>
+              </section>
+            </section>
+          )}
+          {activeTab === "profile" && (
+            <section>
+              <h1>Profile tab!</h1>
+              <span>
+                You can check the logic added to the Tab component in the{" "}
+                <code>index.ts</code> file.
+              </span>
+            </section>
+          )}
+          {activeTab === "settings" && <h1>Settings tab!</h1>}
+        </>
+      );
+    }
+    ```
+
+    ```ts Angular icon="angular" expandable
+    import { Component, inject, signal } from "@angular/core";
+    import { DOCUMENT } from "@angular/common";
+    import { BqTabGroup, BqTab, BqIcon, BqButton, BqInput } from "@beeq/angular/standalone";
+
+    // Apply the TechFlow theme in main.ts (import styles.css separately):
+    // document.documentElement.setAttribute('bq-theme', 'techflow');
+    // document.documentElement.setAttribute('bq-mode', 'dark');
+
+    @Component({
+      standalone: true,
+      imports: [BqTabGroup, BqTab, BqIcon, BqButton, BqInput],
+      template: `
+        <div class="toolbar">
+          <bq-button appearance="secondary" label="Toggle theme" only-icon (bqClick)="toggleTheme()">
+            <bq-icon [attr.name]="isDark() ? 'sun' : 'moon'"></bq-icon>
+          </bq-button>
+        </div>
+
+        <bq-tab-group value="home" (bqChange)="onTabChange($event)">
+          <bq-tab tab-id="home">
+            <bq-icon name="house-line" slot="icon"></bq-icon>
+            Home
+          </bq-tab>
+          <bq-tab tab-id="profile">
+            <bq-icon name="user" slot="icon"></bq-icon>
+            Profile
+          </bq-tab>
+          <bq-tab tab-id="settings">
+            <bq-icon name="gear" slot="icon"></bq-icon>
+            Settings
+          </bq-tab>
+        </bq-tab-group>
+
+        @if (activeTab() === 'home') {
+          <section>
+            <h1>Hello BEEQ(ers)!</h1>
+            <p>
+              This is an example of how to integrate the
+              <a class="bq-link" href="https://beeq.design/" target="_blank" rel="noopener noreferrer">
+                BEEQ component library
+              </a>
+              with HTML/TypeScript while using Vite as the bundler.
+            </p>
+            <section style="margin-block-start: var(--bq-spacing-l);">
+              <h2>Buttons</h2>
+              <bq-button appearance="primary">Primary Button</bq-button>
+              <bq-button appearance="secondary">Secondary Button</bq-button>
+              <bq-button variant="danger">Delete</bq-button>
+              <bq-button variant="ghost">Ghost</bq-button>
+            </section>
+            <section style="margin-block-start: var(--bq-spacing-l);">
+              <h2>Input</h2>
+              <bq-input placeholder="Placeholder">
+                <label slot="label">Input label</label>
+              </bq-input>
+            </section>
+          </section>
+        }
+        @if (activeTab() === 'profile') {
+          <section>
+            <h1>Profile tab!</h1>
+            <span>You can check the logic added to the Tab component in the <code>index.ts</code> file.</span>
+          </section>
+        }
+        @if (activeTab() === 'settings') {
+          <h1>Settings tab!</h1>
+        }
+      `,
+    })
+    export class TechFlowDemoComponent {
+      private readonly document = inject(DOCUMENT);
+      readonly activeTab = signal('home');
+      readonly isDark = signal(true);
+
+      onTabChange(event: CustomEvent<{ value: string }>) {
+        this.activeTab.set(event.detail.value);
+      }
+
+      toggleTheme() {
+        const next = this.isDark() ? 'light' : 'dark';
+        this.document.documentElement.setAttribute('bq-mode', next);
+        this.isDark.set(!this.isDark());
+      }
+    }
+    ```
+
+    ```vue Vue icon="vuejs" expandable
+    <script setup lang="ts">
+      import { ref } from "vue";
+      import { BqTabGroup, BqTab, BqIcon, BqButton, BqInput } from "@beeq/vue";
+
+      // In main.ts, apply the TechFlow theme (import styles.css separately):
+      // document.documentElement.setAttribute('bq-theme', 'techflow');
+      // document.documentElement.setAttribute('bq-mode', 'dark');
+
+      const activeTab = ref("home");
+      const isDark = ref(true);
+
+      function onTabChange(event: CustomEvent<{ value: string }>) {
+        activeTab.value = event.detail.value;
+      }
+
+      function toggleTheme() {
+        const next = isDark.value ? "light" : "dark";
+        document.documentElement.setAttribute("bq-mode", next);
+        isDark.value = !isDark.value;
+      }
     </script>
-  </body>
-</html>
-```
 
-```jsx React icon="react"
-import { useState } from "react";
-import { BqTabGroup, BqTab, BqIcon, BqButton, BqInput } from "@beeq/react";
-
-// In main.tsx, apply the TechFlow theme (import styles.css separately):
-// document.documentElement.setAttribute('bq-theme', 'techflow');
-// document.documentElement.setAttribute('bq-mode', 'dark');
-
-export function TechFlowDemo() {
-  const [activeTab, setActiveTab] = useState("home");
-  const [isDark, setIsDark] = useState(true);
-
-  function toggleTheme() {
-    const next = isDark ? "light" : "dark";
-    document.documentElement.setAttribute("bq-mode", next);
-    setIsDark(!isDark);
-  }
-
-  return (
-    <>
-      <div className="toolbar">
-        <BqButton size="small" appearance="ghost" onBqClick={toggleTheme}>
-          <BqIcon name={isDark ? "sun" : "moon"} slot="prefix" />
-          {isDark ? "Light mode" : "Dark mode"}
+    <template>
+      <div class="toolbar">
+        <BqButton appearance="secondary" label="Toggle theme" only-icon @bqClick="toggleTheme">
+          <BqIcon :name="isDark ? 'sun' : 'moon'" />
         </BqButton>
       </div>
 
-      <BqTabGroup
-        value="home"
-        onBqChange={(e: CustomEvent<{ value: string }>) => setActiveTab(e.detail.value)}
-      >
+      <BqTabGroup value="home" @bqChange="onTabChange">
         <BqTab tabId="home">
           <BqIcon name="house-line" slot="icon" />
           Home
@@ -615,80 +1001,7 @@ export function TechFlowDemo() {
         </BqTab>
       </BqTabGroup>
 
-      {activeTab === "home" && (
-        <section>
-          <h1>Hello BEEQ(ers)!</h1>
-          <p>
-            This is an example of how to integrate the{" "}
-            <a className="bq-link" href="https://beeq.design/" target="_blank" rel="noopener noreferrer">
-              BEEQ component library
-            </a>{" "}
-            with HTML/TypeScript while using Vite as the bundler.
-          </p>
-          <section style={{ marginBlockStart: "var(--bq-spacing-l)" }}>
-            <h2>Buttons</h2>
-            <BqButton appearance="primary">Primary Button</BqButton>
-            <BqButton appearance="secondary">Secondary Button</BqButton>
-            <BqButton variant="danger">Delete</BqButton>
-            <BqButton variant="ghost">Ghost</BqButton>
-          </section>
-          <section style={{ marginBlockStart: "var(--bq-spacing-l)" }}>
-            <h2>Input</h2>
-            <BqInput placeholder="Placeholder">
-              <label slot="label">Input label</label>
-            </BqInput>
-          </section>
-        </section>
-      )}
-      {activeTab === "profile" && (
-        <section>
-          <h1>Profile tab!</h1>
-          <span>
-            You can check the logic added to the Tab component in the{" "}
-            <code>index.ts</code> file.
-          </span>
-        </section>
-      )}
-      {activeTab === "settings" && <h1>Settings tab!</h1>}
-    </>
-  );
-}
-```
-
-```ts Angular icon="angular"
-import { Component } from "@angular/core";
-import type { BqTabGroupCustomEvent } from "@beeq/core";
-import { BqButton, BqIcon, BqInput, BqTab, BqTabGroup } from "@beeq/angular/standalone";
-
-@Component({
-  selector: "app-root",
-  standalone: true,
-  imports: [BqButton, BqIcon, BqInput, BqTab, BqTabGroup],
-  template: `
-    <div class="toolbar">
-      <bq-button size="small" appearance="ghost" (bqClick)="toggleTheme()">
-        <bq-icon [attr.name]="isDark ? 'sun' : 'moon'" slot="prefix"></bq-icon>
-        {{ isDark ? 'Light mode' : 'Dark mode' }}
-      </bq-button>
-    </div>
-
-    <bq-tab-group value="home" (bqChange)="onTabChange($event)">
-      <bq-tab tab-id="home">
-        <bq-icon name="house-line" slot="icon"></bq-icon>
-        Home
-      </bq-tab>
-      <bq-tab tab-id="profile">
-        <bq-icon name="user" slot="icon"></bq-icon>
-        Profile
-      </bq-tab>
-      <bq-tab tab-id="settings">
-        <bq-icon name="gear" slot="icon"></bq-icon>
-        Settings
-      </bq-tab>
-    </bq-tab-group>
-
-    @if (activeTab === "home") {
-      <section>
+      <section v-if="activeTab === 'home'">
         <h1>Hello BEEQ(ers)!</h1>
         <p>
           This is an example of how to integrate the
@@ -699,123 +1012,24 @@ import { BqButton, BqIcon, BqInput, BqTab, BqTabGroup } from "@beeq/angular/stan
         </p>
         <section style="margin-block-start: var(--bq-spacing-l);">
           <h2>Buttons</h2>
-          <bq-button appearance="primary">Primary Button</bq-button>
-          <bq-button appearance="secondary">Secondary Button</bq-button>
-          <bq-button variant="danger">Delete</bq-button>
-          <bq-button variant="ghost">Ghost</bq-button>
+          <BqButton appearance="primary">Primary Button</BqButton>
+          <BqButton appearance="secondary">Secondary Button</BqButton>
+          <BqButton variant="danger">Delete</BqButton>
+          <BqButton variant="ghost">Ghost</BqButton>
         </section>
         <section style="margin-block-start: var(--bq-spacing-l);">
           <h2>Input</h2>
-          <bq-input placeholder="Placeholder">
+          <BqInput placeholder="Placeholder">
             <label slot="label">Input label</label>
-          </bq-input>
+          </BqInput>
         </section>
       </section>
-    }
-
-    @if (activeTab === "profile") {
-      <section>
+      <section v-if="activeTab === 'profile'">
         <h1>Profile tab!</h1>
         <span>You can check the logic added to the Tab component in the <code>index.ts</code> file.</span>
       </section>
-    }
-
-    @if (activeTab === "settings") {
-      <h1>Settings tab!</h1>
-    }
-  `,
-})
-export class AppComponent {
-  activeTab = "home";
-  isDark = true;
-
-  onTabChange(event: BqTabGroupCustomEvent<{ value: string }>) {
-    this.activeTab = event.detail.value;
-  }
-
-  toggleTheme() {
-    const next = this.isDark ? "light" : "dark";
-    document.documentElement.setAttribute("bq-mode", next);
-    this.isDark = !this.isDark;
-  }
-}
-```
-
-```vue Vue icon="vuejs"
-<script setup lang="ts">
-import { ref } from "vue";
-import { BqTabGroup, BqTab, BqIcon, BqButton, BqInput } from "@beeq/vue";
-
-// In main.ts, apply the TechFlow theme (import styles.css separately):
-// document.documentElement.setAttribute('bq-theme', 'techflow');
-// document.documentElement.setAttribute('bq-mode', 'dark');
-
-const activeTab = ref("home");
-const isDark = ref(true);
-
-function onTabChange(event: CustomEvent<{ value: string }>) {
-  activeTab.value = event.detail.value;
-}
-
-function toggleTheme() {
-  const next = isDark.value ? "light" : "dark";
-  document.documentElement.setAttribute("bq-mode", next);
-  isDark.value = !isDark.value;
-}
-</script>
-
-<template>
-  <div class="toolbar">
-    <BqButton size="small" appearance="ghost" @bqClick="toggleTheme">
-      <BqIcon :name="isDark ? 'sun' : 'moon'" slot="prefix" />
-      {{ isDark ? 'Light mode' : 'Dark mode' }}
-    </BqButton>
-  </div>
-
-  <BqTabGroup value="home" @bqChange="onTabChange">
-    <BqTab tabId="home">
-      <BqIcon name="house-line" slot="icon" />
-      Home
-    </BqTab>
-    <BqTab tabId="profile">
-      <BqIcon name="user" slot="icon" />
-      Profile
-    </BqTab>
-    <BqTab tabId="settings">
-      <BqIcon name="gear" slot="icon" />
-      Settings
-    </BqTab>
-  </BqTabGroup>
-
-  <section v-if="activeTab === 'home'">
-    <h1>Hello BEEQ(ers)!</h1>
-    <p>
-      This is an example of how to integrate the
-      <a class="bq-link" href="https://beeq.design/" target="_blank" rel="noopener noreferrer">
-        BEEQ component library
-      </a>
-      with HTML/TypeScript while using Vite as the bundler.
-    </p>
-    <section style="margin-block-start: var(--bq-spacing-l);">
-      <h2>Buttons</h2>
-      <BqButton appearance="primary">Primary Button</BqButton>
-      <BqButton appearance="secondary">Secondary Button</BqButton>
-      <BqButton variant="danger">Delete</BqButton>
-      <BqButton variant="ghost">Ghost</BqButton>
-    </section>
-    <section style="margin-block-start: var(--bq-spacing-l);">
-      <h2>Input</h2>
-      <BqInput placeholder="Placeholder">
-        <label slot="label">Input label</label>
-      </BqInput>
-    </section>
-  </section>
-  <section v-if="activeTab === 'profile'">
-    <h1>Profile tab!</h1>
-    <span>You can check the logic added to the Tab component in the <code>index.ts</code> file.</span>
-  </section>
-  <h1 v-if="activeTab === 'settings'">Settings tab!</h1>
-</template>
-```
-</CodeGroup>
+      <h1 v-if="activeTab === 'settings'">Settings tab!</h1>
+    </template>
+    ```
+  </CodeGroup>
 </CodeLivePreview>

--- a/apps/beeq-docs/theming/custom-theme.mdx
+++ b/apps/beeq-docs/theming/custom-theme.mdx
@@ -1,0 +1,795 @@
+---
+title: Custom Theme
+description: This guide walks you through creating and applying a custom theme across your app or project.
+---
+
+import { CodeLivePreview } from "/snippets/CodeLivePreview.jsx";
+
+To create a custom theme, define your own set of CSS variables that override the base theme variables and declarative colors for both light and dark modes.
+
+<Note>
+  Namespace your theme using the `bq-theme` attribute (e.g., `bq-theme="my-custom-theme"`) or a matching CSS class (e.g., `.my-custom-theme`).
+</Note>
+
+---
+
+## Step-by-step guide
+
+<Steps>
+  <Step title="Define base theme variables">
+    Create a CSS file for your custom theme (e.g., `custom-theme.css`) and set the base design tokens:
+
+    ```css
+    [bq-theme="my-custom-theme"],
+    .my-custom-theme {
+      /* Override font family */
+      --bq-font-family: 'Inter', sans-serif;
+
+      /* Define brand colors using any primitive color from the palette */
+      --bq-brand-light: var(--bq-blue-100);
+      --bq-brand:       var(--bq-blue-600);
+      --bq-brand-dark:  var(--bq-blue-1000);
+
+      /* Define accent colors */
+      --bq-accent-light: var(--bq-purple-100);
+      --bq-accent:       var(--bq-purple-600);
+      --bq-accent-dark:  var(--bq-purple-1000);
+
+      /* Override neutral scale if needed */
+      --bq-neutral-50:  var(--bq-grey-50);
+      --bq-neutral-100: var(--bq-grey-100);
+      /* ... continue with other neutrals ... */
+
+      /* Define semantic colors */
+      --bq-success: var(--bq-teal-600);
+      --bq-danger:  var(--bq-red-600);
+      --bq-warning: var(--bq-gold-600);
+      --bq-info:    var(--bq-blue-600);
+      --bq-focus:   var(--bq-blue-600);
+    }
+    ```
+  </Step>
+
+  <Step title="Define light mode theme">
+    Define the declarative color tokens for the light mode:
+
+    ```css
+    [bq-theme="my-custom-theme"]:not([bq-mode]),    /* Default — no mode specified */
+    [bq-theme="my-custom-theme"][bq-mode="light"],  /* Explicit light mode (via attributes) */
+    .my-custom-theme:not([bq-mode]),                /* Default — no mode (via CSS class) */
+    .my-custom-theme.light {                        /* Explicit light mode (via CSS classes) */
+
+      /* Background colors */
+      --bq-background--primary:   var(--bq-white);
+      --bq-background--secondary: var(--bq-neutral-100);
+      --bq-background--tertiary:  var(--bq-neutral-200);
+      --bq-background--alt:       var(--bq-neutral-300);
+      --bq-background--inverse:   var(--bq-neutral-900);
+      --bq-background--brand:     var(--bq-brand);
+      --bq-background--overlay:   var(--bq-neutral-900);
+
+      /* Icon colors */
+      --bq-icon--primary:   var(--bq-neutral-800);
+      --bq-icon--secondary: var(--bq-neutral-600);
+      --bq-icon--inverse:   var(--bq-neutral-50);
+      --bq-icon--brand:     var(--bq-brand);
+      --bq-icon--alt:       var(--bq-white);
+      --bq-icon--info:      var(--bq-info);
+      --bq-icon--success:   var(--bq-success);
+      --bq-icon--warning:   var(--bq-warning);
+      --bq-icon--danger:    var(--bq-danger);
+
+      /* Stroke colors */
+      --bq-stroke--primary:   var(--bq-neutral-200);
+      --bq-stroke--secondary: var(--bq-neutral-600);
+      --bq-stroke--tertiary:  var(--bq-neutral-900);
+      --bq-stroke--inverse:   var(--bq-white);
+      --bq-stroke--brand:     var(--bq-brand);
+      --bq-stroke--alt:       var(--bq-neutral-50);
+      --bq-stroke--success:   var(--bq-success);
+      --bq-stroke--warning:   var(--bq-warning);
+      --bq-stroke--danger:    var(--bq-danger);
+
+      /* Text colors */
+      --bq-text--primary:   var(--bq-neutral-800);
+      --bq-text--secondary: var(--bq-neutral-600);
+      --bq-text--inverse:   var(--bq-neutral-50);
+      --bq-text--brand:     var(--bq-brand);
+      --bq-text--alt:       var(--bq-white);
+      --bq-text--info:      var(--bq-info);
+      --bq-text--success:   var(--bq-success);
+      --bq-text--warning:   var(--bq-warning);
+      --bq-text--danger:    var(--bq-danger);
+
+      /* UI colors */
+      --bq-ui--primary:      var(--bq-white);
+      --bq-ui--secondary:    var(--bq-neutral-100);
+      --bq-ui--tertiary:     var(--bq-neutral-500);
+      --bq-ui--inverse:      var(--bq-neutral-900);
+      --bq-ui--brand:        var(--bq-brand);
+      --bq-ui--brand-alt:    var(--bq-brand-light);
+      --bq-ui--alt:          var(--bq-neutral-50);
+      --bq-ui--success:      var(--bq-success);
+      --bq-ui--success-alt:  var(--bq-success-light);
+      --bq-ui--warning:      var(--bq-warning);
+      --bq-ui--warning-alt:  var(--bq-warning-light);
+      --bq-ui--danger:       var(--bq-danger);
+      --bq-ui--danger-alt:   var(--bq-danger-light);
+    }
+    ```
+  </Step>
+
+  <Step title="Define dark mode theme">
+    Define the declarative color tokens for the dark mode:
+
+    ```css
+    [bq-theme="my-custom-theme"][bq-mode="dark"],  /* Explicit dark mode (via attributes) */
+    .my-custom-theme.dark {                        /* Explicit dark mode (via CSS classes) */
+
+      /* Background colors */
+      --bq-background--primary:   var(--bq-neutral-1000);
+      --bq-background--secondary: var(--bq-neutral-950);
+      --bq-background--tertiary:  var(--bq-neutral-800);
+      --bq-background--alt:       var(--bq-neutral-700);
+      --bq-background--inverse:   var(--bq-neutral-600);
+      --bq-background--brand:     var(--bq-brand);
+      --bq-background--overlay:   var(--bq-neutral-900);
+
+      /* Icon colors */
+      --bq-icon--primary:   var(--bq-neutral-100);
+      --bq-icon--secondary: var(--bq-neutral-400);
+      --bq-icon--inverse:   var(--bq-neutral-800);
+      --bq-icon--brand:     var(--bq-brand);
+      --bq-icon--alt:       var(--bq-white);
+      --bq-icon--info:      var(--bq-info);
+      --bq-icon--success:   var(--bq-success);
+      --bq-icon--warning:   var(--bq-warning);
+      --bq-icon--danger:    var(--bq-danger);
+
+      /* Stroke colors */
+      --bq-stroke--primary:   var(--bq-neutral-900);
+      --bq-stroke--secondary: var(--bq-neutral-700);
+      --bq-stroke--tertiary:  var(--bq-neutral-400);
+      --bq-stroke--inverse:   var(--bq-neutral-950);
+      --bq-stroke--brand:     var(--bq-brand);
+      --bq-stroke--alt:       var(--bq-neutral-1000);
+      --bq-stroke--success:   var(--bq-success);
+      --bq-stroke--warning:   var(--bq-warning);
+      --bq-stroke--danger:    var(--bq-danger);
+
+      /* Text colors */
+      --bq-text--primary:   var(--bq-neutral-100);
+      --bq-text--secondary: var(--bq-neutral-400);
+      --bq-text--inverse:   var(--bq-neutral-800);
+      --bq-text--brand:     var(--bq-brand);
+      --bq-text--alt:       var(--bq-white);
+      --bq-text--info:      var(--bq-info);
+      --bq-text--success:   var(--bq-success);
+      --bq-text--warning:   var(--bq-warning);
+      --bq-text--danger:    var(--bq-danger);
+
+      /* UI colors */
+      --bq-ui--primary:      var(--bq-neutral-900);
+      --bq-ui--secondary:    var(--bq-neutral-950);
+      --bq-ui--tertiary:     var(--bq-neutral-700);
+      --bq-ui--inverse:      var(--bq-neutral-100);
+      --bq-ui--brand:        var(--bq-brand);
+      --bq-ui--brand-alt:    var(--bq-brand-dark);
+      --bq-ui--alt:          var(--bq-neutral-950);
+      --bq-ui--success:      var(--bq-success);
+      --bq-ui--success-alt:  var(--bq-success-dark);
+      --bq-ui--warning:      var(--bq-warning);
+      --bq-ui--warning-alt:  var(--bq-warning-dark);
+      --bq-ui--danger:       var(--bq-danger);
+      --bq-ui--danger-alt:   var(--bq-danger-dark);
+    }
+    ```
+  </Step>
+
+  <Step title="Apply your custom theme">
+    Include your custom theme CSS file in your project and set the `bq-theme` and `bq-mode` attributes on the `<html>` element:
+
+    ```html
+    <!DOCTYPE html>
+    <html lang="en" bq-theme="my-custom-theme" bq-mode="light">
+      <head>
+        <link rel="stylesheet" href="path/to/beeq.css">
+        <link rel="stylesheet" href="path/to/custom-theme.css">
+      </head>
+      <body>
+        <!-- Your components will automatically use the custom theme -->
+        <bq-button>Click me</bq-button>
+      </body>
+    </html>
+    ```
+
+    To switch to dark mode, change the `bq-mode` attribute:
+
+    ```html
+    <html lang="en" bq-theme="my-custom-theme" bq-mode="dark">
+    ```
+
+    <Tip>
+      You can also use CSS classes instead of HTML attributes:
+
+      ```html
+      <body class="my-custom-theme light"> ... </body>
+      <!-- or -->
+      <body class="my-custom-theme dark"> ... </body>
+      ```
+    </Tip>
+  </Step>
+</Steps>
+
+---
+
+## Full example: TechFlow theme
+
+Here is an almost production-ready custom theme called **TechFlow** — a theme with vibrant teal accents and a sleek design aesthetic.
+
+<CodeLivePreview code={`
+  <style>
+    :host {
+      /* TechFlow — Base variables */
+      --bq-font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      --bq-radius--none: 0;
+      --bq-radius--xs2: 0.0625rem;
+      --bq-radius--xs: 0.125rem;
+      --bq-radius--s: 0.25rem;
+      --bq-radius--m: 0.5rem;
+      --bq-radius--l: 1rem;
+      --bq-radius--full: 9999px;
+      --bq-brand-light: #a8f0e6;
+      --bq-brand: #00d9c4;
+      --bq-brand-dark: #009b88;
+      --bq-accent-light: #e8d5f2;
+      --bq-accent: #9d4edd;
+      --bq-accent-dark: #5a189a;
+      --bq-success-light: #a1e4cb;
+      --bq-success: #05b981;
+      --bq-success-dark: #047857;
+      --bq-danger-light: #fecaca;
+      --bq-danger: #ef4444;
+      --bq-danger-dark: #991b1b;
+      --bq-warning-light: #fef3c7;
+      --bq-warning: #f59e0b;
+      --bq-warning-dark: #92400e;
+      --bq-info-light: #bfdbfe;
+      --bq-info: #3b82f6;
+      --bq-info-dark: #1e3a8a;
+      --bq-focus: #00d9c4;
+      --bq-white: #ffffff;
+      --bq-black: #000000;
+      --bq-neutral-50: #f9fafb;
+      --bq-neutral-100: #f3f4f6;
+      --bq-neutral-200: #e5e7eb;
+      --bq-neutral-300: #d1d5db;
+      --bq-neutral-400: #9ca3af;
+      --bq-neutral-500: #6b7280;
+      --bq-neutral-600: #4b5563;
+      --bq-neutral-700: #374151;
+      --bq-neutral-800: #1f2937;
+      --bq-neutral-900: #111827;
+      --bq-neutral-950: #0f172a;
+      --bq-neutral-1000: #030712;
+      /* TechFlow — Dark mode declarative tokens */
+      --bq-background--primary: #030712;
+      --bq-background--secondary: #0f172a;
+      --bq-background--tertiary: #1f2937;
+      --bq-background--alt: #374151;
+      --bq-background--inverse: #f9fafb;
+      --bq-background--brand: #009b88;
+      --bq-background--overlay: rgba(0, 0, 0, 0.7);
+      --bq-icon--primary: #f3f4f6;
+      --bq-icon--secondary: #9ca3af;
+      --bq-icon--inverse: #1f2937;
+      --bq-icon--brand: #00d9c4;
+      --bq-icon--alt: #ffffff;
+      --bq-icon--info: #60a5fa;
+      --bq-icon--success: #34d399;
+      --bq-icon--warning: #fbbf24;
+      --bq-icon--danger: #f87171;
+      --bq-stroke--primary: #374151;
+      --bq-stroke--secondary: #4b5563;
+      --bq-stroke--tertiary: #9ca3af;
+      --bq-stroke--inverse: #0f172a;
+      --bq-stroke--brand: #00d9c4;
+      --bq-stroke--alt: #1f2937;
+      --bq-stroke--success: #34d399;
+      --bq-stroke--warning: #fbbf24;
+      --bq-stroke--danger: #f87171;
+      --bq-text--primary: #f9fafb;
+      --bq-text--secondary: #9ca3af;
+      --bq-text--inverse: #1f2937;
+      --bq-text--brand: #00d9c4;
+      --bq-text--alt: #ffffff;
+      --bq-text--info: #60a5fa;
+      --bq-text--success: #34d399;
+      --bq-text--warning: #fbbf24;
+      --bq-text--danger: #f87171;
+      --bq-ui--primary: #1f2937;
+      --bq-ui--secondary: #374151;
+      --bq-ui--tertiary: #4b5563;
+      --bq-ui--inverse: #f9fafb;
+      --bq-ui--brand: #00d9c4;
+      --bq-ui--brand-alt: #009b88;
+      --bq-ui--alt: #0f172a;
+      --bq-ui--success: #34d399;
+      --bq-ui--success-alt: #10b981;
+      --bq-ui--warning: #fbbf24;
+      --bq-ui--warning-alt: #f59e0b;
+      --bq-ui--danger: #f87171;
+      --bq-ui--danger-alt: #ef4444;
+      --bq-state--hover: rgba(255, 255, 255, 0.1);
+      --bq-state--active: rgba(255, 255, 255, 0.15);
+      flex-direction: column !important;
+      align-items: stretch !important;
+      background: var(--bq-background--primary) !important;
+      color: var(--bq-text--primary);
+      font-family: var(--bq-font-family);
+      padding: var(--bq-spacing-m);
+    }
+
+    .toolbar {
+      display: flex;
+      justify-content: flex-end;
+      margin-block-end: var(--bq-spacing-m);
+    }
+
+    .tab-panel {
+      display: none;
+      padding: var(--bq-spacing-l);
+    }
+
+    .tab-panel.active {
+      display: block;
+    }
+
+    :host(.light) {
+      --bq-background--primary: #ffffff;
+      --bq-background--secondary: #f9fafb;
+      --bq-background--tertiary: #f3f4f6;
+      --bq-background--alt: #e5e7eb;
+      --bq-background--inverse: #111827;
+      --bq-background--brand: #a8f0e6;
+      --bq-background--overlay: rgba(0, 0, 0, 0.5);
+      --bq-icon--primary: #1f2937;
+      --bq-icon--secondary: #6b7280;
+      --bq-icon--inverse: #f9fafb;
+      --bq-icon--brand: #00d9c4;
+      --bq-icon--alt: #ffffff;
+      --bq-icon--info: #3b82f6;
+      --bq-icon--success: #05b981;
+      --bq-icon--warning: #f59e0b;
+      --bq-icon--danger: #ef4444;
+      --bq-stroke--primary: #e5e7eb;
+      --bq-stroke--secondary: #d1d5db;
+      --bq-stroke--tertiary: #9ca3af;
+      --bq-stroke--inverse: #ffffff;
+      --bq-stroke--brand: #00d9c4;
+      --bq-stroke--alt: #f3f4f6;
+      --bq-stroke--success: #05b981;
+      --bq-stroke--warning: #f59e0b;
+      --bq-stroke--danger: #ef4444;
+      --bq-text--primary: #111827;
+      --bq-text--secondary: #6b7280;
+      --bq-text--inverse: #f9fafb;
+      --bq-text--brand: #00d9c4;
+      --bq-text--alt: #ffffff;
+      --bq-text--info: #3b82f6;
+      --bq-text--success: #05b981;
+      --bq-text--warning: #f59e0b;
+      --bq-text--danger: #ef4444;
+      --bq-ui--primary: #ffffff;
+      --bq-ui--secondary: #f3f4f6;
+      --bq-ui--tertiary: #e5e7eb;
+      --bq-ui--inverse: #111827;
+      --bq-ui--brand: #00d9c4;
+      --bq-ui--brand-alt: #a8f0e6;
+      --bq-ui--alt: #f9fafb;
+      --bq-ui--success: #05b981;
+      --bq-ui--success-alt: #a1e4cb;
+      --bq-ui--warning: #f59e0b;
+      --bq-ui--warning-alt: #fef3c7;
+      --bq-ui--danger: #ef4444;
+      --bq-ui--danger-alt: #fecaca;
+      --bq-state--hover: rgba(0, 0, 0, 0.08);
+      --bq-state--active: rgba(0, 0, 0, 0.12);
+    }
+  </style>
+
+  <div class="toolbar">
+    <bq-button size="small" appearance="ghost" id="theme-toggle">
+      <bq-icon id="toggle-icon" name="sun" slot="prefix"></bq-icon>
+      <span id="toggle-label">Light mode</span>
+    </bq-button>
+  </div>
+
+  <bq-tab-group value="home">
+    <bq-tab tab-id="home">
+      <bq-icon name="house-line" slot="icon"></bq-icon>
+      Home
+    </bq-tab>
+    <bq-tab tab-id="profile">
+      <bq-icon name="user" slot="icon"></bq-icon>
+      Profile
+    </bq-tab>
+    <bq-tab tab-id="settings">
+      <bq-icon name="gear" slot="icon"></bq-icon>
+      Settings
+    </bq-tab>
+  </bq-tab-group>
+
+  <div class="tab-panel active" id="home">
+    <h1>Hello BEEQ(ers)!</h1>
+    <p>
+      This is an example of how to integrate the
+      <a class="bq-link" href="https://beeq.design/" target="_blank" rel="noopener noreferrer">
+        BEEQ component library
+      </a>
+      with HTML/TypeScript while using Vite as the bundler.
+    </p>
+    <section style="margin-block-start: var(--bq-spacing-l);">
+      <h2>Buttons</h2>
+      <bq-button appearance="primary">Primary Button</bq-button>
+      <bq-button appearance="secondary">Secondary Button</bq-button>
+      <bq-button variant="danger">Delete</bq-button>
+      <bq-button variant="ghost">Ghost</bq-button>
+    </section>
+    <section style="margin-block-start: var(--bq-spacing-l);">
+      <h2>Input</h2>
+      <bq-input placeholder="Placeholder">
+        <label slot="label">Input label</label>
+      </bq-input>
+    </section>
+  </div>
+
+  <div class="tab-panel" id="profile">
+    <h1>Profile tab!</h1>
+    <span>
+      You can check the logic added to the Tab component in the
+      <code>index.ts</code> file.
+    </span>
+  </div>
+
+  <div class="tab-panel" id="settings">
+    <h1>Settings tab!</h1>
+  </div>
+
+  <script>
+    (() => {
+      const TAB_ACTIVE_CLASS = 'active';
+      const bqTabElem = previewRoot.querySelector('bq-tab-group');
+      const tabPanels = previewRoot.querySelectorAll('.tab-panel');
+      const toggleBtn = previewRoot.querySelector('#theme-toggle');
+      const toggleIcon = previewRoot.querySelector('#toggle-icon');
+      const toggleLabel = previewRoot.querySelector('#toggle-label');
+
+      bqTabElem?.addEventListener('bqChange', (event) => {
+        if (!tabPanels.length) return;
+        const activeTab = event.detail.value;
+        if (!activeTab) return;
+        tabPanels.forEach((tabPanel) => {
+          tabPanel.classList.remove(TAB_ACTIVE_CLASS);
+          if (tabPanel.id === activeTab) tabPanel.classList.add(TAB_ACTIVE_CLASS);
+        });
+      });
+
+      toggleBtn?.addEventListener('bqClick', () => {
+        const isLight = previewRoot.host.classList.toggle('light');
+        if (toggleIcon) toggleIcon.setAttribute('name', isLight ? 'moon' : 'sun');
+        if (toggleLabel) toggleLabel.textContent = isLight ? 'Dark mode' : 'Light mode';
+      });
+    })();
+  </script>
+`}>
+<CodeGroup>
+```html HTML icon="html5"
+<!DOCTYPE html>
+<html lang="en" bq-theme="techflow" bq-mode="dark">
+  <head>
+    <link rel="stylesheet" href="path/to/beeq.css">
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <div class="toolbar">
+      <bq-button size="small" appearance="ghost" id="theme-toggle">
+        <bq-icon id="toggle-icon" name="sun" slot="prefix"></bq-icon>
+        Light mode
+      </bq-button>
+    </div>
+
+    <bq-tab-group value="home" id="tabs">
+      <bq-tab tab-id="home">
+        <bq-icon name="house-line" slot="icon"></bq-icon>
+        Home
+      </bq-tab>
+      <bq-tab tab-id="profile">
+        <bq-icon name="user" slot="icon"></bq-icon>
+        Profile
+      </bq-tab>
+      <bq-tab tab-id="settings">
+        <bq-icon name="gear" slot="icon"></bq-icon>
+        Settings
+      </bq-tab>
+    </bq-tab-group>
+
+    <div class="tab-panel active" id="home">
+      <h1>Hello BEEQ(ers)!</h1>
+      <p>
+        This is an example of how to integrate the
+        <a class="bq-link" href="https://beeq.design/" target="_blank" rel="noopener noreferrer">
+          BEEQ component library
+        </a>
+        with HTML/TypeScript while using Vite as the bundler.
+      </p>
+      <section style="margin-block-start: var(--bq-spacing-l);">
+        <h2>Buttons</h2>
+        <bq-button appearance="primary">Primary Button</bq-button>
+        <bq-button appearance="secondary">Secondary Button</bq-button>
+        <bq-button variant="danger">Delete</bq-button>
+        <bq-button variant="ghost">Ghost</bq-button>
+      </section>
+      <section style="margin-block-start: var(--bq-spacing-l);">
+        <h2>Input</h2>
+        <bq-input placeholder="Placeholder">
+          <label slot="label">Input label</label>
+        </bq-input>
+      </section>
+    </div>
+    <div class="tab-panel" id="profile">
+      <h1>Profile tab!</h1>
+      <span>You can check the logic added to the Tab component in the <code>index.ts</code> file.</span>
+    </div>
+    <div class="tab-panel" id="settings">
+      <h1>Settings tab!</h1>
+    </div>
+
+    <script type="module">
+      const TAB_ACTIVE_CLASS = 'active';
+      const bqTabElem = document.getElementById('tabs');
+      const tabPanels = document.querySelectorAll('.tab-panel');
+      const toggleBtn = document.getElementById('theme-toggle');
+      const toggleIcon = document.getElementById('toggle-icon');
+
+      bqTabElem?.addEventListener('bqChange', (event) => {
+        const activeTab = event.detail.value;
+        tabPanels.forEach((panel) => {
+          panel.classList.toggle(TAB_ACTIVE_CLASS, panel.id === activeTab);
+        });
+      });
+
+      toggleBtn?.addEventListener('bqClick', () => {
+        const isNowLight = document.documentElement.getAttribute('bq-mode') !== 'light';
+        document.documentElement.setAttribute('bq-mode', isNowLight ? 'light' : 'dark');
+        toggleIcon?.setAttribute('name', isNowLight ? 'moon' : 'sun');
+        if (toggleBtn.lastChild) toggleBtn.lastChild.textContent = isNowLight ? ' Dark mode' : ' Light mode';
+      });
+    </script>
+  </body>
+</html>
+```
+
+```jsx React icon="react"
+import { useState } from "react";
+import { BqTabGroup, BqTab, BqIcon, BqButton, BqInput } from "@beeq/react";
+
+// In main.tsx, apply the TechFlow theme (import styles.css separately):
+// document.documentElement.setAttribute('bq-theme', 'techflow');
+// document.documentElement.setAttribute('bq-mode', 'dark');
+
+export function TechFlowDemo() {
+  const [activeTab, setActiveTab] = useState("home");
+  const [isDark, setIsDark] = useState(true);
+
+  function toggleTheme() {
+    const next = isDark ? "light" : "dark";
+    document.documentElement.setAttribute("bq-mode", next);
+    setIsDark(!isDark);
+  }
+
+  return (
+    <>
+      <div className="toolbar">
+        <BqButton size="small" appearance="ghost" onBqClick={toggleTheme}>
+          <BqIcon name={isDark ? "sun" : "moon"} slot="prefix" />
+          {isDark ? "Light mode" : "Dark mode"}
+        </BqButton>
+      </div>
+
+      <BqTabGroup
+        value="home"
+        onBqChange={(e: CustomEvent<{ value: string }>) => setActiveTab(e.detail.value)}
+      >
+        <BqTab tabId="home">
+          <BqIcon name="house-line" slot="icon" />
+          Home
+        </BqTab>
+        <BqTab tabId="profile">
+          <BqIcon name="user" slot="icon" />
+          Profile
+        </BqTab>
+        <BqTab tabId="settings">
+          <BqIcon name="gear" slot="icon" />
+          Settings
+        </BqTab>
+      </BqTabGroup>
+
+      {activeTab === "home" && (
+        <section>
+          <h1>Hello BEEQ(ers)!</h1>
+          <p>
+            This is an example of how to integrate the{" "}
+            <a className="bq-link" href="https://beeq.design/" target="_blank" rel="noopener noreferrer">
+              BEEQ component library
+            </a>{" "}
+            with HTML/TypeScript while using Vite as the bundler.
+          </p>
+          <section style={{ marginBlockStart: "var(--bq-spacing-l)" }}>
+            <h2>Buttons</h2>
+            <BqButton appearance="primary">Primary Button</BqButton>
+            <BqButton appearance="secondary">Secondary Button</BqButton>
+            <BqButton variant="danger">Delete</BqButton>
+            <BqButton variant="ghost">Ghost</BqButton>
+          </section>
+          <section style={{ marginBlockStart: "var(--bq-spacing-l)" }}>
+            <h2>Input</h2>
+            <BqInput placeholder="Placeholder">
+              <label slot="label">Input label</label>
+            </BqInput>
+          </section>
+        </section>
+      )}
+      {activeTab === "profile" && (
+        <section>
+          <h1>Profile tab!</h1>
+          <span>
+            You can check the logic added to the Tab component in the{" "}
+            <code>index.ts</code> file.
+          </span>
+        </section>
+      )}
+      {activeTab === "settings" && <h1>Settings tab!</h1>}
+    </>
+  );
+}
+```
+
+```html Angular icon="angular"
+<!-- app.component.html -->
+<!-- Standalone: import { BqTabGroup, BqTab, BqIcon, BqButton, BqInput } from "@beeq/angular/standalone" -->
+<!-- Modules: components are available after importing BeeQModule -->
+<!-- Apply the TechFlow theme in main.ts (import styles.css separately): -->
+<!-- document.documentElement.setAttribute('bq-theme', 'techflow'); -->
+<!-- document.documentElement.setAttribute('bq-mode', 'dark'); -->
+
+<div class="toolbar">
+  <bq-button size="small" appearance="ghost" (bqClick)="toggleTheme()">
+    <bq-icon [attr.name]="isDark ? 'sun' : 'moon'" slot="prefix"></bq-icon>
+    {{ isDark ? 'Light mode' : 'Dark mode' }}
+  </bq-button>
+</div>
+
+<bq-tab-group value="home" (bqChange)="onTabChange($event)">
+  <bq-tab tab-id="home">
+    <bq-icon name="house-line" slot="icon"></bq-icon>
+    Home
+  </bq-tab>
+  <bq-tab tab-id="profile">
+    <bq-icon name="user" slot="icon"></bq-icon>
+    Profile
+  </bq-tab>
+  <bq-tab tab-id="settings">
+    <bq-icon name="gear" slot="icon"></bq-icon>
+    Settings
+  </bq-tab>
+</bq-tab-group>
+
+<section *ngIf="activeTab === 'home'">
+  <h1>Hello BEEQ(ers)!</h1>
+  <p>
+    This is an example of how to integrate the
+    <a class="bq-link" href="https://beeq.design/" target="_blank" rel="noopener noreferrer">
+      BEEQ component library
+    </a>
+    with HTML/TypeScript while using Vite as the bundler.
+  </p>
+  <section style="margin-block-start: var(--bq-spacing-l);">
+    <h2>Buttons</h2>
+    <bq-button appearance="primary">Primary Button</bq-button>
+    <bq-button appearance="secondary">Secondary Button</bq-button>
+    <bq-button variant="danger">Delete</bq-button>
+    <bq-button variant="ghost">Ghost</bq-button>
+  </section>
+  <section style="margin-block-start: var(--bq-spacing-l);">
+    <h2>Input</h2>
+    <bq-input placeholder="Placeholder">
+      <label slot="label">Input label</label>
+    </bq-input>
+  </section>
+</section>
+<section *ngIf="activeTab === 'profile'">
+  <h1>Profile tab!</h1>
+  <span>You can check the logic added to the Tab component in the <code>index.ts</code> file.</span>
+</section>
+<h1 *ngIf="activeTab === 'settings'">Settings tab!</h1>
+```
+
+```vue Vue icon="vuejs"
+<script setup lang="ts">
+import { ref } from "vue";
+import { BqTabGroup, BqTab, BqIcon, BqButton, BqInput } from "@beeq/vue";
+
+// In main.ts, apply the TechFlow theme (import styles.css separately):
+// document.documentElement.setAttribute('bq-theme', 'techflow');
+// document.documentElement.setAttribute('bq-mode', 'dark');
+
+const activeTab = ref("home");
+const isDark = ref(true);
+
+function onTabChange(event: CustomEvent<{ value: string }>) {
+  activeTab.value = event.detail.value;
+}
+
+function toggleTheme() {
+  const next = isDark.value ? "light" : "dark";
+  document.documentElement.setAttribute("bq-mode", next);
+  isDark.value = !isDark.value;
+}
+</script>
+
+<template>
+  <div class="toolbar">
+    <BqButton size="small" appearance="ghost" @bqClick="toggleTheme">
+      <BqIcon :name="isDark ? 'sun' : 'moon'" slot="prefix" />
+      {{ isDark ? 'Light mode' : 'Dark mode' }}
+    </BqButton>
+  </div>
+
+  <BqTabGroup value="home" @bqChange="onTabChange">
+    <BqTab tabId="home">
+      <BqIcon name="house-line" slot="icon" />
+      Home
+    </BqTab>
+    <BqTab tabId="profile">
+      <BqIcon name="user" slot="icon" />
+      Profile
+    </BqTab>
+    <BqTab tabId="settings">
+      <BqIcon name="gear" slot="icon" />
+      Settings
+    </BqTab>
+  </BqTabGroup>
+
+  <section v-if="activeTab === 'home'">
+    <h1>Hello BEEQ(ers)!</h1>
+    <p>
+      This is an example of how to integrate the
+      <a class="bq-link" href="https://beeq.design/" target="_blank" rel="noopener noreferrer">
+        BEEQ component library
+      </a>
+      with HTML/TypeScript while using Vite as the bundler.
+    </p>
+    <section style="margin-block-start: var(--bq-spacing-l);">
+      <h2>Buttons</h2>
+      <BqButton appearance="primary">Primary Button</BqButton>
+      <BqButton appearance="secondary">Secondary Button</BqButton>
+      <BqButton variant="danger">Delete</BqButton>
+      <BqButton variant="ghost">Ghost</BqButton>
+    </section>
+    <section style="margin-block-start: var(--bq-spacing-l);">
+      <h2>Input</h2>
+      <BqInput placeholder="Placeholder">
+        <label slot="label">Input label</label>
+      </BqInput>
+    </section>
+  </section>
+  <section v-if="activeTab === 'profile'">
+    <h1>Profile tab!</h1>
+    <span>You can check the logic added to the Tab component in the <code>index.ts</code> file.</span>
+  </section>
+  <h1 v-if="activeTab === 'settings'">Settings tab!</h1>
+</template>
+```
+</CodeGroup>
+</CodeLivePreview>

--- a/apps/beeq-docs/theming/global-css-variables.mdx
+++ b/apps/beeq-docs/theming/global-css-variables.mdx
@@ -1,0 +1,315 @@
+---
+title: Global CSS Variables
+description: Find out about every global CSS variable that BEEQ offers and their uses.
+---
+
+Global CSS variables are the foundation of the BEEQ theme system. They cover brand colors, neutrals, typography, spacing, radius, shadows, and strokes. On top of these base variables, semantic tokens map each value to a specific role in the UI — backgrounds, text, borders, icons, UI elements, and interactive states — and automatically adapt to light and dark mode.
+
+<Note>
+  Base variables are the foundation of your theme and should be set at the root level for global consistency. See the [Custom Theme](/theming/custom-theme) page for details on overriding them.
+</Note>
+
+---
+
+## Base theme variables
+
+Base variables define the raw design values for your theme. They are set once at the root level and consumed by the declarative color variables above them.
+
+### Brand & accent colors
+
+Your primary brand identity and the secondary highlight color.
+
+```css
+--bq-brand-light:  /* Light variant of brand color */
+--bq-brand:        /* Main brand color */
+--bq-brand-dark:   /* Dark variant of brand color */
+
+--bq-accent-light: /* Light variant of accent color */
+--bq-accent:       /* Main accent color */
+--bq-accent-dark:  /* Dark variant of accent color */
+```
+
+### State colors
+
+Used to convey meaning in the UI for actions and states such as success, danger, warning, and info.
+
+```css
+/* Success — for positive actions and states */
+--bq-success-light: /* Light success color */
+--bq-success:       /* Main success color */
+--bq-success-dark:  /* Dark success color */
+
+/* Danger — for errors and destructive actions */
+--bq-danger-light:  /* Light danger color */
+--bq-danger:        /* Main danger color */
+--bq-danger-dark:   /* Dark danger color */
+
+/* Warning — for cautionary messages */
+--bq-warning-light: /* Light warning color */
+--bq-warning:       /* Main warning color */
+--bq-warning-dark:  /* Dark warning color */
+
+/* Info — for informational messages */
+--bq-info-light:    /* Light info color */
+--bq-info:          /* Main info color */
+--bq-info-dark:     /* Dark info color */
+
+/* Focus — for focus indicators */
+--bq-focus:         /* Focus ring color */
+```
+
+### Neutral colors
+
+The neutral color scale provides a range of grays for backgrounds, borders, and text.
+
+```css
+--bq-white: /* Pure white or near-white */
+--bq-black: /* Pure black or near-black */
+
+/* Neutral scale (50–1000) */
+--bq-neutral-50:    /* Lightest neutral */
+--bq-neutral-100:   /* Very light neutral */
+--bq-neutral-200:   /* Light neutral */
+--bq-neutral-300:   /* Light-medium neutral */
+--bq-neutral-400:   /* Medium-light neutral */
+--bq-neutral-500:   /* Medium neutral */
+--bq-neutral-600:   /* Medium-dark neutral */
+--bq-neutral-700:   /* Dark-medium neutral */
+--bq-neutral-800:   /* Dark neutral */
+--bq-neutral-900:   /* Very dark neutral */
+--bq-neutral-950:   /* Extra dark neutral */
+--bq-neutral-1000:  /* Darkest neutral */
+```
+
+### Data visualization colors
+
+For charts and graphs — 12 distinct colors.
+
+```css
+--bq-data-01:  /* First data color */
+--bq-data-02:  /* Second data color */
+--bq-data-03:  /* Third data color */
+--bq-data-04:  /* Fourth data color */
+--bq-data-05:  /* Fifth data color */
+--bq-data-06:  /* Sixth data color */
+--bq-data-07:  /* Seventh data color */
+--bq-data-08:  /* Eighth data color */
+--bq-data-09:  /* Ninth data color */
+--bq-data-10:  /* Tenth data color */
+--bq-data-11:  /* Eleventh data color */
+--bq-data-12:  /* Twelfth data color */
+```
+
+### Typography
+
+Typography variables define font family, sizes, weights, and line heights.
+
+<Tip>
+  See also the [Typography](/foundations/typography) page for the full type system.
+</Tip>
+
+```css
+/* Font family */
+--bq-font-family: /* Main font stack, e.g., "'Outfit', sans-serif" */
+
+/* Font sizes */
+--bq-font-size--xs:   0.75rem;   /* 12px */
+--bq-font-size--s:    0.875rem;  /* 14px */
+--bq-font-size--m:    1rem;      /* 16px */
+--bq-font-size--l:    1.125rem;  /* 18px */
+--bq-font-size--xl:   1.5rem;    /* 24px */
+--bq-font-size--xxl:  2rem;      /* 32px */
+--bq-font-size--xxl2: 2.5rem;    /* 40px */
+--bq-font-size--xxl3: 3rem;      /* 48px */
+--bq-font-size--xxl4: 3.5rem;    /* 56px */
+--bq-font-size--xxl5: 4rem;      /* 64px */
+
+/* Font weights */
+--bq-font-weight--thin:     100;
+--bq-font-weight--light:    300;
+--bq-font-weight--regular:  400;
+--bq-font-weight--medium:   500;
+--bq-font-weight--semibold: 600;
+--bq-font-weight--bold:     700;
+--bq-font-weight--black:    900;
+
+/* Line heights */
+--bq-font-line-height--small:   1.2;
+--bq-font-line-height--regular: 1.5;
+--bq-font-line-height--large:   1.75;
+```
+
+### Spacing
+
+The spacing scale provides consistent spacing units for margins, paddings, and gaps. It is based on a 4px grid.
+
+<Tip>
+  See also the [Spacing](/foundations/spacing) page for the full spacing system.
+</Tip>
+
+```css
+--bq-spacing-xs3:  0.125rem;  /* 2px */
+--bq-spacing-xs2:  0.25rem;   /* 4px */
+--bq-spacing-xs:   0.5rem;    /* 8px */
+--bq-spacing-s:    0.75rem;   /* 12px */
+--bq-spacing-m:    1rem;      /* 16px */
+--bq-spacing-l:    1.5rem;    /* 24px */
+--bq-spacing-xl:   2rem;      /* 32px */
+--bq-spacing-xxl:  2.5rem;    /* 40px */
+--bq-spacing-xxl2: 3rem;      /* 48px */
+--bq-spacing-xxl3: 4rem;      /* 64px */
+--bq-spacing-xxl4: 5rem;      /* 80px */
+```
+
+### Border radius
+
+The border radius scale defines corner rounding for UI elements.
+
+<Tip>
+  See also the [Radius](/foundations/radius) page for full usage guidance.
+</Tip>
+
+```css
+--bq-radius--none: 0;
+--bq-radius--xs2:  0.125rem;  /* 2px */
+--bq-radius--xs:   0.25rem;   /* 4px */
+--bq-radius--s:    0.5rem;    /* 8px */
+--bq-radius--m:    0.75rem;   /* 12px */
+--bq-radius--l:    1.5rem;    /* 24px */
+--bq-radius--full: 9999px;
+```
+
+### Box shadow
+
+The box shadow scale provides elevation effects for UI elements.
+
+<Tip>
+  See also the [Shadows](/foundations/shadows) page for elevation guidance.
+</Tip>
+
+```css
+--bq-box-shadow--xs: 0 2px 0 rgba(0, 0, 0, 0.016);
+--bq-box-shadow--s:  0 8px 24px rgba(0, 0, 0, 0.04);
+--bq-box-shadow--m:  0 10px 48px -16px rgba(0, 0, 0, 0.12);
+--bq-box-shadow--l:  0 20px 58px -16px rgba(0, 0, 0, 0.16);
+```
+
+### Stroke
+
+The stroke width scale defines standard border widths.
+
+<Tip>
+  See also the [Stroke](/foundations/stroke) page for border usage guidance.
+</Tip>
+
+```css
+--bq-stroke-s: 1px;
+--bq-stroke-m: 2px;
+--bq-stroke-l: 3px;
+```
+
+---
+
+## Declarative color variables
+
+Semantic tokens are used throughout the components and change based on the theme mode (light/dark). Always prefer these over primitive values.
+
+### Background colors
+
+Used for various background surfaces such as pages, cards, and panels.
+
+```css
+--bq-background--primary:   /* Main background color */
+--bq-background--secondary: /* Secondary background (cards, panels) */
+--bq-background--tertiary:  /* Tertiary background (nested surfaces) */
+--bq-background--alt:       /* Alternative background */
+--bq-background--inverse:   /* Inverse background (tooltips, dark mode overlays) */
+--bq-background--brand:     /* Brand-colored backgrounds */
+--bq-background--overlay:   /* Overlay/backdrop color (with opacity) */
+```
+
+### Icon colors
+
+Used for SVG icons and graphical elements.
+
+```css
+--bq-icon--primary:   /* Primary icon color */
+--bq-icon--secondary: /* Secondary icon color */
+--bq-icon--inverse:   /* Inverse icon color */
+--bq-icon--brand:     /* Brand-colored icons */
+--bq-icon--alt:       /* Alternative icon color */
+--bq-icon--info:      /* Informational icons */
+--bq-icon--success:   /* Success state icons */
+--bq-icon--warning:   /* Warning state icons */
+--bq-icon--danger:    /* Error/danger icons */
+```
+
+### Border colors
+
+Used for borders and outlines around UI elements.
+
+```css
+--bq-stroke--primary:   /* Primary border color */
+--bq-stroke--secondary: /* Secondary border color */
+--bq-stroke--tertiary:  /* Tertiary border color */
+--bq-stroke--inverse:   /* Inverse border color */
+--bq-stroke--brand:     /* Brand-colored borders */
+--bq-stroke--alt:       /* Alternative border color */
+--bq-stroke--success:   /* Success state borders */
+--bq-stroke--warning:   /* Warning state borders */
+--bq-stroke--danger:    /* Error/danger borders */
+```
+
+### Text colors
+
+Used for typography and text elements.
+
+```css
+--bq-text--primary:   /* Primary text color */
+--bq-text--secondary: /* Secondary text color (muted) */
+--bq-text--inverse:   /* Inverse text color (on dark backgrounds) */
+--bq-text--brand:     /* Brand-colored text */
+--bq-text--alt:       /* Alternative text color */
+--bq-text--info:      /* Informational text */
+--bq-text--success:   /* Success state text */
+--bq-text--warning:   /* Warning state text */
+--bq-text--danger:    /* Error/danger text */
+```
+
+### UI colors
+
+Used for small UI elements like buttons, tags, and badges.
+
+```css
+--bq-ui--primary:      /* Primary UI element color */
+--bq-ui--secondary:    /* Secondary UI element color */
+--bq-ui--tertiary:     /* Tertiary UI element color */
+--bq-ui--inverse:      /* Inverse UI element color */
+--bq-ui--brand:        /* Brand-colored UI elements */
+--bq-ui--brand-alt:    /* Alternative brand UI color */
+--bq-ui--alt:          /* Alternative UI color */
+--bq-ui--success:      /* Success state UI color */
+--bq-ui--success-alt:  /* Alternative success UI color */
+--bq-ui--warning:      /* Warning state UI color */
+--bq-ui--warning-alt:  /* Alternative warning UI color */
+--bq-ui--danger:       /* Danger state UI color */
+--bq-ui--danger-alt:   /* Alternative danger UI color */
+```
+
+### State colors
+
+Used for interactive states like hover and active. They blend with a base color using the CSS [`color-mix()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-mix) function for better visual feedback.
+
+```css
+/* Example usage */
+/* color-mix(in srgb, var(--bq-ui--primary) 80%, var(--bq-state--hover) 20%) */
+
+--bq-state--hover:  /* Hover state blend color */
+--bq-state--active: /* Active/pressed state blend color */
+```
+
+---
+
+## Want to go further?
+
+Learn about the [component CSS variables](/theming/styles) exposed by each BEEQ component, and visit the [Customization](/theming/custom-theme) page for implementation details and examples.

--- a/apps/beeq-docs/theming/global-css-variables.mdx
+++ b/apps/beeq-docs/theming/global-css-variables.mdx
@@ -81,6 +81,14 @@ The neutral color scale provides a range of grays for backgrounds, borders, and 
 --bq-neutral-1000:  /* Darkest neutral */
 ```
 
+<Tip>
+  BEEQ also provides an extensive primitive color palette — blue, coral, cyan, gold, green, indigo,
+  iris, lime, magenta, orange, purple, red, sky, teal, volcano, and yellow (each with 10 shades, 100–1000).
+  Use these when defining brand and accent tokens in a custom theme.
+
+  See the [Colors](/foundations/colors) page for the full palette and guidance on usage.
+</Tip>
+
 ### Data visualization colors
 
 For charts and graphs — 12 distinct colors.
@@ -310,6 +318,13 @@ Used for interactive states like hover and active. They blend with a base color 
 
 ---
 
-## Want to go further?
+## Next steps
 
-Learn about the [component CSS variables](/theming/styles) exposed by each BEEQ component, and visit the [Customization](/theming/custom-theme) page for implementation details and examples.
+<CardGroup cols={2}>
+  <Card horizontal title="Component CSS variables" icon="palette" href="/theming/component-css-variables">
+    Explore the CSS variables exposed by each BEEQ component for targeted, scoped customization.
+  </Card>
+  <Card horizontal title="Custom Theme" icon="paintbrush" href="/theming/custom-theme">
+    Follow the step-by-step guide to create and apply a fully custom theme to your app.
+  </Card>
+</CardGroup>

--- a/apps/beeq-docs/theming/overview.mdx
+++ b/apps/beeq-docs/theming/overview.mdx
@@ -1,0 +1,252 @@
+---
+title: Themes & Modes
+description: The BEEQ design system supports two themes — **beeq** and **endava** — and two modes — **dark** and **light**. You can apply these styles using HTML attributes or CSS classes.
+---
+
+Themes and modes let you adapt the look and feel of your product for different brand identities and user preferences. They form part of the **BEEQ Design System**, which provides consistent, scalable UI foundations for all types of projects.
+
+Currently, BEEQ offers two ready-to-use themes:
+
+- **BEEQ**: The default theme, featuring a simple and user-friendly layout suitable for different applications. Ideal for apps and products following the default BEEQ brand guidelines.
+- **ENDAVA**: Designed for internal Endava applications, giving a corporate feel. Use this for projects where you need to match Endava's corporate branding.
+
+Modes allow your interface to respect user preferences for light or dark backgrounds, improving accessibility, focus, and comfort in various environments:
+
+- **Light Mode**: Best during daytime or well-lit environments, or when a more neutral design is preferred.
+- **Dark Mode**: Reduces eye strain in low-light settings, saves device battery, and gives a modern appearance.
+
+<Note>
+  Explore related sections: [Colors](/foundations/colors), [Global CSS Variables](/theming/global-css-variables), and [Customization](/theming/custom-theme).
+</Note>
+
+---
+
+## Applying themes
+
+BEEQ lets you apply themes using either HTML attributes (recommended) or CSS classes, ensuring a consistent look for every application.
+
+### Using HTML attributes
+
+Set the `bq-theme` attribute on the `<html>` element (recommended) or the `<body>` tag.
+
+```html
+<html bq-theme="beeq">
+  <!-- Your content here -->
+</html>
+```
+
+```html
+<html bq-theme="endava">
+  <!-- Your content here -->
+</html>
+```
+
+### Using CSS classes
+
+Alternatively, apply themes using CSS classes directly on the root element.
+
+```html
+<html class="beeq">
+  <!-- Your content here -->
+</html>
+```
+
+```html
+<html class="endava">
+  <!-- Your content here -->
+</html>
+```
+
+<Note>
+  When applying a theme, maintain consistency and avoid mixing different themes throughout the app.
+</Note>
+
+---
+
+## Applying modes
+
+Modes let you switch between light and dark color schemes to match user preferences or specific app needs. You can control modes globally or for specific sections using HTML attributes or CSS classes.
+
+### Using HTML attributes
+
+Set the `bq-mode` attribute to control the color scheme.
+
+```html
+<html bq-mode="dark">
+  <!-- Your content here -->
+</html>
+```
+
+```html
+<html bq-mode="light">
+  <!-- Your content here -->
+</html>
+```
+
+### Using CSS classes
+
+```html
+<html class="dark">
+  <!-- Your content here -->
+</html>
+```
+
+```html
+<html class="light">
+  <!-- Your content here -->
+</html>
+```
+
+### Combining modes
+
+You can mix and match modes at various levels of your layout. For instance, you might use dark mode for the main section of your app and switch to light mode for a nested component.
+
+```html
+<html bq-mode="dark">
+  <body>
+    <!-- Your content here -->
+    <section bq-mode="light">
+      <!-- This section applies light mode to all elements and components inside -->
+    </section>
+  </body>
+</html>
+```
+
+---
+
+## User's color scheme preferences
+
+**BEEQ does not automatically detect or apply the user's preferred color scheme.** It is up to you to control whether users see light or dark mode in your app. To provide a better experience:
+
+- Make the `prefers-color-scheme` setting your default.
+- Allow users to switch this option in your app.
+- Remember their choice and apply it when they log in or return to the app.
+
+The `prefers-color-scheme` media query is not used by BEEQ automatically, as not all applications support dark mode, which might cause problems for those that don't.
+
+### Example
+
+Here is a working example showing how to read the user's preferred color scheme on load and let them toggle it using a `bq-switch`.
+
+<Tip>
+  You can toggle the documentation between light and dark mode from the top bar and see how the theme changes in the example.
+</Tip>
+
+<CodeGroup>
+```css styles.css
+@import "@beeq/core/dist/beeq/beeq.css";
+
+.nav-bar {
+  display: flex;
+  justify-content: center;
+  background-color: var(--bq-ui--primary);
+  border-bottom: 1px solid var(--bq-stroke--primary);
+}
+
+.nav-bar__main {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  justify-content: end;
+  gap: var(--bq-spacing-xl);
+  padding: var(--bq-spacing-m);
+  max-width: 1440px;
+
+  @media (min-width: 600px) {
+    flex-direction: row;
+  }
+}
+
+.nav-bar__mode {
+  display: flex;
+  align-items: center;
+  gap: var(--bq-spacing-xs);
+  color: var(--bq-text--primary);
+}
+
+.main {
+  padding: var(--bq-spacing-m);
+
+  h1 {
+    margin-block-end: var(--bq-spacing-l);
+  }
+}
+
+.content {
+  background: var(--bq-ui--alt);
+  border: 2px dashed var(--bq-stroke--primary);
+  height: 10rem;
+  width: 100%;
+}
+```
+
+```ts index.ts
+import type { BqSwitchCustomEvent } from '@beeq/core';
+import "./styles.css";
+
+const switcher = document.querySelector('bq-switch[name="mode"]') as HTMLBqSwitchElement | null;
+if (!switcher) {
+  throw new Error('bq-switch[name="mode"] not found');
+}
+
+// Get the user's preferred color scheme when the page loads
+const prefersDark = window.matchMedia
+  ? window.matchMedia('(prefers-color-scheme: dark)').matches
+  : false;
+
+// Reflect initial theme mode based on the user's color scheme
+switcher.checked = prefersDark;
+setThemeMode(prefersDark);
+
+// Handle changes from the BEEQ switch button interaction
+switcher.addEventListener('bqChange', (event: BqSwitchCustomEvent<{ checked: boolean }>) => {
+  setThemeMode(event.detail.checked);
+});
+
+function setThemeMode(isDark: boolean) {
+  try {
+    document.documentElement.setAttribute('bq-mode', isDark ? 'dark' : 'light');
+  } catch (error) {
+    throw new Error(`Unable to set the theme mode preference: ${error}`);
+  }
+}
+```
+
+```html index.html
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>BEEQ Theme Mode</title>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <header class="nav-bar">
+      <div class="nav-bar__main">
+        <div class="nav-bar__mode">
+          <bq-icon name="sun-thin"></bq-icon>
+          <bq-switch name="mode"></bq-switch>
+          <bq-icon name="moon-fill"></bq-icon>
+        </div>
+      </div>
+    </header>
+
+    <main class="main">
+      <h1>Dashboard</h1>
+      <div class="content">
+        <!-- Your content -->
+      </div>
+    </main>
+
+    <script src="index.ts"></script>
+  </body>
+</html>
+```
+</CodeGroup>
+
+---
+
+## Next steps
+
+- For advanced customization, visit the [Customization guide](/theming/custom-theme).
+- To understand the color tokens powering themes and modes, see [Global CSS Variables](/theming/global-css-variables).

--- a/apps/beeq-docs/theming/overview.mdx
+++ b/apps/beeq-docs/theming/overview.mdx
@@ -3,17 +3,10 @@ title: Themes & Modes
 description: The BEEQ design system supports two themes — **beeq** and **endava** — and two modes — **dark** and **light**. You can apply these styles using HTML attributes or CSS classes.
 ---
 
-Themes and modes let you adapt the look and feel of your product for different brand identities and user preferences. They form part of the **BEEQ Design System**, which provides consistent, scalable UI foundations for all types of projects.
+import { CodeLivePreview } from "/snippets/CodeLivePreview.jsx";
 
-Currently, BEEQ offers two ready-to-use themes:
-
-- **BEEQ**: The default theme, featuring a simple and user-friendly layout suitable for different applications. Ideal for apps and products following the default BEEQ brand guidelines.
-- **ENDAVA**: Designed for internal Endava applications, giving a corporate feel. Use this for projects where you need to match Endava's corporate branding.
-
-Modes allow your interface to respect user preferences for light or dark backgrounds, improving accessibility, focus, and comfort in various environments:
-
-- **Light Mode**: Best during daytime or well-lit environments, or when a more neutral design is preferred.
-- **Dark Mode**: Reduces eye strain in low-light settings, saves device battery, and gives a modern appearance.
+Themes and modes let you adapt the look and feel of your product to match different brand identities and user preferences — making BEEQ suitable for both consumer-facing apps and internal tools.
+BEEQ also supports mixing modes within the same layout, so individual sections can use a different color scheme from the rest of the page.
 
 <Note>
   Explore related sections: [Colors](/foundations/colors), [Global CSS Variables](/theming/global-css-variables), and [Customization](/theming/custom-theme).
@@ -129,124 +122,332 @@ The `prefers-color-scheme` media query is not used by BEEQ automatically, as not
 Here is a working example showing how to read the user's preferred color scheme on load and let them toggle it using a `bq-switch`.
 
 <Tip>
-  You can toggle the documentation between light and dark mode from the top bar and see how the theme changes in the example.
+  Toggle the `bq-switch` in the live preview below to switch between light and dark mode. You can also use the Mintlify top-bar toggle to change the page mode and see how the theme variables adapt.
 </Tip>
 
-<CodeGroup>
-```css styles.css
-@import "@beeq/core/dist/beeq/beeq.css";
+<CodeLivePreview code={`
+  <style>
+    :host {
+      flex-direction: column !important;
+      align-items: stretch !important;
+      padding: 0 !important;
+    }
 
-.nav-bar {
-  display: flex;
-  justify-content: center;
-  background-color: var(--bq-ui--primary);
-  border-bottom: 1px solid var(--bq-stroke--primary);
-}
+    .nav-bar {
+      display: flex;
+      justify-content: center;
+      background-color: var(--bq-ui--primary);
+      border-bottom: 1px solid var(--bq-stroke--primary);
+    }
 
-.nav-bar__main {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  flex-direction: column;
-  justify-content: end;
-  gap: var(--bq-spacing-xl);
-  padding: var(--bq-spacing-m);
-  max-width: 1440px;
+    .nav-bar__main {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      flex-direction: row;
+      justify-content: flex-end;
+      gap: var(--bq-spacing-xl);
+      padding: var(--bq-spacing-m);
+      max-width: 1440px;
+    }
 
-  @media (min-width: 600px) {
-    flex-direction: row;
-  }
-}
+    .nav-bar__mode {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+      color: var(--bq-text--primary);
+    }
 
-.nav-bar__mode {
-  display: flex;
-  align-items: center;
-  gap: var(--bq-spacing-xs);
-  color: var(--bq-text--primary);
-}
+    .main {
+      padding: var(--bq-spacing-m);
+    }
 
-.main {
-  padding: var(--bq-spacing-m);
+    .main h1 {
+      margin-block-end: var(--bq-spacing-l);
+      color: var(--bq-text--primary);
+    }
 
-  h1 {
-    margin-block-end: var(--bq-spacing-l);
-  }
-}
+    .content {
+      background: var(--bq-ui--alt);
+      border: 2px dashed var(--bq-stroke--primary);
+      height: 10rem;
+      width: 100%;
+    }
+  </style>
 
-.content {
-  background: var(--bq-ui--alt);
-  border: 2px dashed var(--bq-stroke--primary);
-  height: 10rem;
-  width: 100%;
-}
-```
+  <header class="nav-bar">
+    <div class="nav-bar__main">
+      <div class="nav-bar__mode">
+        <bq-icon name="sun-thin"></bq-icon>
+        <bq-switch name="mode"></bq-switch>
+        <bq-icon name="moon-fill"></bq-icon>
+      </div>
+    </div>
+  </header>
 
-```ts index.ts
-import type { BqSwitchCustomEvent } from '@beeq/core';
-import "./styles.css";
+  <main class="main">
+    <h1>Dashboard</h1>
+    <div class="content"></div>
+  </main>
 
-const switcher = document.querySelector('bq-switch[name="mode"]') as HTMLBqSwitchElement | null;
-if (!switcher) {
-  throw new Error('bq-switch[name="mode"] not found');
-}
+  <script>
+    (() => {
+      const switcher = previewRoot.querySelector('bq-switch[name="mode"]');
+      if (!switcher) return;
+      const prefersDark = window.matchMedia
+        ? window.matchMedia('(prefers-color-scheme: dark)').matches
+        : false;
+      switcher.checked = prefersDark;
+      setThemeMode(prefersDark);
+      switcher.addEventListener('bqChange', (event) => {
+        setThemeMode(event.detail.checked);
+      });
+      function setThemeMode(isDark) {
+        previewRoot.host.setAttribute('bq-mode', isDark ? 'dark' : 'light');
+      }
+    })();
+  </script>
+`}>
+  <CodeGroup>
+    ```css CSS icon="css" expandable
+    @import "@beeq/core/dist/beeq/beeq.css";
 
-// Get the user's preferred color scheme when the page loads
-const prefersDark = window.matchMedia
-  ? window.matchMedia('(prefers-color-scheme: dark)').matches
-  : false;
+    .nav-bar {
+      display: flex;
+      justify-content: center;
+      background-color: var(--bq-ui--primary);
+      border-bottom: 1px solid var(--bq-stroke--primary);
+    }
 
-// Reflect initial theme mode based on the user's color scheme
-switcher.checked = prefersDark;
-setThemeMode(prefersDark);
+    .nav-bar__main {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      flex-direction: column;
+      justify-content: end;
+      gap: var(--bq-spacing-xl);
+      padding: var(--bq-spacing-m);
+      max-width: 1440px;
 
-// Handle changes from the BEEQ switch button interaction
-switcher.addEventListener('bqChange', (event: BqSwitchCustomEvent<{ checked: boolean }>) => {
-  setThemeMode(event.detail.checked);
-});
+      @media (min-width: 600px) {
+        flex-direction: row;
+      }
+    }
 
-function setThemeMode(isDark: boolean) {
-  try {
-    document.documentElement.setAttribute('bq-mode', isDark ? 'dark' : 'light');
-  } catch (error) {
-    throw new Error(`Unable to set the theme mode preference: ${error}`);
-  }
-}
-```
+    .nav-bar__mode {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+      color: var(--bq-text--primary);
+    }
 
-```html index.html
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>BEEQ Theme Mode</title>
-    <meta charset="UTF-8" />
-  </head>
-  <body>
-    <header class="nav-bar">
-      <div class="nav-bar__main">
-        <div class="nav-bar__mode">
-          <bq-icon name="sun-thin"></bq-icon>
-          <bq-switch name="mode"></bq-switch>
-          <bq-icon name="moon-fill"></bq-icon>
+    .main {
+      padding: var(--bq-spacing-m);
+
+      h1 {
+        margin-block-end: var(--bq-spacing-l);
+      }
+    }
+
+    .content {
+      background: var(--bq-ui--alt);
+      border: 2px dashed var(--bq-stroke--primary);
+      height: 10rem;
+      width: 100%;
+    }
+    ```
+
+    ```ts TypeScript icon="js" expandable
+    import type { BqSwitchCustomEvent } from '@beeq/core';
+    import "./styles.css";
+
+    const switcher = document.querySelector('bq-switch[name="mode"]') as HTMLBqSwitchElement | null;
+    if (!switcher) {
+      throw new Error('bq-switch[name="mode"] not found');
+    }
+
+    // Get the user's preferred color scheme when the page loads
+    const prefersDark = window.matchMedia
+      ? window.matchMedia('(prefers-color-scheme: dark)').matches
+      : false;
+
+    // Reflect initial theme mode based on the user's color scheme
+    switcher.checked = prefersDark;
+    setThemeMode(prefersDark);
+
+    // Handle changes from the BEEQ switch button interaction
+    switcher.addEventListener('bqChange', (event: BqSwitchCustomEvent<{ checked: boolean }>) => {
+      setThemeMode(event.detail.checked);
+    });
+
+    function setThemeMode(isDark: boolean) {
+      document.documentElement.setAttribute('bq-mode', isDark ? 'dark' : 'light');
+    }
+    ```
+
+    ```html HTML icon="html5" expandable
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>BEEQ Theme Mode</title>
+        <meta charset="UTF-8" />
+      </head>
+      <body>
+        <header class="nav-bar">
+          <div class="nav-bar__main">
+            <div class="nav-bar__mode">
+              <bq-icon name="sun-thin"></bq-icon>
+              <bq-switch name="mode"></bq-switch>
+              <bq-icon name="moon-fill"></bq-icon>
+            </div>
+          </div>
+        </header>
+
+        <main class="main">
+          <h1>Dashboard</h1>
+          <div class="content">
+            <!-- Your content -->
+          </div>
+        </main>
+
+        <script src="index.ts"></script>
+      </body>
+    </html>
+    ```
+
+    ```tsx React icon="react" expandable
+    import { useState, useEffect } from "react";
+    import { BqIcon, BqSwitch } from "@beeq/react";
+    import "./styles.css";
+
+    export default function App() {
+      const [isDark, setIsDark] = useState(
+        () => window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false
+      );
+
+      useEffect(() => {
+        document.documentElement.setAttribute("bq-mode", isDark ? "dark" : "light");
+      }, [isDark]);
+
+      const handleModeChange = (event: CustomEvent<{ checked: boolean }>) => {
+        setIsDark(event.detail.checked);
+      };
+
+      return (
+        <>
+          <header className="nav-bar">
+            <div className="nav-bar__main">
+              <div className="nav-bar__mode">
+                <BqIcon name="sun-thin" />
+                <BqSwitch name="mode" checked={isDark} onBqChange={handleModeChange} />
+                <BqIcon name="moon-fill" />
+              </div>
+            </div>
+          </header>
+          <main className="main">
+            <h1>Dashboard</h1>
+            <div className="content" />
+          </main>
+        </>
+      );
+    }
+    ```
+
+    ```ts Angular icon="angular" expandable
+    import { Component, OnInit, inject, signal } from "@angular/core";
+    import { DOCUMENT } from "@angular/common";
+    import { BqIcon, BqSwitch } from "@beeq/angular/standalone";
+
+    @Component({
+      standalone: true,
+      imports: [BqIcon, BqSwitch],
+      styleUrl: "./styles.css",
+      template: `
+        <header class="nav-bar">
+          <div class="nav-bar__main">
+            <div class="nav-bar__mode">
+              <bq-icon name="sun-thin"></bq-icon>
+              <bq-switch name="mode" [attr.checked]="isDark() || null" (bqChange)="handleModeChange($event)"></bq-switch>
+              <bq-icon name="moon-fill"></bq-icon>
+            </div>
+          </div>
+        </header>
+        <main class="main">
+          <h1>Dashboard</h1>
+          <div class="content"></div>
+        </main>
+      `,
+    })
+    export class AppComponent implements OnInit {
+      private readonly document = inject(DOCUMENT);
+      readonly isDark = signal(false);
+
+      ngOnInit() {
+        const prefersDark = window.matchMedia
+          ? window.matchMedia("(prefers-color-scheme: dark)").matches
+          : false;
+        this.isDark.set(prefersDark);
+        this.document.documentElement.setAttribute("bq-mode", prefersDark ? "dark" : "light");
+      }
+
+      handleModeChange(event: CustomEvent<{ checked: boolean }>) {
+        const isDark = event.detail.checked;
+        this.isDark.set(isDark);
+        this.document.documentElement.setAttribute("bq-mode", isDark ? "dark" : "light");
+      }
+    }
+    ```
+
+    ```vue Vue icon="vuejs" expandable
+    <script setup lang="ts">
+    import { ref, watch, onMounted } from "vue";
+    import { BqIcon, BqSwitch } from "@beeq/vue";
+
+    const isDark = ref(
+      window.matchMedia ? window.matchMedia("(prefers-color-scheme: dark)").matches : false
+    );
+
+    onMounted(() => {
+      document.documentElement.setAttribute("bq-mode", isDark.value ? "dark" : "light");
+    });
+
+    watch(isDark, (value) => {
+      document.documentElement.setAttribute("bq-mode", value ? "dark" : "light");
+    });
+
+    function handleModeChange(event: CustomEvent<{ checked: boolean }>) {
+      isDark.value = event.detail.checked;
+    }
+    </script>
+
+    <template>
+      <header class="nav-bar">
+        <div class="nav-bar__main">
+          <div class="nav-bar__mode">
+            <BqIcon name="sun-thin" />
+            <BqSwitch name="mode" :checked="isDark" @bqChange="handleModeChange" />
+            <BqIcon name="moon-fill" />
+          </div>
         </div>
-      </div>
-    </header>
-
-    <main class="main">
-      <h1>Dashboard</h1>
-      <div class="content">
-        <!-- Your content -->
-      </div>
-    </main>
-
-    <script src="index.ts"></script>
-  </body>
-</html>
-```
-</CodeGroup>
+      </header>
+      <main class="main">
+        <h1>Dashboard</h1>
+        <div class="content" />
+      </main>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
 
 ---
 
 ## Next steps
 
-- For advanced customization, visit the [Customization guide](/theming/custom-theme).
-- To understand the color tokens powering themes and modes, see [Global CSS Variables](/theming/global-css-variables).
+<CardGroup cols={2}>
+  <Card horizontal title="Custom Theme" icon="paintbrush" href="/theming/custom-theme">
+    Follow the step-by-step guide to create and apply a fully custom theme to your app.
+  </Card>
+  <Card horizontal title="Global CSS Variables" icon="palette" href="/theming/global-css-variables">
+    Explore the color tokens and base variables that power BEEQ themes and modes.
+  </Card>
+</CardGroup>

--- a/apps/beeq-docs/theming/styles.mdx
+++ b/apps/beeq-docs/theming/styles.mdx
@@ -1,0 +1,255 @@
+---
+title: Component CSS Variables
+description: Each BEEQ component exposes CSS custom properties that give you fine-grained control over styling without touching global variables.
+---
+
+import { CodeLivePreview } from "/snippets/CodeLivePreview.jsx";
+
+Each component provides its own CSS custom properties, scoped to that component. This lets you tweak colors, spacing, or other design tokens locally without breaking consistency across the theme. You can find the component CSS variables listed at the bottom of each component documentation page.
+
+<Tip>
+  For quick reference, you can also check these variables documented in each component's `scss/*.variables.scss` file on [GitHub](https://github.com/Endava/BEEQ/tree/main/packages/beeq/src/components).
+</Tip>
+
+---
+
+## How to override component CSS variables
+
+There are two strategies for customizing a BEEQ component's styles:
+
+<CardGroup cols={2}>
+  <Card title="Global override" icon="globe">
+    Set CSS custom properties on the component element selector to apply changes across **all instances** of a component in your theme.
+  </Card>
+  <Card title="Targeted override" icon="crosshairs">
+    Use CSS classes or specific component selectors to customize **individual instances** without affecting others.
+  </Card>
+</CardGroup>
+
+### Global override
+
+Set CSS custom properties directly on the component selector. This applies the customization to all instances of that component across your entire application.
+
+```css
+bq-<component> {
+  --bq-<component>--<property>: value;
+}
+```
+
+### Targeted override
+
+Create a custom CSS class and apply it to specific component instances. This gives fine-grained control without affecting other instances.
+
+```css
+.my-component-variant {
+  --bq-<component>--<property>: value;
+}
+```
+
+```html
+<bq-component class="my-component-variant">Content</bq-component>
+```
+
+---
+
+## Example: customizing the Badge component
+
+The [Badge](/components/badge) component exposes the following CSS custom properties (see [`bq-badge.variables.scss`](https://github.com/Endava/BEEQ/blob/main/packages/beeq/src/components/badge/scss/bq-badge.variables.scss)):
+
+```css
+--bq-badge--background-color: /* Badge background */
+--bq-badge--box-shadow:       /* Badge shadow */
+--bq-badge--border-color:     /* Badge border color */
+--bq-badge--border-radius:    /* Badge border radius */
+--bq-badge--border-style:     /* Badge border style */
+--bq-badge--border-width:     /* Badge border width */
+--bq-badge--size-small:       /* Small badge size (8px) */
+--bq-badge--size-medium:      /* Medium badge size (12px) */
+--bq-badge--size-large:       /* Large badge size (16px) */
+--bq-badge--text-color:       /* Badge text color */
+```
+
+### Global override
+
+Applies the custom styles to every `bq-badge` in the application.
+
+<CodeLivePreview code={`
+  <style>
+    :host {
+      flex-direction: row !important;
+      flex-wrap: wrap !important;
+    }
+    
+    bq-badge {
+      --bq-badge--background-color: var(--bq-green-400);
+      --bq-badge--box-shadow: var(--bq-box-shadow--l);
+      --bq-badge--border-color: var(--bq-green-600);
+      --bq-badge--border-style: solid;
+      --bq-badge--border-width: 1px;
+      --bq-badge--border-radius: 4px;
+    }
+  </style>
+    <bq-badge size="small"></bq-badge>
+    <bq-badge size="medium"></bq-badge>
+    <bq-badge>99+</bq-badge>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-badge size="small"></bq-badge>
+    <bq-badge size="medium"></bq-badge>
+    <bq-badge>99+</bq-badge>
+    ```
+
+    ```jsx React icon="react"
+    import { BqBadge } from "@beeq/react";
+    // Import the CSS override in your global stylesheet (see CSS tab)
+
+    <BqBadge size="small" />
+    <BqBadge size="medium" />
+    <BqBadge>99+</BqBadge>
+    ```
+
+    ```html Angular icon="angular"
+    <!-- Standalone: import { BqBadge } from "@beeq/angular/standalone" -->
+    <!-- Modules: components are available after importing BeeQModule -->
+    <!-- Import the CSS override in your global stylesheet (see CSS tab) -->
+
+    <bq-badge size="small"></bq-badge>
+    <bq-badge size="medium"></bq-badge>
+    <bq-badge>99+</bq-badge>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqBadge } from "@beeq/vue";
+    // Import the CSS override in your global stylesheet (see CSS tab)
+    </script>
+
+    <template>
+      <BqBadge size="small" />
+      <BqBadge size="medium" />
+      <BqBadge>99+</BqBadge>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+### Targeted override
+
+Only the `bq-badge` elements with the matching CSS class will have the overridden style.
+
+<CodeLivePreview code={`
+  <style>
+    :host {
+      flex-direction: row !important;
+      flex-wrap: wrap !important;
+    }
+    
+    bq-badge.success {
+      --bq-badge--background-color: var(--bq-green-400);
+      --bq-badge--box-shadow: var(--bq-box-shadow--l);
+      --bq-badge--border-color: var(--bq-green-600);
+      --bq-badge--border-style: solid;
+      --bq-badge--border-width: 1px;
+      --bq-badge--border-radius: 4px;
+    }
+  </style>
+
+  <bq-badge size="small"></bq-badge>
+  <bq-badge size="medium"></bq-badge>
+  <bq-badge>99+</bq-badge>
+  <bq-badge class="success">completed</bq-badge>
+`}>
+  <CodeGroup>
+    ```html HTML icon="html5"
+    <bq-badge size="small"></bq-badge>
+    <bq-badge size="medium"></bq-badge>
+    <bq-badge>99+</bq-badge>
+    <bq-badge class="success">completed</bq-badge>
+    ```
+
+    ```jsx React icon="react"
+    import { BqBadge } from "@beeq/react";
+    // Import the CSS override in your global stylesheet (see CSS tab)
+
+    <BqBadge size="small" />
+    <BqBadge size="medium" />
+    <BqBadge>99+</BqBadge>
+    <BqBadge className="success">completed</BqBadge>
+    ```
+
+    ```html Angular icon="angular"
+    <!-- Standalone: import { BqBadge } from "@beeq/angular/standalone" -->
+    <!-- Modules: components are available after importing BeeQModule -->
+    <!-- Import the CSS override in your global stylesheet (see CSS tab) -->
+
+    <bq-badge size="small"></bq-badge>
+    <bq-badge size="medium"></bq-badge>
+    <bq-badge>99+</bq-badge>
+    <bq-badge class="success">completed</bq-badge>
+    ```
+
+    ```vue Vue icon="vuejs"
+    <script setup lang="ts">
+    import { BqBadge } from "@beeq/vue";
+    // Import the CSS override in your global stylesheet (see CSS tab)
+    </script>
+
+    <template>
+      <BqBadge size="small" />
+      <BqBadge size="medium" />
+      <BqBadge>99+</BqBadge>
+      <BqBadge class="success">completed</BqBadge>
+    </template>
+    ```
+  </CodeGroup>
+</CodeLivePreview>
+
+---
+
+## Best practices
+
+<CardGroup cols={2}>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Use semantic tokens
+    </span>
+    Prefer declarative color variables (`--bq-background--primary`) over primitive values (`--bq-grey-100`) in your custom themes for better consistency and automatic mode switching.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Test both modes
+    </span>
+    Always test your custom theme in both light and dark modes to ensure proper contrast and readability.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Scope component overrides
+    </span>
+    When customizing individual components, use CSS classes or component selectors to scope your changes and avoid unintended side effects.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Maintain accessibility
+    </span>
+    Ensure sufficient color contrast ratios. WCAG 2.1 Level AA requires 4.5:1 for normal text and 3:1 for large text.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Use CSS variables for flexibility
+    </span>
+    Expose your own CSS variables if you are building reusable component patterns on top of BEEQ.
+  </Card>
+  <Card>
+    <span className="flex items-center mr-2 text-lg font-medium" role="heading">
+      <Icon className="mr-2" icon="check" iconType="solid" size={20} color="var(--bq-stroke--success)" />
+      Leverage primitive colors
+    </span>
+    Use the extensive [primitive color palette](/foundations/colors) when defining theme colors. It includes blue, coral, cyan, gold, green, indigo, iris, lime, magenta, orange, purple, red, sky, teal, volcano, and yellow — each with 10 shades (100–1000).
+  </Card>
+</CardGroup>

--- a/apps/beeq-docs/theming/styles.mdx
+++ b/apps/beeq-docs/theming/styles.mdx
@@ -94,6 +94,17 @@ Applies the custom styles to every `bq-badge` in the application.
     <bq-badge>99+</bq-badge>
 `}>
   <CodeGroup>
+    ```css CSS icon="css3"
+    bq-badge {
+      --bq-badge--background-color: var(--bq-green-400);
+      --bq-badge--box-shadow: var(--bq-box-shadow--l);
+      --bq-badge--border-color: var(--bq-green-600);
+      --bq-badge--border-style: solid;
+      --bq-badge--border-width: 1px;
+      --bq-badge--border-radius: 4px;
+    }
+    ```
+
     ```html HTML icon="html5"
     <bq-badge size="small"></bq-badge>
     <bq-badge size="medium"></bq-badge>
@@ -168,6 +179,17 @@ Only the `bq-badge` elements with the matching CSS class will have the overridde
   <bq-badge class="success">completed</bq-badge>
 `}>
   <CodeGroup>
+    ```css CSS icon="css3"
+    bq-badge.success {
+      --bq-badge--background-color: var(--bq-green-400);
+      --bq-badge--box-shadow: var(--bq-box-shadow--l);
+      --bq-badge--border-color: var(--bq-green-600);
+      --bq-badge--border-style: solid;
+      --bq-badge--border-width: 1px;
+      --bq-badge--border-radius: 4px;
+    }
+    ```
+
     ```html HTML icon="html5"
     <bq-badge size="small"></bq-badge>
     <bq-badge size="medium"></bq-badge>

--- a/apps/beeq-docs/theming/styles.mdx
+++ b/apps/beeq-docs/theming/styles.mdx
@@ -109,14 +109,21 @@ Applies the custom styles to every `bq-badge` in the application.
     <BqBadge>99+</BqBadge>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqBadge } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-    <!-- Import the CSS override in your global stylesheet (see CSS tab) -->
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqBadge } from "@beeq/angular/standalone";
 
-    <bq-badge size="small"></bq-badge>
-    <bq-badge size="medium"></bq-badge>
-    <bq-badge>99+</bq-badge>
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqBadge],
+      template: `
+        <bq-badge size="small"></bq-badge>
+        <bq-badge size="medium"></bq-badge>
+        <bq-badge>99+</bq-badge>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -178,15 +185,22 @@ Only the `bq-badge` elements with the matching CSS class will have the overridde
     <BqBadge className="success">completed</BqBadge>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqBadge } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-    <!-- Import the CSS override in your global stylesheet (see CSS tab) -->
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqBadge } from "@beeq/angular/standalone";
 
-    <bq-badge size="small"></bq-badge>
-    <bq-badge size="medium"></bq-badge>
-    <bq-badge>99+</bq-badge>
-    <bq-badge class="success">completed</bq-badge>
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqBadge],
+      template: `
+        <bq-badge size="small"></bq-badge>
+        <bq-badge size="medium"></bq-badge>
+        <bq-badge>99+</bq-badge>
+        <bq-badge class="success">completed</bq-badge>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/theming/themes-and-modes.mdx
+++ b/apps/beeq-docs/theming/themes-and-modes.mdx
@@ -238,7 +238,7 @@ function setThemeMode(isDark: boolean) {
       </div>
     </main>
 
-    <script src="index.ts"></script>
+    <script type="module" src="/src/index.ts"></script>
   </body>
 </html>
 ```


### PR DESCRIPTION
## Description
Adds the missing Theming & Customization documentation pages.

## Documentation
This PR adds documentation in `apps/beeq-docs`:
- adds `theming/overview.mdx`
- adds `theming/global-css-variables.mdx`
- adds `theming/styles.mdx`
- adds `theming/custom-theme.mdx`
- updates `docs.json` navigation to include the new "Theming & customization" group under Guides

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [ ] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
- The TechFlow full example renders in dark mode by default and includes a ghost toggle button to switch between dark and light — all four framework tabs reflect the same toggle pattern.
- ❌ SVG assets (overview/anatomy images) are still pending for all pages in this batch — placeholder `<Frame>` image paths are in place and will be replaced once assets are delivered.