### PR TITLE
docs: angular standalone accent and vue + angular inline style improvements

### DIFF
--- a/apps/beeq-docs/components/accordion.mdx
+++ b/apps/beeq-docs/components/accordion.mdx
@@ -100,6 +100,7 @@ Accordion items are collapsed by default. This works best when the heading alone
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAccordion } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -159,6 +160,7 @@ Use the `expanded` attribute when a section should start open — for example wh
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAccordion } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -244,6 +246,7 @@ Two appearance values are available:
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAccordion } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -334,6 +337,7 @@ The `small` size uses more compact padding and a smaller border radius, giving i
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAccordion } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -447,6 +451,7 @@ Use the default group behavior when the sections are mutually exclusive or when 
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAccordionGroup, BqAccordion } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -556,6 +561,7 @@ Allow multiple sections to stay open when people may need to review, reference, 
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAccordionGroup, BqAccordion } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -697,6 +703,7 @@ These provide additional context to help people scan and understand the sections
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAccordion, BqIcon, BqAvatar } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -798,6 +805,7 @@ Use `disabled` only when a section is temporarily unavailable. The header will n
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAccordion } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -878,6 +886,7 @@ Add the `no-animation` attribute to disable this and make the panel appear/disap
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAccordion } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -993,6 +1002,7 @@ Alternatively, combine a single icon in the `expand` slot with the `rotate` prop
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAccordion, BqIcon } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -1147,6 +1157,7 @@ Developers can [rely on the exposed shadow DOM parts](https://www.beeq.design/3d
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAccordionGroup, BqAccordion, BqIcon } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,

--- a/apps/beeq-docs/components/accordion.mdx
+++ b/apps/beeq-docs/components/accordion.mdx
@@ -1219,15 +1219,15 @@ Developers can [rely on the exposed shadow DOM parts](https://www.beeq.design/3d
     </template>
 
     <style>
-    .my-accordion {
-      &::part(header) {
-        flex-direction: row-reverse;
+      .my-accordion {
+        &::part(header) {
+          flex-direction: row-reverse;
+        }
+        div[slot="header"] {
+          display: flex;
+          justify-content: space-between;
+        }
       }
-      div[slot="header"] {
-        display: flex;
-        justify-content: space-between;
-      }
-    }
     </style>
     ```
   </CodeGroup>

--- a/apps/beeq-docs/components/accordion.mdx
+++ b/apps/beeq-docs/components/accordion.mdx
@@ -1096,7 +1096,7 @@ Developers can [rely on the exposed shadow DOM parts](https://www.beeq.design/3d
   </bq-accordion-group>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     .my-accordion {
       &::part(header) {
         flex-direction: row-reverse;
@@ -1131,7 +1131,6 @@ Developers can [rely on the exposed shadow DOM parts](https://www.beeq.design/3d
 
     ```jsx React icon="react" expandable
     import { BqAccordion, BqAccordionGroup, BqIcon } from "@beeq/react";
-    import "./my-accordion.css";
     import "./styles.css";
 
     <BqAccordionGroup appearance="ghost">

--- a/apps/beeq-docs/components/accordion.mdx
+++ b/apps/beeq-docs/components/accordion.mdx
@@ -106,9 +106,9 @@ Accordion items are collapsed by default. This works best when the heading alone
       imports: [BqAccordion],
       template: `
         <bq-accordion>
-              <span slot="header">Accordion title</span>
-              <p>This is the accordion panel content. It is hidden by default and revealed when the header is clicked.</p>
-            </bq-accordion>
+          <span slot="header">Accordion title</span>
+          <p>This is the accordion panel content. It is hidden by default and revealed when the header is clicked.</p>
+        </bq-accordion>
       `,
     })
     export class AppComponent {}
@@ -164,10 +164,10 @@ Use the `expanded` attribute when a section should start open — for example wh
       standalone: true,
       imports: [BqAccordion],
       template: `
-            <bq-accordion expanded>
-              <span slot="header">Expanded by default</span>
-              <p>This panel is visible when the component first renders.</p>
-            </bq-accordion>
+        <bq-accordion expanded>
+          <span slot="header">Expanded by default</span>
+          <p>This panel is visible when the component first renders.</p>
+        </bq-accordion>
       `,
     })
     export class AppComponent {}
@@ -249,17 +249,17 @@ Two appearance values are available:
       standalone: true,
       imports: [BqAccordion],
       template: `
-            <!-- Filled: default -->
-            <bq-accordion expanded>
-              <span slot="header">Filled (default)</span>
-              <p>The header has a background color in the filled appearance.</p>
-            </bq-accordion>
-        
-            <!-- Ghost -->
-            <bq-accordion appearance="ghost" expanded>
-              <span slot="header">Ghost</span>
-              <p>The header has no background in the ghost appearance.</p>
-            </bq-accordion>
+        <!-- Filled: default -->
+        <bq-accordion expanded>
+          <span slot="header">Filled (default)</span>
+          <p>The header has a background color in the filled appearance.</p>
+        </bq-accordion>
+
+        <!-- Ghost -->
+        <bq-accordion appearance="ghost" expanded>
+          <span slot="header">Ghost</span>
+          <p>The header has no background in the ghost appearance.</p>
+        </bq-accordion>
       `,
     })
     export class AppComponent {}
@@ -339,15 +339,15 @@ The `small` size uses more compact padding and a smaller border radius, giving i
       standalone: true,
       imports: [BqAccordion],
       template: `
-            <bq-accordion size="medium" expanded>
-              <span slot="header">Medium accordion (default)</span>
-              <p>This is the medium size — more padding, suitable for most use cases.</p>
-            </bq-accordion>
-        
-            <bq-accordion size="small" expanded>
-              <span slot="header">Small accordion</span>
-              <p>This is the small size — compact padding for dense layouts and using small border radius.</p>
-            </bq-accordion>
+        <bq-accordion size="medium" expanded>
+          <span slot="header">Medium accordion (default)</span>
+          <p>This is the medium size — more padding, suitable for most use cases.</p>
+        </bq-accordion>
+
+        <bq-accordion size="small" expanded>
+          <span slot="header">Small accordion</span>
+          <p>This is the small size — compact padding for dense layouts and using small border radius.</p>
+        </bq-accordion>
       `,
     })
     export class AppComponent {}
@@ -452,20 +452,20 @@ Use the default group behavior when the sections are mutually exclusive or when 
       standalone: true,
       imports: [BqAccordionGroup, BqAccordion],
       template: `
-            <bq-accordion-group>
-              <bq-accordion>
-                <span slot="header">Section one</span>
-                <p>Content for section one.</p>
-              </bq-accordion>
-              <bq-accordion>
-                <span slot="header">Section two</span>
-                <p>Content for section two.</p>
-              </bq-accordion>
-              <bq-accordion>
-                <span slot="header">Section three</span>
-                <p>Content for section three.</p>
-              </bq-accordion>
-            </bq-accordion-group>
+        <bq-accordion-group>
+          <bq-accordion>
+            <span slot="header">Section one</span>
+            <p>Content for section one.</p>
+          </bq-accordion>
+          <bq-accordion>
+            <span slot="header">Section two</span>
+            <p>Content for section two.</p>
+          </bq-accordion>
+          <bq-accordion>
+            <span slot="header">Section three</span>
+            <p>Content for section three.</p>
+          </bq-accordion>
+        </bq-accordion-group>
       `,
     })
     export class AppComponent {}
@@ -561,20 +561,20 @@ Allow multiple sections to stay open when people may need to review, reference, 
       standalone: true,
       imports: [BqAccordionGroup, BqAccordion],
       template: `
-            <bq-accordion-group multiple>
-              <bq-accordion expanded>
-                <span slot="header">Section one</span>
-                <p>Content for section one.</p>
-              </bq-accordion>
-              <bq-accordion expanded>
-                <span slot="header">Section two</span>
-                <p>Content for section two.</p>
-              </bq-accordion>
-              <bq-accordion>
-                <span slot="header">Section three</span>
-                <p>Content for section three.</p>
-              </bq-accordion>
-            </bq-accordion-group>
+        <bq-accordion-group multiple>
+          <bq-accordion expanded>
+            <span slot="header">Section one</span>
+            <p>Content for section one.</p>
+          </bq-accordion>
+          <bq-accordion expanded>
+            <span slot="header">Section two</span>
+            <p>Content for section two.</p>
+          </bq-accordion>
+          <bq-accordion>
+            <span slot="header">Section three</span>
+            <p>Content for section three.</p>
+          </bq-accordion>
+        </bq-accordion-group>
       `,
     })
     export class AppComponent {}
@@ -702,30 +702,30 @@ These provide additional context to help people scan and understand the sections
       standalone: true,
       imports: [BqAccordion, BqIcon, BqAvatar],
       template: `
-            <!-- Prefix icon -->
-            <bq-accordion>
-              <bq-icon name="heart" slot="prefix"></bq-icon>
-              <span slot="header">With prefix icon</span>
-              <p>The header includes an icon in the prefix slot before the title text.</p>
-            </bq-accordion>
-        
-            <!-- Prefix avatar -->
-            <bq-accordion>
-              <bq-avatar
-                size="xsmall"
-                image="https://images.unsplash.com/photo-1524593689594-aae2f26b75ab?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1000&q=80"
-                slot="prefix"
-              ></bq-avatar>
-              <span slot="header">With prefix avatar</span>
-              <p>The prefix slot also accepts an avatar for person-related sections.</p>
-            </bq-accordion>
-        
-            <!-- Suffix icon -->
-            <bq-accordion>
-              <span slot="header">With suffix icon</span>
-              <bq-icon name="gear" slot="suffix"></bq-icon>
-              <p>The header includes an icon in the suffix slot after the title text.</p>
-            </bq-accordion>
+        <!-- Prefix icon -->
+        <bq-accordion>
+          <bq-icon name="heart" slot="prefix"></bq-icon>
+          <span slot="header">With prefix icon</span>
+          <p>The header includes an icon in the prefix slot before the title text.</p>
+        </bq-accordion>
+
+        <!-- Prefix avatar -->
+        <bq-accordion>
+          <bq-avatar
+            size="xsmall"
+            image="https://images.unsplash.com/photo-1524593689594-aae2f26b75ab?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1000&q=80"
+            slot="prefix"
+            ></bq-avatar>
+            <span slot="header">With prefix avatar</span>
+            <p>The prefix slot also accepts an avatar for person-related sections.</p>
+          </bq-accordion>
+
+          <!-- Suffix icon -->
+          <bq-accordion>
+            <span slot="header">With suffix icon</span>
+            <bq-icon name="gear" slot="suffix"></bq-icon>
+            <p>The header includes an icon in the suffix slot after the title text.</p>
+          </bq-accordion>
       `,
     })
     export class AppComponent {}
@@ -803,10 +803,10 @@ Use `disabled` only when a section is temporarily unavailable. The header will n
       standalone: true,
       imports: [BqAccordion],
       template: `
-            <bq-accordion disabled>
-              <span slot="header">Disabled accordion</span>
-              <p>This content cannot be accessed while the accordion is disabled.</p>
-            </bq-accordion>
+        <bq-accordion disabled>
+          <span slot="header">Disabled accordion</span>
+          <p>This content cannot be accessed while the accordion is disabled.</p>
+        </bq-accordion>
       `,
     })
     export class AppComponent {}
@@ -883,17 +883,17 @@ Add the `no-animation` attribute to disable this and make the panel appear/disap
       standalone: true,
       imports: [BqAccordion],
       template: `
-            <!-- Default: animated -->
-            <bq-accordion>
-              <span slot="header">With animation (default)</span>
-              <p>The panel slides open and closed smoothly.</p>
-            </bq-accordion>
-        
-            <!-- Instant: no animation -->
-            <bq-accordion no-animation>
-              <span slot="header">No animation</span>
-              <p>The panel appears and disappears instantly.</p>
-            </bq-accordion>
+        <!-- Default: animated -->
+        <bq-accordion>
+          <span slot="header">With animation (default)</span>
+          <p>The panel slides open and closed smoothly.</p>
+        </bq-accordion>
+
+        <!-- Instant: no animation -->
+        <bq-accordion no-animation>
+          <span slot="header">No animation</span>
+          <p>The panel appears and disappears instantly.</p>
+        </bq-accordion>
       `,
     })
     export class AppComponent {}
@@ -998,20 +998,20 @@ Alternatively, combine a single icon in the `expand` slot with the `rotate` prop
       standalone: true,
       imports: [BqAccordion, BqIcon],
       template: `
-            <!-- Two separate icons -->
-            <bq-accordion>
-              <bq-icon name="folder-simple" slot="expand"></bq-icon>
-              <bq-icon name="folder-open" slot="collapse"></bq-icon>
-              <span slot="header">Custom icons for expand and collapse</span>
-              <p>This accordion shows an open folder when expanded and a closed folder when collapsed.</p>
-            </bq-accordion>
-        
-            <!-- Single icon + rotate -->
-            <bq-accordion rotate>
-              <bq-icon name="caret-up" slot="expand"></bq-icon>
-              <span slot="header">Custom icon with rotation</span>
-              <p>This accordion uses a single caret icon that rotates 180° when expanded.</p>
-            </bq-accordion>
+        <!-- Two separate icons -->
+        <bq-accordion>
+          <bq-icon name="folder-simple" slot="expand"></bq-icon>
+          <bq-icon name="folder-open" slot="collapse"></bq-icon>
+          <span slot="header">Custom icons for expand and collapse</span>
+          <p>This accordion shows an open folder when expanded and a closed folder when collapsed.</p>
+        </bq-accordion>
+
+        <!-- Single icon + rotate -->
+        <bq-accordion rotate>
+          <bq-icon name="caret-up" slot="expand"></bq-icon>
+          <span slot="header">Custom icon with rotation</span>
+          <p>This accordion uses a single caret icon that rotates 180° when expanded.</p>
+        </bq-accordion>
       `,
     })
     export class AppComponent {}
@@ -1151,24 +1151,24 @@ Developers can [rely on the exposed shadow DOM parts](https://www.beeq.design/3d
       standalone: true,
       imports: [BqAccordionGroup, BqAccordion, BqIcon],
       template: `
-            <bq-accordion-group appearance="ghost">
-              <bq-accordion class="my-accordion" rotate>
-                <bq-icon name="caret-down" slot="expand"></bq-icon>
-                <div slot="header">
-                  <span>Order summary</span>
-                  <span>$123.99</span>
-                </div>
-                <p>This is an example of a custom header layout using the header slot and CSS part selectors to move the expand icon to the end and space out the header content.</p>
-              </bq-accordion>
-              <bq-accordion class="my-accordion" rotate>
-                <bq-icon name="caret-down" slot="expand"></bq-icon>
-                <div slot="header">
-                  <span>Order summary</span>
-                  <span>$123.99</span>
-                </div>
-                <p>This is an example of a custom header layout using the header slot and CSS part selectors to move the expand icon to the end and space out the header content.</p>
-              </bq-accordion>
-            </bq-accordion-group>
+        <bq-accordion-group appearance="ghost">
+          <bq-accordion class="my-accordion" rotate>
+            <bq-icon name="caret-down" slot="expand"></bq-icon>
+            <div slot="header">
+              <span>Order summary</span>
+              <span>$123.99</span>
+            </div>
+            <p>This is an example of a custom header layout using the header slot and CSS part selectors to move the expand icon to the end and space out the header content.</p>
+          </bq-accordion>
+          <bq-accordion class="my-accordion" rotate>
+            <bq-icon name="caret-down" slot="expand"></bq-icon>
+            <div slot="header">
+              <span>Order summary</span>
+              <span>$123.99</span>
+            </div>
+            <p>This is an example of a custom header layout using the header slot and CSS part selectors to move the expand icon to the end and space out the header content.</p>
+          </bq-accordion>
+        </bq-accordion-group>
       `,
     })
     export class AppComponent {}

--- a/apps/beeq-docs/components/accordion.mdx
+++ b/apps/beeq-docs/components/accordion.mdx
@@ -1096,7 +1096,7 @@ Developers can [rely on the exposed shadow DOM parts](https://www.beeq.design/3d
   </bq-accordion-group>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     .my-accordion {
       &::part(header) {
         flex-direction: row-reverse;
@@ -1182,7 +1182,7 @@ Developers can [rely on the exposed shadow DOM parts](https://www.beeq.design/3d
           </bq-accordion>
         </bq-accordion-group>
       `,
-      style: `
+      styles: [`
         .my-accordion {
           &::part(header) {
             flex-direction: row-reverse;
@@ -1192,7 +1192,7 @@ Developers can [rely on the exposed shadow DOM parts](https://www.beeq.design/3d
             justify-content: space-between;
           }
         }
-      `,
+      `],
     })
     export class AppComponent {}
     ```

--- a/apps/beeq-docs/components/accordion.mdx
+++ b/apps/beeq-docs/components/accordion.mdx
@@ -97,14 +97,21 @@ Accordion items are collapsed by default. This works best when the heading alone
     </BqAccordion>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqAccordion } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-
-    <bq-accordion>
-      <span slot="header">Accordion title</span>
-      <p>This is the accordion panel content. It is hidden by default and revealed when the header is clicked.</p>
-    </bq-accordion>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqAccordion } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqAccordion],
+      template: `
+        <bq-accordion>
+              <span slot="header">Accordion title</span>
+              <p>This is the accordion panel content. It is hidden by default and revealed when the header is clicked.</p>
+            </bq-accordion>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -149,11 +156,21 @@ Use the `expanded` attribute when a section should start open — for example wh
     </BqAccordion>
     ```
 
-    ```html Angular icon="angular"
-    <bq-accordion expanded>
-      <span slot="header">Expanded by default</span>
-      <p>This panel is visible when the component first renders.</p>
-    </bq-accordion>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqAccordion } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqAccordion],
+      template: `
+            <bq-accordion expanded>
+              <span slot="header">Expanded by default</span>
+              <p>This panel is visible when the component first renders.</p>
+            </bq-accordion>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -224,18 +241,28 @@ Two appearance values are available:
     </BqAccordion>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Filled: default -->
-    <bq-accordion expanded>
-      <span slot="header">Filled (default)</span>
-      <p>The header has a background color in the filled appearance.</p>
-    </bq-accordion>
-
-    <!-- Ghost -->
-    <bq-accordion appearance="ghost" expanded>
-      <span slot="header">Ghost</span>
-      <p>The header has no background in the ghost appearance.</p>
-    </bq-accordion>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqAccordion } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqAccordion],
+      template: `
+            <!-- Filled: default -->
+            <bq-accordion expanded>
+              <span slot="header">Filled (default)</span>
+              <p>The header has a background color in the filled appearance.</p>
+            </bq-accordion>
+        
+            <!-- Ghost -->
+            <bq-accordion appearance="ghost" expanded>
+              <span slot="header">Ghost</span>
+              <p>The header has no background in the ghost appearance.</p>
+            </bq-accordion>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -304,16 +331,26 @@ The `small` size uses more compact padding and a smaller border radius, giving i
     </BqAccordion>
     ```
 
-    ```html Angular icon="angular"
-    <bq-accordion size="medium" expanded>
-      <span slot="header">Medium accordion (default)</span>
-      <p>This is the medium size — more padding, suitable for most use cases.</p>
-    </bq-accordion>
-
-    <bq-accordion size="small" expanded>
-      <span slot="header">Small accordion</span>
-      <p>This is the small size — compact padding for dense layouts and using small border radius.</p>
-    </bq-accordion>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqAccordion } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqAccordion],
+      template: `
+            <bq-accordion size="medium" expanded>
+              <span slot="header">Medium accordion (default)</span>
+              <p>This is the medium size — more padding, suitable for most use cases.</p>
+            </bq-accordion>
+        
+            <bq-accordion size="small" expanded>
+              <span slot="header">Small accordion</span>
+              <p>This is the small size — compact padding for dense layouts and using small border radius.</p>
+            </bq-accordion>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -407,21 +444,31 @@ Use the default group behavior when the sections are mutually exclusive or when 
     </BqAccordionGroup>
     ```
 
-    ```html Angular icon="angular"
-    <bq-accordion-group>
-      <bq-accordion>
-        <span slot="header">Section one</span>
-        <p>Content for section one.</p>
-      </bq-accordion>
-      <bq-accordion>
-        <span slot="header">Section two</span>
-        <p>Content for section two.</p>
-      </bq-accordion>
-      <bq-accordion>
-        <span slot="header">Section three</span>
-        <p>Content for section three.</p>
-      </bq-accordion>
-    </bq-accordion-group>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqAccordionGroup, BqAccordion } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqAccordionGroup, BqAccordion],
+      template: `
+            <bq-accordion-group>
+              <bq-accordion>
+                <span slot="header">Section one</span>
+                <p>Content for section one.</p>
+              </bq-accordion>
+              <bq-accordion>
+                <span slot="header">Section two</span>
+                <p>Content for section two.</p>
+              </bq-accordion>
+              <bq-accordion>
+                <span slot="header">Section three</span>
+                <p>Content for section three.</p>
+              </bq-accordion>
+            </bq-accordion-group>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -506,21 +553,31 @@ Allow multiple sections to stay open when people may need to review, reference, 
     </BqAccordionGroup>
     ```
 
-    ```html Angular icon="angular"
-    <bq-accordion-group multiple>
-      <bq-accordion expanded>
-        <span slot="header">Section one</span>
-        <p>Content for section one.</p>
-      </bq-accordion>
-      <bq-accordion expanded>
-        <span slot="header">Section two</span>
-        <p>Content for section two.</p>
-      </bq-accordion>
-      <bq-accordion>
-        <span slot="header">Section three</span>
-        <p>Content for section three.</p>
-      </bq-accordion>
-    </bq-accordion-group>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqAccordionGroup, BqAccordion } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqAccordionGroup, BqAccordion],
+      template: `
+            <bq-accordion-group multiple>
+              <bq-accordion expanded>
+                <span slot="header">Section one</span>
+                <p>Content for section one.</p>
+              </bq-accordion>
+              <bq-accordion expanded>
+                <span slot="header">Section two</span>
+                <p>Content for section two.</p>
+              </bq-accordion>
+              <bq-accordion>
+                <span slot="header">Section three</span>
+                <p>Content for section three.</p>
+              </bq-accordion>
+            </bq-accordion-group>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -637,31 +694,41 @@ These provide additional context to help people scan and understand the sections
     </BqAccordion>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Prefix icon -->
-    <bq-accordion>
-      <bq-icon name="heart" slot="prefix"></bq-icon>
-      <span slot="header">With prefix icon</span>
-      <p>The header includes an icon in the prefix slot before the title text.</p>
-    </bq-accordion>
-
-    <!-- Prefix avatar -->
-    <bq-accordion>
-      <bq-avatar
-        size="xsmall"
-        image="https://images.unsplash.com/photo-1524593689594-aae2f26b75ab?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1000&q=80"
-        slot="prefix"
-      ></bq-avatar>
-      <span slot="header">With prefix avatar</span>
-      <p>The prefix slot also accepts an avatar for person-related sections.</p>
-    </bq-accordion>
-
-    <!-- Suffix icon -->
-    <bq-accordion>
-      <span slot="header">With suffix icon</span>
-      <bq-icon name="gear" slot="suffix"></bq-icon>
-      <p>The header includes an icon in the suffix slot after the title text.</p>
-    </bq-accordion>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqAccordion, BqIcon, BqAvatar } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqAccordion, BqIcon, BqAvatar],
+      template: `
+            <!-- Prefix icon -->
+            <bq-accordion>
+              <bq-icon name="heart" slot="prefix"></bq-icon>
+              <span slot="header">With prefix icon</span>
+              <p>The header includes an icon in the prefix slot before the title text.</p>
+            </bq-accordion>
+        
+            <!-- Prefix avatar -->
+            <bq-accordion>
+              <bq-avatar
+                size="xsmall"
+                image="https://images.unsplash.com/photo-1524593689594-aae2f26b75ab?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1000&q=80"
+                slot="prefix"
+              ></bq-avatar>
+              <span slot="header">With prefix avatar</span>
+              <p>The prefix slot also accepts an avatar for person-related sections.</p>
+            </bq-accordion>
+        
+            <!-- Suffix icon -->
+            <bq-accordion>
+              <span slot="header">With suffix icon</span>
+              <bq-icon name="gear" slot="suffix"></bq-icon>
+              <p>The header includes an icon in the suffix slot after the title text.</p>
+            </bq-accordion>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -728,11 +795,21 @@ Use `disabled` only when a section is temporarily unavailable. The header will n
     </BqAccordion>
     ```
 
-    ```html Angular icon="angular"
-    <bq-accordion disabled>
-      <span slot="header">Disabled accordion</span>
-      <p>This content cannot be accessed while the accordion is disabled.</p>
-    </bq-accordion>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqAccordion } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqAccordion],
+      template: `
+            <bq-accordion disabled>
+              <span slot="header">Disabled accordion</span>
+              <p>This content cannot be accessed while the accordion is disabled.</p>
+            </bq-accordion>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -798,18 +875,28 @@ Add the `no-animation` attribute to disable this and make the panel appear/disap
     </BqAccordion>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Default: animated -->
-    <bq-accordion>
-      <span slot="header">With animation (default)</span>
-      <p>The panel slides open and closed smoothly.</p>
-    </bq-accordion>
-
-    <!-- Instant: no animation -->
-    <bq-accordion no-animation>
-      <span slot="header">No animation</span>
-      <p>The panel appears and disappears instantly.</p>
-    </bq-accordion>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqAccordion } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqAccordion],
+      template: `
+            <!-- Default: animated -->
+            <bq-accordion>
+              <span slot="header">With animation (default)</span>
+              <p>The panel slides open and closed smoothly.</p>
+            </bq-accordion>
+        
+            <!-- Instant: no animation -->
+            <bq-accordion no-animation>
+              <span slot="header">No animation</span>
+              <p>The panel appears and disappears instantly.</p>
+            </bq-accordion>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -903,21 +990,31 @@ Alternatively, combine a single icon in the `expand` slot with the `rotate` prop
     </BqAccordion>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Two separate icons -->
-    <bq-accordion>
-      <bq-icon name="folder-simple" slot="expand"></bq-icon>
-      <bq-icon name="folder-open" slot="collapse"></bq-icon>
-      <span slot="header">Custom icons for expand and collapse</span>
-      <p>This accordion shows an open folder when expanded and a closed folder when collapsed.</p>
-    </bq-accordion>
-
-    <!-- Single icon + rotate -->
-    <bq-accordion rotate>
-      <bq-icon name="caret-up" slot="expand"></bq-icon>
-      <span slot="header">Custom icon with rotation</span>
-      <p>This accordion uses a single caret icon that rotates 180° when expanded.</p>
-    </bq-accordion>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqAccordion, BqIcon } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqAccordion, BqIcon],
+      template: `
+            <!-- Two separate icons -->
+            <bq-accordion>
+              <bq-icon name="folder-simple" slot="expand"></bq-icon>
+              <bq-icon name="folder-open" slot="collapse"></bq-icon>
+              <span slot="header">Custom icons for expand and collapse</span>
+              <p>This accordion shows an open folder when expanded and a closed folder when collapsed.</p>
+            </bq-accordion>
+        
+            <!-- Single icon + rotate -->
+            <bq-accordion rotate>
+              <bq-icon name="caret-up" slot="expand"></bq-icon>
+              <span slot="header">Custom icon with rotation</span>
+              <p>This accordion uses a single caret icon that rotates 180° when expanded.</p>
+            </bq-accordion>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -1046,25 +1143,35 @@ Developers can [rely on the exposed shadow DOM parts](https://www.beeq.design/3d
     </BqAccordionGroup>
     ```
 
-    ```html Angular icon="angular"
-    <bq-accordion-group appearance="ghost">
-      <bq-accordion class="my-accordion" rotate>
-        <bq-icon name="caret-down" slot="expand"></bq-icon>
-        <div slot="header">
-          <span>Order summary</span>
-          <span>$123.99</span>
-        </div>
-        <p>This is an example of a custom header layout using the header slot and CSS part selectors to move the expand icon to the end and space out the header content.</p>
-      </bq-accordion>
-      <bq-accordion class="my-accordion" rotate>
-        <bq-icon name="caret-down" slot="expand"></bq-icon>
-        <div slot="header">
-          <span>Order summary</span>
-          <span>$123.99</span>
-        </div>
-        <p>This is an example of a custom header layout using the header slot and CSS part selectors to move the expand icon to the end and space out the header content.</p>
-      </bq-accordion>
-    </bq-accordion-group>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqAccordionGroup, BqAccordion, BqIcon } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqAccordionGroup, BqAccordion, BqIcon],
+      template: `
+            <bq-accordion-group appearance="ghost">
+              <bq-accordion class="my-accordion" rotate>
+                <bq-icon name="caret-down" slot="expand"></bq-icon>
+                <div slot="header">
+                  <span>Order summary</span>
+                  <span>$123.99</span>
+                </div>
+                <p>This is an example of a custom header layout using the header slot and CSS part selectors to move the expand icon to the end and space out the header content.</p>
+              </bq-accordion>
+              <bq-accordion class="my-accordion" rotate>
+                <bq-icon name="caret-down" slot="expand"></bq-icon>
+                <div slot="header">
+                  <span>Order summary</span>
+                  <span>$123.99</span>
+                </div>
+                <p>This is an example of a custom header layout using the header slot and CSS part selectors to move the expand icon to the end and space out the header content.</p>
+              </bq-accordion>
+            </bq-accordion-group>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/accordion.mdx
+++ b/apps/beeq-docs/components/accordion.mdx
@@ -81,14 +81,14 @@ Accordion items are collapsed by default. This works best when the heading alone
   </bq-accordion>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-accordion>
       <span slot="header">Accordion title</span>
       <p>This is the accordion panel content. It is hidden by default and revealed when the header is clicked.</p>
     </bq-accordion>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqAccordion } from "@beeq/react";
 
     <BqAccordion>
@@ -97,7 +97,7 @@ Accordion items are collapsed by default. This works best when the heading alone
     </BqAccordion>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAccordion } from "@beeq/angular/standalone";
     @Component({
@@ -114,7 +114,7 @@ Accordion items are collapsed by default. This works best when the heading alone
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqAccordion } from "@beeq/vue";
     </script>
@@ -140,14 +140,14 @@ Use the `expanded` attribute when a section should start open — for example wh
   </bq-accordion>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-accordion expanded>
       <span slot="header">Expanded by default</span>
       <p>This panel is visible when the component first renders.</p>
     </bq-accordion>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqAccordion } from "@beeq/react";
 
     <BqAccordion expanded>
@@ -156,7 +156,7 @@ Use the `expanded` attribute when a section should start open — for example wh
     </BqAccordion>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAccordion } from "@beeq/angular/standalone";
     @Component({
@@ -173,7 +173,7 @@ Use the `expanded` attribute when a section should start open — for example wh
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqAccordion } from "@beeq/vue";
     </script>
@@ -211,7 +211,7 @@ Two appearance values are available:
   </div>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <!-- Filled: default, no need to set appearance explicitly -->
     <bq-accordion expanded>
       <span slot="header">Filled (default)</span>
@@ -225,7 +225,7 @@ Two appearance values are available:
     </bq-accordion>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqAccordion } from "@beeq/react";
 
     {/* Filled: default */}
@@ -241,7 +241,7 @@ Two appearance values are available:
     </BqAccordion>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAccordion } from "@beeq/angular/standalone";
     @Component({
@@ -265,7 +265,7 @@ Two appearance values are available:
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqAccordion } from "@beeq/vue";
     </script>
@@ -305,7 +305,7 @@ The `small` size uses more compact padding and a smaller border radius, giving i
   </div>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-accordion size="medium" expanded>
       <span slot="header">Medium accordion (default)</span>
       <p>This is the medium size — more padding, suitable for most use cases.</p>
@@ -317,7 +317,7 @@ The `small` size uses more compact padding and a smaller border radius, giving i
     </bq-accordion>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqAccordion } from "@beeq/react";
 
     <BqAccordion size="medium" expanded>
@@ -331,7 +331,7 @@ The `small` size uses more compact padding and a smaller border radius, giving i
     </BqAccordion>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAccordion } from "@beeq/angular/standalone";
     @Component({
@@ -353,7 +353,7 @@ The `small` size uses more compact padding and a smaller border radius, giving i
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqAccordion } from "@beeq/vue";
     </script>
@@ -408,7 +408,7 @@ Use the default group behavior when the sections are mutually exclusive or when 
   </bq-accordion-group>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-accordion-group>
       <bq-accordion>
         <span slot="header">Section one</span>
@@ -425,7 +425,7 @@ Use the default group behavior when the sections are mutually exclusive or when 
     </bq-accordion-group>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqAccordion, BqAccordionGroup } from "@beeq/react";
 
     <BqAccordionGroup>
@@ -444,7 +444,7 @@ Use the default group behavior when the sections are mutually exclusive or when 
     </BqAccordionGroup>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAccordionGroup, BqAccordion } from "@beeq/angular/standalone";
     @Component({
@@ -471,7 +471,7 @@ Use the default group behavior when the sections are mutually exclusive or when 
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqAccordion, BqAccordionGroup } from "@beeq/vue";
     </script>
@@ -517,7 +517,7 @@ Allow multiple sections to stay open when people may need to review, reference, 
   </bq-accordion-group>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-accordion-group multiple>
       <bq-accordion expanded>
         <span slot="header">Section one</span>
@@ -534,7 +534,7 @@ Allow multiple sections to stay open when people may need to review, reference, 
     </bq-accordion-group>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqAccordion, BqAccordionGroup } from "@beeq/react";
 
     <BqAccordionGroup multiple>
@@ -553,7 +553,7 @@ Allow multiple sections to stay open when people may need to review, reference, 
     </BqAccordionGroup>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAccordionGroup, BqAccordion } from "@beeq/angular/standalone";
     @Component({
@@ -580,7 +580,7 @@ Allow multiple sections to stay open when people may need to review, reference, 
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqAccordion, BqAccordionGroup } from "@beeq/vue";
     </script>
@@ -638,7 +638,7 @@ These provide additional context to help people scan and understand the sections
   </bq-accordion-group>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <!-- Prefix icon -->
     <bq-accordion>
       <bq-icon name="heart" slot="prefix"></bq-icon>
@@ -665,7 +665,7 @@ These provide additional context to help people scan and understand the sections
     </bq-accordion>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqAccordion, BqAvatar, BqIcon } from "@beeq/react";
 
     {/* Prefix icon */}
@@ -694,7 +694,7 @@ These provide additional context to help people scan and understand the sections
     </BqAccordion>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAccordion, BqIcon, BqAvatar } from "@beeq/angular/standalone";
     @Component({
@@ -731,7 +731,7 @@ These provide additional context to help people scan and understand the sections
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqAccordion, BqAvatar, BqIcon } from "@beeq/vue";
     </script>
@@ -779,14 +779,14 @@ Use `disabled` only when a section is temporarily unavailable. The header will n
   </bq-accordion>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-accordion disabled>
       <span slot="header">Disabled accordion</span>
       <p>This content cannot be accessed while the accordion is disabled.</p>
     </bq-accordion>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqAccordion } from "@beeq/react";
 
     <BqAccordion disabled>
@@ -795,7 +795,7 @@ Use `disabled` only when a section is temporarily unavailable. The header will n
     </BqAccordion>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAccordion } from "@beeq/angular/standalone";
     @Component({
@@ -812,7 +812,7 @@ Use `disabled` only when a section is temporarily unavailable. The header will n
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqAccordion } from "@beeq/vue";
     </script>
@@ -845,7 +845,7 @@ Add the `no-animation` attribute to disable this and make the panel appear/disap
   </div>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <!-- Default: animated -->
     <bq-accordion>
       <span slot="header">With animation (default)</span>
@@ -859,7 +859,7 @@ Add the `no-animation` attribute to disable this and make the panel appear/disap
     </bq-accordion>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqAccordion } from "@beeq/react";
 
     {/* Default: animated */}
@@ -875,7 +875,7 @@ Add the `no-animation` attribute to disable this and make the panel appear/disap
     </BqAccordion>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAccordion } from "@beeq/angular/standalone";
     @Component({
@@ -899,7 +899,7 @@ Add the `no-animation` attribute to disable this and make the panel appear/disap
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqAccordion } from "@beeq/vue";
     </script>
@@ -954,7 +954,7 @@ Alternatively, combine a single icon in the `expand` slot with the `rotate` prop
     </bq-accordion-group>
   `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <!-- Two separate icons: different icon for each state -->
     <bq-accordion>
       <bq-icon name="folder-simple" slot="expand"></bq-icon>
@@ -971,7 +971,7 @@ Alternatively, combine a single icon in the `expand` slot with the `rotate` prop
     </bq-accordion>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqAccordion, BqIcon } from "@beeq/react";
 
     {/* Two separate icons */}
@@ -990,7 +990,7 @@ Alternatively, combine a single icon in the `expand` slot with the `rotate` prop
     </BqAccordion>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAccordion, BqIcon } from "@beeq/angular/standalone";
     @Component({
@@ -1017,7 +1017,7 @@ Alternatively, combine a single icon in the `expand` slot with the `rotate` prop
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqAccordion, BqIcon } from "@beeq/vue";
     </script>
@@ -1086,7 +1086,7 @@ Developers can [rely on the exposed shadow DOM parts](https://www.beeq.design/3d
   </bq-accordion-group>
 `}>
   <CodeGroup>
-    ```css CSS icon="css"
+    ```css styles.css icon="css" expandable
     .my-accordion {
       &::part(header) {
         flex-direction: row-reverse;
@@ -1098,7 +1098,7 @@ Developers can [rely on the exposed shadow DOM parts](https://www.beeq.design/3d
     }
     ```
 
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-accordion-group appearance="ghost">
       <bq-accordion class="my-accordion" rotate>
         <bq-icon name="caret-down" slot="expand"></bq-icon>
@@ -1119,9 +1119,10 @@ Developers can [rely on the exposed shadow DOM parts](https://www.beeq.design/3d
     </bq-accordion-group>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqAccordion, BqAccordionGroup, BqIcon } from "@beeq/react";
     import "./my-accordion.css";
+    import "./styles.css";
 
     <BqAccordionGroup appearance="ghost">
       <BqAccordion className="my-accordion" rotate>
@@ -1143,7 +1144,7 @@ Developers can [rely on the exposed shadow DOM parts](https://www.beeq.design/3d
     </BqAccordionGroup>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAccordionGroup, BqAccordion, BqIcon } from "@beeq/angular/standalone";
     @Component({
@@ -1170,11 +1171,22 @@ Developers can [rely on the exposed shadow DOM parts](https://www.beeq.design/3d
           </bq-accordion>
         </bq-accordion-group>
       `,
+      style: `
+        .my-accordion {
+          &::part(header) {
+            flex-direction: row-reverse;
+          }
+          div[slot="header"] {
+            display: flex;
+            justify-content: space-between;
+          }
+        }
+      `,
     })
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <template>
       <BqAccordionGroup appearance="ghost">
         <BqAccordion class="my-accordion" rotate>
@@ -1195,6 +1207,18 @@ Developers can [rely on the exposed shadow DOM parts](https://www.beeq.design/3d
         </BqAccordion>
       </BqAccordionGroup>
     </template>
+
+    <style>
+    .my-accordion {
+      &::part(header) {
+        flex-direction: row-reverse;
+      }
+      div[slot="header"] {
+        display: flex;
+        justify-content: space-between;
+      }
+    }
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>

--- a/apps/beeq-docs/components/alert.mdx
+++ b/apps/beeq-docs/components/alert.mdx
@@ -256,32 +256,32 @@ Use the `default` variant for general-purpose alerts. It lets you customize the 
       standalone: true,
       imports: [BqAlert, BqIcon, BqButton],
       template: `
-            <bq-alert open>
-              <bq-icon name="star" slot="icon"></bq-icon>
-              Title
-            </bq-alert>
-        
-            <bq-alert open>
-              <bq-icon name="star" slot="icon"></bq-icon>
-              Title
-              <span slot="body">
-                Description
-                <a class="bq-link" href="https://example.com">Link</a>
-              </span>
-            </bq-alert>
-        
-            <bq-alert open>
-              <bq-icon name="star" slot="icon"></bq-icon>
-              Title
-              <span slot="body">
-                Description
-                <a class="bq-link" href="https://example.com">Link</a>
-              </span>
-              <div slot="footer">
-                <bq-button size="small">Button</bq-button>
-                <bq-button appearance="link" size="small">Button</bq-button>
-              </div>
-            </bq-alert>
+        <bq-alert open>
+          <bq-icon name="star" slot="icon"></bq-icon>
+          Title
+        </bq-alert>
+
+        <bq-alert open>
+          <bq-icon name="star" slot="icon"></bq-icon>
+          Title
+          <span slot="body">
+            Description
+            <a class="bq-link" href="https://example.com">Link</a>
+          </span>
+        </bq-alert>
+
+        <bq-alert open>
+          <bq-icon name="star" slot="icon"></bq-icon>
+          Title
+          <span slot="body">
+            Description
+            <a class="bq-link" href="https://example.com">Link</a>
+          </span>
+          <div slot="footer">
+            <bq-button size="small">Button</bq-button>
+            <bq-button appearance="link" size="small">Button</bq-button>
+          </div>
+        </bq-alert>
       `,
     })
     export class AppComponent {}
@@ -434,27 +434,27 @@ Use the `info` variant when users need additional, non-critical information. It 
       standalone: true,
       imports: [BqAlert, BqButton],
       template: `
-            <bq-alert open type="info">Title</bq-alert>
-        
-            <bq-alert open type="info">
-              Title
-              <span slot="body">
-                Description
-                <a class="bq-link" href="https://example.com">Link</a>
-              </span>
-            </bq-alert>
-        
-            <bq-alert open type="info">
-              Title
-              <span slot="body">
-                Description
-                <a class="bq-link" href="https://example.com">Link</a>
-              </span>
-              <div slot="footer">
-                <bq-button size="small">Button</bq-button>
-                <bq-button appearance="link" size="small">Button</bq-button>
-              </div>
-            </bq-alert>
+        <bq-alert open type="info">Title</bq-alert>
+
+        <bq-alert open type="info">
+          Title
+          <span slot="body">
+            Description
+            <a class="bq-link" href="https://example.com">Link</a>
+          </span>
+        </bq-alert>
+
+        <bq-alert open type="info">
+          Title
+          <span slot="body">
+            Description
+            <a class="bq-link" href="https://example.com">Link</a>
+          </span>
+          <div slot="footer">
+            <bq-button size="small">Button</bq-button>
+            <bq-button appearance="link" size="small">Button</bq-button>
+          </div>
+        </bq-alert>
       `,
     })
     export class AppComponent {}
@@ -598,27 +598,27 @@ Use the `success` variant to notify users about successful actions or positive o
       standalone: true,
       imports: [BqAlert, BqButton],
       template: `
-            <bq-alert open type="success">Title</bq-alert>
-        
-            <bq-alert open type="success">
-              Title
-              <span slot="body">
-                Description
-                <a class="bq-link" href="https://example.com">Link</a>
-              </span>
-            </bq-alert>
-        
-            <bq-alert open type="success">
-              Title
-              <span slot="body">
-                Description
-                <a class="bq-link" href="https://example.com">Link</a>
-              </span>
-              <div slot="footer">
-                <bq-button size="small">Button</bq-button>
-                <bq-button appearance="link" size="small">Button</bq-button>
-              </div>
-            </bq-alert>
+        <bq-alert open type="success">Title</bq-alert>
+
+        <bq-alert open type="success">
+          Title
+          <span slot="body">
+            Description
+            <a class="bq-link" href="https://example.com">Link</a>
+          </span>
+        </bq-alert>
+
+        <bq-alert open type="success">
+          Title
+          <span slot="body">
+            Description
+            <a class="bq-link" href="https://example.com">Link</a>
+          </span>
+          <div slot="footer">
+            <bq-button size="small">Button</bq-button>
+            <bq-button appearance="link" size="small">Button</bq-button>
+          </div>
+        </bq-alert>
       `,
     })
     export class AppComponent {}
@@ -762,27 +762,27 @@ Use the `warning` variant to indicate potential issues or actions that users sho
       standalone: true,
       imports: [BqAlert, BqButton],
       template: `
-            <bq-alert open type="warning">Title</bq-alert>
-        
-            <bq-alert open type="warning">
-              Title
-              <span slot="body">
-                Description
-                <a class="bq-link" href="https://example.com">Link</a>
-              </span>
-            </bq-alert>
-        
-            <bq-alert open type="warning">
-              Title
-              <span slot="body">
-                Description
-                <a class="bq-link" href="https://example.com">Link</a>
-              </span>
-              <div slot="footer">
-                <bq-button size="small">Button</bq-button>
-                <bq-button appearance="link" size="small">Button</bq-button>
-              </div>
-            </bq-alert>
+        <bq-alert open type="warning">Title</bq-alert>
+
+        <bq-alert open type="warning">
+          Title
+          <span slot="body">
+            Description
+            <a class="bq-link" href="https://example.com">Link</a>
+          </span>
+        </bq-alert>
+
+        <bq-alert open type="warning">
+          Title
+          <span slot="body">
+            Description
+            <a class="bq-link" href="https://example.com">Link</a>
+          </span>
+          <div slot="footer">
+            <bq-button size="small">Button</bq-button>
+            <bq-button appearance="link" size="small">Button</bq-button>
+          </div>
+        </bq-alert>
       `,
     })
     export class AppComponent {}
@@ -926,27 +926,27 @@ Use the `error` variant for issues that require immediate attention. It works be
       standalone: true,
       imports: [BqAlert, BqButton],
       template: `
-            <bq-alert open type="error">Title</bq-alert>
-        
-            <bq-alert open type="error">
-              Title
-              <span slot="body">
-                Description
-                <a class="bq-link" href="https://example.com">Link</a>
-              </span>
-            </bq-alert>
-        
-            <bq-alert open type="error">
-              Title
-              <span slot="body">
-                Description
-                <a class="bq-link" href="https://example.com">Link</a>
-              </span>
-              <div slot="footer">
-                <bq-button size="small">Button</bq-button>
-                <bq-button appearance="link" size="small">Button</bq-button>
-              </div>
-            </bq-alert>
+        <bq-alert open type="error">Title</bq-alert>
+
+        <bq-alert open type="error">
+          Title
+          <span slot="body">
+            Description
+            <a class="bq-link" href="https://example.com">Link</a>
+          </span>
+        </bq-alert>
+
+        <bq-alert open type="error">
+          Title
+          <span slot="body">
+            Description
+            <a class="bq-link" href="https://example.com">Link</a>
+          </span>
+          <div slot="footer">
+            <bq-button size="small">Button</bq-button>
+            <bq-button appearance="link" size="small">Button</bq-button>
+          </div>
+        </bq-alert>
       `,
     })
     export class AppComponent {}
@@ -1080,15 +1080,15 @@ Use the `sticky` attribute for persistent alerts that remain visible until users
       standalone: true,
       imports: [BqAlert, BqButton],
       template: `
-            <main>
-              <h1>Dashboard</h1>
-              <div></div>
-        
-              <bq-alert sticky open type="error">
-                Title
-                <bq-button appearance="link" size="small">Button</bq-button>
-              </bq-alert>
-            </main>
+        <main>
+          <h1>Dashboard</h1>
+          <div></div>
+
+          <bq-alert sticky open type="error">
+            Title
+            <bq-button appearance="link" size="small">Button</bq-button>
+          </bq-alert>
+        </main>
       `,
     })
     export class AppComponent {}
@@ -1181,10 +1181,10 @@ Set `auto-dismiss` to hide the alert automatically after a delay. Use `time` to 
       standalone: true,
       imports: [BqAlert],
       template: `
-            <bq-alert open auto-dismiss time="8000" type="success">
-              Changes saved
-              <span slot="body">Your settings have been updated.</span>
-            </bq-alert>
+        <bq-alert open auto-dismiss time="8000" type="success">
+          Changes saved
+          <span slot="body">Your settings have been updated.</span>
+        </bq-alert>
       `,
     })
     export class AppComponent {}

--- a/apps/beeq-docs/components/alert.mdx
+++ b/apps/beeq-docs/components/alert.mdx
@@ -248,33 +248,43 @@ Use the `default` variant for general-purpose alerts. It lets you customize the 
     </>
     ```
 
-    ```html Angular icon="angular"
-    <bq-alert open>
-      <bq-icon name="star" slot="icon"></bq-icon>
-      Title
-    </bq-alert>
-
-    <bq-alert open>
-      <bq-icon name="star" slot="icon"></bq-icon>
-      Title
-      <span slot="body">
-        Description
-        <a class="bq-link" href="https://example.com">Link</a>
-      </span>
-    </bq-alert>
-
-    <bq-alert open>
-      <bq-icon name="star" slot="icon"></bq-icon>
-      Title
-      <span slot="body">
-        Description
-        <a class="bq-link" href="https://example.com">Link</a>
-      </span>
-      <div slot="footer">
-        <bq-button size="small">Button</bq-button>
-        <bq-button appearance="link" size="small">Button</bq-button>
-      </div>
-    </bq-alert>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqAlert, BqIcon, BqButton } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqAlert, BqIcon, BqButton],
+      template: `
+            <bq-alert open>
+              <bq-icon name="star" slot="icon"></bq-icon>
+              Title
+            </bq-alert>
+        
+            <bq-alert open>
+              <bq-icon name="star" slot="icon"></bq-icon>
+              Title
+              <span slot="body">
+                Description
+                <a class="bq-link" href="https://example.com">Link</a>
+              </span>
+            </bq-alert>
+        
+            <bq-alert open>
+              <bq-icon name="star" slot="icon"></bq-icon>
+              Title
+              <span slot="body">
+                Description
+                <a class="bq-link" href="https://example.com">Link</a>
+              </span>
+              <div slot="footer">
+                <bq-button size="small">Button</bq-button>
+                <bq-button appearance="link" size="small">Button</bq-button>
+              </div>
+            </bq-alert>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -416,28 +426,38 @@ Use the `info` variant when users need additional, non-critical information. It 
     </>
     ```
 
-    ```html Angular icon="angular"
-    <bq-alert open type="info">Title</bq-alert>
-
-    <bq-alert open type="info">
-      Title
-      <span slot="body">
-        Description
-        <a class="bq-link" href="https://example.com">Link</a>
-      </span>
-    </bq-alert>
-
-    <bq-alert open type="info">
-      Title
-      <span slot="body">
-        Description
-        <a class="bq-link" href="https://example.com">Link</a>
-      </span>
-      <div slot="footer">
-        <bq-button size="small">Button</bq-button>
-        <bq-button appearance="link" size="small">Button</bq-button>
-      </div>
-    </bq-alert>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqAlert, BqButton } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqAlert, BqButton],
+      template: `
+            <bq-alert open type="info">Title</bq-alert>
+        
+            <bq-alert open type="info">
+              Title
+              <span slot="body">
+                Description
+                <a class="bq-link" href="https://example.com">Link</a>
+              </span>
+            </bq-alert>
+        
+            <bq-alert open type="info">
+              Title
+              <span slot="body">
+                Description
+                <a class="bq-link" href="https://example.com">Link</a>
+              </span>
+              <div slot="footer">
+                <bq-button size="small">Button</bq-button>
+                <bq-button appearance="link" size="small">Button</bq-button>
+              </div>
+            </bq-alert>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -570,28 +590,38 @@ Use the `success` variant to notify users about successful actions or positive o
     </>
     ```
 
-    ```html Angular icon="angular"
-    <bq-alert open type="success">Title</bq-alert>
-
-    <bq-alert open type="success">
-      Title
-      <span slot="body">
-        Description
-        <a class="bq-link" href="https://example.com">Link</a>
-      </span>
-    </bq-alert>
-
-    <bq-alert open type="success">
-      Title
-      <span slot="body">
-        Description
-        <a class="bq-link" href="https://example.com">Link</a>
-      </span>
-      <div slot="footer">
-        <bq-button size="small">Button</bq-button>
-        <bq-button appearance="link" size="small">Button</bq-button>
-      </div>
-    </bq-alert>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqAlert, BqButton } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqAlert, BqButton],
+      template: `
+            <bq-alert open type="success">Title</bq-alert>
+        
+            <bq-alert open type="success">
+              Title
+              <span slot="body">
+                Description
+                <a class="bq-link" href="https://example.com">Link</a>
+              </span>
+            </bq-alert>
+        
+            <bq-alert open type="success">
+              Title
+              <span slot="body">
+                Description
+                <a class="bq-link" href="https://example.com">Link</a>
+              </span>
+              <div slot="footer">
+                <bq-button size="small">Button</bq-button>
+                <bq-button appearance="link" size="small">Button</bq-button>
+              </div>
+            </bq-alert>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -724,28 +754,38 @@ Use the `warning` variant to indicate potential issues or actions that users sho
     </>
     ```
 
-    ```html Angular icon="angular"
-    <bq-alert open type="warning">Title</bq-alert>
-
-    <bq-alert open type="warning">
-      Title
-      <span slot="body">
-        Description
-        <a class="bq-link" href="https://example.com">Link</a>
-      </span>
-    </bq-alert>
-
-    <bq-alert open type="warning">
-      Title
-      <span slot="body">
-        Description
-        <a class="bq-link" href="https://example.com">Link</a>
-      </span>
-      <div slot="footer">
-        <bq-button size="small">Button</bq-button>
-        <bq-button appearance="link" size="small">Button</bq-button>
-      </div>
-    </bq-alert>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqAlert, BqButton } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqAlert, BqButton],
+      template: `
+            <bq-alert open type="warning">Title</bq-alert>
+        
+            <bq-alert open type="warning">
+              Title
+              <span slot="body">
+                Description
+                <a class="bq-link" href="https://example.com">Link</a>
+              </span>
+            </bq-alert>
+        
+            <bq-alert open type="warning">
+              Title
+              <span slot="body">
+                Description
+                <a class="bq-link" href="https://example.com">Link</a>
+              </span>
+              <div slot="footer">
+                <bq-button size="small">Button</bq-button>
+                <bq-button appearance="link" size="small">Button</bq-button>
+              </div>
+            </bq-alert>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -878,28 +918,38 @@ Use the `error` variant for issues that require immediate attention. It works be
     </>
     ```
 
-    ```html Angular icon="angular"
-    <bq-alert open type="error">Title</bq-alert>
-
-    <bq-alert open type="error">
-      Title
-      <span slot="body">
-        Description
-        <a class="bq-link" href="https://example.com">Link</a>
-      </span>
-    </bq-alert>
-
-    <bq-alert open type="error">
-      Title
-      <span slot="body">
-        Description
-        <a class="bq-link" href="https://example.com">Link</a>
-      </span>
-      <div slot="footer">
-        <bq-button size="small">Button</bq-button>
-        <bq-button appearance="link" size="small">Button</bq-button>
-      </div>
-    </bq-alert>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqAlert, BqButton } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqAlert, BqButton],
+      template: `
+            <bq-alert open type="error">Title</bq-alert>
+        
+            <bq-alert open type="error">
+              Title
+              <span slot="body">
+                Description
+                <a class="bq-link" href="https://example.com">Link</a>
+              </span>
+            </bq-alert>
+        
+            <bq-alert open type="error">
+              Title
+              <span slot="body">
+                Description
+                <a class="bq-link" href="https://example.com">Link</a>
+              </span>
+              <div slot="footer">
+                <bq-button size="small">Button</bq-button>
+                <bq-button appearance="link" size="small">Button</bq-button>
+              </div>
+            </bq-alert>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -1022,16 +1072,26 @@ Use the `sticky` attribute for persistent alerts that remain visible until users
     </main>
     ```
 
-    ```html Angular icon="angular"
-    <main>
-      <h1>Dashboard</h1>
-      <div></div>
-
-      <bq-alert sticky open type="error">
-        Title
-        <bq-button appearance="link" size="small">Button</bq-button>
-      </bq-alert>
-    </main>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqAlert, BqButton } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqAlert, BqButton],
+      template: `
+            <main>
+              <h1>Dashboard</h1>
+              <div></div>
+        
+              <bq-alert sticky open type="error">
+                Title
+                <bq-button appearance="link" size="small">Button</bq-button>
+              </bq-alert>
+            </main>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -1113,11 +1173,21 @@ Set `auto-dismiss` to hide the alert automatically after a delay. Use `time` to 
     </BqAlert>
     ```
 
-    ```html Angular icon="angular"
-    <bq-alert open auto-dismiss time="8000" type="success">
-      Changes saved
-      <span slot="body">Your settings have been updated.</span>
-    </bq-alert>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqAlert } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqAlert],
+      template: `
+            <bq-alert open auto-dismiss time="8000" type="success">
+              Changes saved
+              <span slot="body">Your settings have been updated.</span>
+            </bq-alert>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/alert.mdx
+++ b/apps/beeq-docs/components/alert.mdx
@@ -251,6 +251,7 @@ Use the `default` variant for general-purpose alerts. It lets you customize the 
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqAlert, BqIcon, BqButton } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -429,6 +430,7 @@ Use the `info` variant when users need additional, non-critical information. It 
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqAlert, BqButton } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -593,6 +595,7 @@ Use the `success` variant to notify users about successful actions or positive o
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqAlert, BqButton } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -757,6 +760,7 @@ Use the `warning` variant to indicate potential issues or actions that users sho
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqAlert, BqButton } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -921,6 +925,7 @@ Use the `error` variant for issues that require immediate attention. It works be
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqAlert, BqButton } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -1075,6 +1080,7 @@ Use the `sticky` attribute for persistent alerts that remain visible until users
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqAlert, BqButton } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -1176,6 +1182,7 @@ Set `auto-dismiss` to hide the alert automatically after a delay. Use `time` to 
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqAlert } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,

--- a/apps/beeq-docs/components/avatar.mdx
+++ b/apps/beeq-docs/components/avatar.mdx
@@ -149,14 +149,21 @@ Use initials when no uploaded image is available or when the interface is intent
     <BqAvatar initials="BQ" label="Avatar component label" />
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqAvatar } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-
-    <bq-avatar
-      initials="BQ"
-      label="Avatar component label"
-    ></bq-avatar>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqAvatar } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqAvatar],
+      template: `
+        <bq-avatar
+              initials="BQ"
+              label="Avatar component label"
+            ></bq-avatar>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -208,13 +215,23 @@ When a profile photo or logo is available, pass both `image` and `initials`. The
     />
     ```
 
-    ```html Angular icon="angular"
-    <bq-avatar
-      alt-text="User profile"
-      image="https://images.unsplash.com/photo-1524593689594-aae2f26b75ab?auto=format&fit=crop&w=1000&q=80"
-      initials="BQ"
-      label="Avatar component label"
-    ></bq-avatar>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqAvatar } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqAvatar],
+      template: `
+            <bq-avatar
+              alt-text="User profile"
+              image="https://images.unsplash.com/photo-1524593689594-aae2f26b75ab?auto=format&fit=crop&w=1000&q=80"
+              initials="BQ"
+              label="Avatar component label"
+            ></bq-avatar>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -273,11 +290,21 @@ Avatar supports four sizes (`xsmall`, `small`, `medium`, `large`) and two shapes
     <BqAvatar label="Large square avatar" initials="BQ" shape="square" size="large" />
     ```
 
-    ```html Angular icon="angular"
-    <bq-avatar label="Extra small avatar" initials="B" size="xsmall"></bq-avatar>
-    <bq-avatar label="Small avatar" initials="BQ" size="small"></bq-avatar>
-    <bq-avatar label="Medium square avatar" initials="BQ" shape="square" size="medium"></bq-avatar>
-    <bq-avatar label="Large square avatar" initials="BQ" shape="square" size="large"></bq-avatar>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqAvatar } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqAvatar],
+      template: `
+            <bq-avatar label="Extra small avatar" initials="B" size="xsmall"></bq-avatar>
+            <bq-avatar label="Small avatar" initials="BQ" size="small"></bq-avatar>
+            <bq-avatar label="Medium square avatar" initials="BQ" shape="square" size="medium"></bq-avatar>
+            <bq-avatar label="Large square avatar" initials="BQ" shape="square" size="large"></bq-avatar>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -415,22 +442,32 @@ Use a grouped avatar pattern when you need to represent multiple participants in
     </div>
     ```
 
-    ```html Angular icon="angular"
-    <div class="avatar--group">
-      <bq-avatar
-        alt-text="User profile"
-        image="https://i.pravatar.cc/500?img=12"
-        label="Olivia Bennett"
-        size="small"
-      ></bq-avatar>
-      <bq-avatar
-        alt-text="User profile"
-        image="https://i.pravatar.cc/500?img=32"
-        label="Liam Carter"
-        size="small"
-      ></bq-avatar>
-      <bq-avatar initials="BQ" label="BEEQ team" size="small"></bq-avatar>
-    </div>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqAvatar } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqAvatar],
+      template: `
+            <div class="avatar--group">
+              <bq-avatar
+                alt-text="User profile"
+                image="https://i.pravatar.cc/500?img=12"
+                label="Olivia Bennett"
+                size="small"
+              ></bq-avatar>
+              <bq-avatar
+                alt-text="User profile"
+                image="https://i.pravatar.cc/500?img=32"
+                label="Liam Carter"
+                size="small"
+              ></bq-avatar>
+              <bq-avatar initials="BQ" label="BEEQ team" size="small"></bq-avatar>
+            </div>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -551,35 +588,45 @@ Use the `badge` slot when the avatar needs a compact status or count indicator. 
     </div>
     ```
 
-    ```html Angular icon="angular" expandable
-    <div class="avatar--with-badge">
-      <!-- Offline user -->
-      <bq-avatar
-        alt-text="User profile"
-        image="https://i.pravatar.cc/500"
-        label="Avatar component label"
-      >
-        <bq-badge slot="badge" size="medium" background-color="ui--tertiary"></bq-badge>
-      </bq-avatar>
-
-      <!-- Online user -->
-      <bq-avatar
-        alt-text="User profile"
-        image="https://i.pravatar.cc/500"
-        label="Avatar component label"
-      >
-        <bq-badge slot="badge" size="medium" background-color="ui--success"></bq-badge>
-      </bq-avatar>
-
-      <!-- Unread notifications -->
-      <bq-avatar
-        alt-text="User profile"
-        image="https://i.pravatar.cc/500"
-        label="Avatar component label"
-      >
-        <bq-badge slot="badge">16</bq-badge>
-      </bq-avatar>
-    </div>
+    ```ts Angular icon="angular" expandable
+    import { Component } from "@angular/core";
+    import { BqAvatar, BqBadge } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqAvatar, BqBadge],
+      template: `
+            <div class="avatar--with-badge">
+              <!-- Offline user -->
+              <bq-avatar
+                alt-text="User profile"
+                image="https://i.pravatar.cc/500"
+                label="Avatar component label"
+              >
+                <bq-badge slot="badge" size="medium" background-color="ui--tertiary"></bq-badge>
+              </bq-avatar>
+        
+              <!-- Online user -->
+              <bq-avatar
+                alt-text="User profile"
+                image="https://i.pravatar.cc/500"
+                label="Avatar component label"
+              >
+                <bq-badge slot="badge" size="medium" background-color="ui--success"></bq-badge>
+              </bq-avatar>
+        
+              <!-- Unread notifications -->
+              <bq-avatar
+                alt-text="User profile"
+                image="https://i.pravatar.cc/500"
+                label="Avatar component label"
+              >
+                <bq-badge slot="badge">16</bq-badge>
+              </bq-avatar>
+            </div>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs" expandable

--- a/apps/beeq-docs/components/avatar.mdx
+++ b/apps/beeq-docs/components/avatar.mdx
@@ -382,7 +382,7 @@ Use a grouped avatar pattern when you need to represent multiple participants in
   </div>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     .avatar--group {
       display: flex;
       align-items: center;

--- a/apps/beeq-docs/components/avatar.mdx
+++ b/apps/beeq-docs/components/avatar.mdx
@@ -139,17 +139,17 @@ Use initials when no uploaded image is available or when the interface is intent
   ></bq-avatar>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-avatar initials="BQ" label="Avatar component label"></bq-avatar>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqAvatar } from "@beeq/react";
 
     <BqAvatar initials="BQ" label="Avatar component label" />
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAvatar } from "@beeq/angular/standalone";
     @Component({
@@ -166,7 +166,7 @@ Use initials when no uploaded image is available or when the interface is intent
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqAvatar } from "@beeq/vue";
     </script>
@@ -195,7 +195,7 @@ When a profile photo or logo is available, pass both `image` and `initials`. The
   ></bq-avatar>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-avatar
       alt-text="User profile"
       image="https://images.unsplash.com/photo-1524593689594-aae2f26b75ab?auto=format&fit=crop&w=1000&q=80"
@@ -204,7 +204,7 @@ When a profile photo or logo is available, pass both `image` and `initials`. The
     ></bq-avatar>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqAvatar } from "@beeq/react";
 
     <BqAvatar
@@ -215,7 +215,7 @@ When a profile photo or logo is available, pass both `image` and `initials`. The
     />
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAvatar } from "@beeq/angular/standalone";
     @Component({
@@ -234,7 +234,7 @@ When a profile photo or logo is available, pass both `image` and `initials`. The
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqAvatar } from "@beeq/vue";
     </script>
@@ -274,14 +274,14 @@ Avatar supports four sizes (`xsmall`, `small`, `medium`, `large`) and two shapes
   </div>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-avatar label="Extra small avatar" initials="B" size="xsmall"></bq-avatar>
     <bq-avatar label="Small avatar" initials="BQ" size="small"></bq-avatar>
     <bq-avatar label="Medium square avatar" initials="BQ" shape="square" size="medium"></bq-avatar>
     <bq-avatar label="Large square avatar" initials="BQ" shape="square" size="large"></bq-avatar>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqAvatar } from "@beeq/react";
 
     <BqAvatar label="Extra small avatar" initials="B" size="xsmall" />
@@ -290,7 +290,7 @@ Avatar supports four sizes (`xsmall`, `small`, `medium`, `large`) and two shapes
     <BqAvatar label="Large square avatar" initials="BQ" shape="square" size="large" />
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAvatar } from "@beeq/angular/standalone";
     @Component({
@@ -307,7 +307,7 @@ Avatar supports four sizes (`xsmall`, `small`, `medium`, `large`) and two shapes
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqAvatar } from "@beeq/vue";
     </script>
@@ -379,7 +379,7 @@ Use a grouped avatar pattern when you need to represent multiple participants in
   </div>
 `}>
   <CodeGroup>
-    ```css CSS icon="css"
+    ```css styles.css icon="css" expandable
     .avatar--group {
       display: flex;
       align-items: center;
@@ -404,7 +404,7 @@ Use a grouped avatar pattern when you need to represent multiple participants in
     }
     ```
 
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <div class="avatar--group">
       <bq-avatar
         alt-text="User profile"
@@ -422,8 +422,9 @@ Use a grouped avatar pattern when you need to represent multiple participants in
     </div>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqAvatar } from "@beeq/react";
+    import "./styles.css";
 
     <div className="avatar--group">
       <BqAvatar
@@ -442,7 +443,7 @@ Use a grouped avatar pattern when you need to represent multiple participants in
     </div>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAvatar } from "@beeq/angular/standalone";
     @Component({
@@ -466,11 +467,35 @@ Use a grouped avatar pattern when you need to represent multiple participants in
               <bq-avatar initials="BQ" label="BEEQ team" size="small"></bq-avatar>
             </div>
       `,
+      style: `
+        .avatar--group {
+          display: flex;
+          align-items: center;
+
+          & bq-avatar {
+            cursor: pointer;
+            margin-inline-start: calc(var(--bq-spacing-xs) * -1);
+
+            &::part(base) {
+              transition: scale 0.25s ease-in-out;
+            }
+
+            &::part(base):hover {
+              scale: 1.2;
+              z-index: 1;
+            }
+
+            &:first-child {
+              margin-inline-start: 0;
+            }
+          }
+        }
+      `,
     })
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqAvatar } from "@beeq/vue";
     </script>
@@ -492,6 +517,33 @@ Use a grouped avatar pattern when you need to represent multiple participants in
         <BqAvatar initials="BQ" label="BEEQ team" size="small" />
       </div>
     </template>
+
+
+    <style>
+    .avatar--group {
+      display: flex;
+      align-items: center;
+
+      & bq-avatar {
+        cursor: pointer;
+        margin-inline-start: calc(var(--bq-spacing-xs) * -1);
+
+        &::part(base) {
+          transition: scale 0.25s ease-in-out;
+        }
+
+        &::part(base):hover {
+          scale: 1.2;
+          z-index: 1;
+        }
+
+        &:first-child {
+          margin-inline-start: 0;
+        }
+      }
+    }
+
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>

--- a/apps/beeq-docs/components/avatar.mdx
+++ b/apps/beeq-docs/components/avatar.mdx
@@ -158,9 +158,9 @@ Use initials when no uploaded image is available or when the interface is intent
       imports: [BqAvatar],
       template: `
         <bq-avatar
-              initials="BQ"
-              label="Avatar component label"
-            ></bq-avatar>
+          initials="BQ"
+          label="Avatar component label"
+          ></bq-avatar>
       `,
     })
     export class AppComponent {}
@@ -223,12 +223,12 @@ When a profile photo or logo is available, pass both `image` and `initials`. The
       standalone: true,
       imports: [BqAvatar],
       template: `
-            <bq-avatar
-              alt-text="User profile"
-              image="https://images.unsplash.com/photo-1524593689594-aae2f26b75ab?auto=format&fit=crop&w=1000&q=80"
-              initials="BQ"
-              label="Avatar component label"
-            ></bq-avatar>
+        <bq-avatar
+          alt-text="User profile"
+          image="https://images.unsplash.com/photo-1524593689594-aae2f26b75ab?auto=format&fit=crop&w=1000&q=80"
+          initials="BQ"
+          label="Avatar component label"
+          ></bq-avatar>
       `,
     })
     export class AppComponent {}
@@ -298,10 +298,10 @@ Avatar supports four sizes (`xsmall`, `small`, `medium`, `large`) and two shapes
       standalone: true,
       imports: [BqAvatar],
       template: `
-            <bq-avatar label="Extra small avatar" initials="B" size="xsmall"></bq-avatar>
-            <bq-avatar label="Small avatar" initials="BQ" size="small"></bq-avatar>
-            <bq-avatar label="Medium square avatar" initials="BQ" shape="square" size="medium"></bq-avatar>
-            <bq-avatar label="Large square avatar" initials="BQ" shape="square" size="large"></bq-avatar>
+        <bq-avatar label="Extra small avatar" initials="B" size="xsmall"></bq-avatar>
+        <bq-avatar label="Small avatar" initials="BQ" size="small"></bq-avatar>
+        <bq-avatar label="Medium square avatar" initials="BQ" shape="square" size="medium"></bq-avatar>
+        <bq-avatar label="Large square avatar" initials="BQ" shape="square" size="large"></bq-avatar>
       `,
     })
     export class AppComponent {}
@@ -450,18 +450,18 @@ Use a grouped avatar pattern when you need to represent multiple participants in
       standalone: true,
       imports: [BqAvatar],
       template: `
-            <div class="avatar--group">
-              <bq-avatar
-                alt-text="User profile"
-                image="https://i.pravatar.cc/500?img=12"
-                label="Olivia Bennett"
-                size="small"
-              ></bq-avatar>
-              <bq-avatar
-                alt-text="User profile"
-                image="https://i.pravatar.cc/500?img=32"
-                label="Liam Carter"
-                size="small"
+        <div class="avatar--group">
+          <bq-avatar
+            alt-text="User profile"
+            image="https://i.pravatar.cc/500?img=12"
+            label="Olivia Bennett"
+            size="small"
+            ></bq-avatar>
+            <bq-avatar
+              alt-text="User profile"
+              image="https://i.pravatar.cc/500?img=32"
+              label="Liam Carter"
+              size="small"
               ></bq-avatar>
               <bq-avatar initials="BQ" label="BEEQ team" size="small"></bq-avatar>
             </div>
@@ -596,34 +596,34 @@ Use the `badge` slot when the avatar needs a compact status or count indicator. 
       standalone: true,
       imports: [BqAvatar, BqBadge],
       template: `
-            <div class="avatar--with-badge">
-              <!-- Offline user -->
-              <bq-avatar
-                alt-text="User profile"
-                image="https://i.pravatar.cc/500"
-                label="Avatar component label"
-              >
-                <bq-badge slot="badge" size="medium" background-color="ui--tertiary"></bq-badge>
-              </bq-avatar>
-        
-              <!-- Online user -->
-              <bq-avatar
-                alt-text="User profile"
-                image="https://i.pravatar.cc/500"
-                label="Avatar component label"
-              >
-                <bq-badge slot="badge" size="medium" background-color="ui--success"></bq-badge>
-              </bq-avatar>
-        
-              <!-- Unread notifications -->
-              <bq-avatar
-                alt-text="User profile"
-                image="https://i.pravatar.cc/500"
-                label="Avatar component label"
-              >
-                <bq-badge slot="badge">16</bq-badge>
-              </bq-avatar>
-            </div>
+        <div class="avatar--with-badge">
+          <!-- Offline user -->
+          <bq-avatar
+            alt-text="User profile"
+            image="https://i.pravatar.cc/500"
+            label="Avatar component label"
+            >
+            <bq-badge slot="badge" size="medium" background-color="ui--tertiary"></bq-badge>
+          </bq-avatar>
+
+          <!-- Online user -->
+          <bq-avatar
+            alt-text="User profile"
+            image="https://i.pravatar.cc/500"
+            label="Avatar component label"
+            >
+            <bq-badge slot="badge" size="medium" background-color="ui--success"></bq-badge>
+          </bq-avatar>
+
+          <!-- Unread notifications -->
+          <bq-avatar
+            alt-text="User profile"
+            image="https://i.pravatar.cc/500"
+            label="Avatar component label"
+            >
+            <bq-badge slot="badge">16</bq-badge>
+          </bq-avatar>
+        </div>
       `,
     })
     export class AppComponent {}

--- a/apps/beeq-docs/components/avatar.mdx
+++ b/apps/beeq-docs/components/avatar.mdx
@@ -524,29 +524,28 @@ Use a grouped avatar pattern when you need to represent multiple participants in
 
 
     <style>
-    .avatar--group {
-      display: flex;
-      align-items: center;
+      .avatar--group {
+        display: flex;
+        align-items: center;
 
-      & bq-avatar {
-        cursor: pointer;
-        margin-inline-start: calc(var(--bq-spacing-xs) * -1);
+        & bq-avatar {
+          cursor: pointer;
+          margin-inline-start: calc(var(--bq-spacing-xs) * -1);
 
-        &::part(base) {
-          transition: scale 0.25s ease-in-out;
-        }
+          &::part(base) {
+            transition: scale 0.25s ease-in-out;
+          }
 
-        &::part(base):hover {
-          scale: 1.2;
-          z-index: 1;
-        }
+          &::part(base):hover {
+            scale: 1.2;
+            z-index: 1;
+          }
 
-        &:first-child {
-          margin-inline-start: 0;
+          &:first-child {
+            margin-inline-start: 0;
+          }
         }
       }
-    }
-
     </style>
     ```
   </CodeGroup>

--- a/apps/beeq-docs/components/avatar.mdx
+++ b/apps/beeq-docs/components/avatar.mdx
@@ -382,7 +382,7 @@ Use a grouped avatar pattern when you need to represent multiple participants in
   </div>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     .avatar--group {
       display: flex;
       align-items: center;
@@ -471,7 +471,7 @@ Use a grouped avatar pattern when you need to represent multiple participants in
               <bq-avatar initials="BQ" label="BEEQ team" size="small"></bq-avatar>
             </div>
       `,
-      style: `
+      styles: [`
         .avatar--group {
           display: flex;
           align-items: center;
@@ -494,7 +494,7 @@ Use a grouped avatar pattern when you need to represent multiple participants in
             }
           }
         }
-      `,
+      `],
     })
     export class AppComponent {}
     ```

--- a/apps/beeq-docs/components/avatar.mdx
+++ b/apps/beeq-docs/components/avatar.mdx
@@ -152,6 +152,7 @@ Use initials when no uploaded image is available or when the interface is intent
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAvatar } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -218,6 +219,7 @@ When a profile photo or logo is available, pass both `image` and `initials`. The
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAvatar } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -293,6 +295,7 @@ Avatar supports four sizes (`xsmall`, `small`, `medium`, `large`) and two shapes
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAvatar } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -446,6 +449,7 @@ Use a grouped avatar pattern when you need to represent multiple participants in
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAvatar } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -643,6 +647,7 @@ Use the `badge` slot when the avatar needs a compact status or count indicator. 
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqAvatar, BqBadge } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,

--- a/apps/beeq-docs/components/badge.mdx
+++ b/apps/beeq-docs/components/badge.mdx
@@ -113,12 +113,19 @@ Use the badge without slot content when you only need a small visual signal. `si
     <BqBadge size="medium" />
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqBadge } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-
-    <bq-badge></bq-badge>
-    <bq-badge size="medium"></bq-badge>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqBadge } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqBadge],
+      template: `
+        <bq-badge></bq-badge>
+            <bq-badge size="medium"></bq-badge>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -159,9 +166,19 @@ Add slot content when the badge needs to communicate a count. Keep the value sho
     <BqBadge>12</BqBadge>
     ```
 
-    ```html Angular icon="angular"
-    <bq-badge>2</bq-badge>
-    <bq-badge>12</bq-badge>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqBadge } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqBadge],
+      template: `
+            <bq-badge>2</bq-badge>
+            <bq-badge>12</bq-badge>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -247,11 +264,21 @@ When a badge is paired with an icon or trigger, position it on the outer edge so
     </div>
     ```
 
-    ```html Angular icon="angular"
-    <div class="badge--icon" aria-label="Notifications">
-      <bq-icon name="bell-ringing" size="24"></bq-icon>
-      <bq-badge>9</bq-badge>
-    </div>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqIcon, BqBadge } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqIcon, BqBadge],
+      template: `
+            <div class="badge--icon" aria-label="Notifications">
+              <bq-icon name="bell-ringing" size="24"></bq-icon>
+              <bq-badge>9</bq-badge>
+            </div>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/badge.mdx
+++ b/apps/beeq-docs/components/badge.mdx
@@ -101,19 +101,19 @@ Use the badge without slot content when you only need a small visual signal. `si
   <bq-badge size="medium"></bq-badge>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-badge></bq-badge>
     <bq-badge size="medium"></bq-badge>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqBadge } from "@beeq/react";
 
     <BqBadge />
     <BqBadge size="medium" />
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqBadge } from "@beeq/angular/standalone";
     @Component({
@@ -128,7 +128,7 @@ Use the badge without slot content when you only need a small visual signal. `si
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqBadge } from "@beeq/vue";
     </script>
@@ -154,19 +154,19 @@ Add slot content when the badge needs to communicate a count. Keep the value sho
   <bq-badge>12</bq-badge>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-badge>2</bq-badge>
     <bq-badge>12</bq-badge>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqBadge } from "@beeq/react";
 
     <BqBadge>2</BqBadge>
     <BqBadge>12</BqBadge>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqBadge } from "@beeq/angular/standalone";
     @Component({
@@ -181,7 +181,7 @@ Add slot content when the badge needs to communicate a count. Keep the value sho
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqBadge } from "@beeq/vue";
     </script>
@@ -235,7 +235,7 @@ When a badge is paired with an icon or trigger, position it on the outer edge so
   </div>
 `}>
   <CodeGroup>
-    ```css CSS icon="css"
+    ```css styles.css icon="css" expandable
     .badge--icon {
       position: relative;
       display: inline-flex;
@@ -248,15 +248,16 @@ When a badge is paired with an icon or trigger, position it on the outer edge so
     }
     ```
 
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <div class="badge--icon" aria-label="Notifications">
       <bq-icon name="bell-ringing" size="24"></bq-icon>
       <bq-badge>9</bq-badge>
     </div>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqBadge, BqIcon } from "@beeq/react";
+    import "./styles.css";
 
     <div className="badge--icon" aria-label="Notifications">
       <BqIcon name="bell-ringing" size="24" />
@@ -264,7 +265,7 @@ When a badge is paired with an icon or trigger, position it on the outer edge so
     </div>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqBadge } from "@beeq/angular/standalone";
     @Component({
@@ -277,11 +278,23 @@ When a badge is paired with an icon or trigger, position it on the outer edge so
           <bq-badge>9</bq-badge>
         </div>
       `,
+      style: `
+        .badge--icon {
+          position: relative;
+          display: inline-flex;
+
+          & bq-badge {
+            position: absolute;
+            inset-block-start: -4px;
+            inset-inline-end: -4px;
+          }
+        }
+      `,
     })
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqBadge, BqIcon } from "@beeq/vue";
     </script>
@@ -292,6 +305,21 @@ When a badge is paired with an icon or trigger, position it on the outer edge so
         <BqBadge>9</BqBadge>
       </div>
     </template>
+
+
+    <style>
+    .badge--icon {
+      position: relative;
+      display: inline-flex;
+
+      & bq-badge {
+        position: absolute;
+        inset-block-start: -4px;
+        inset-inline-end: -4px;
+      }
+    }
+
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>

--- a/apps/beeq-docs/components/badge.mdx
+++ b/apps/beeq-docs/components/badge.mdx
@@ -116,6 +116,7 @@ Use the badge without slot content when you only need a small visual signal. `si
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqBadge } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -169,6 +170,7 @@ Add slot content when the badge needs to communicate a count. Keep the value sho
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqBadge } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -268,6 +270,7 @@ When a badge is paired with an icon or trigger, position it on the outer edge so
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqBadge } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,

--- a/apps/beeq-docs/components/badge.mdx
+++ b/apps/beeq-docs/components/badge.mdx
@@ -237,7 +237,7 @@ When a badge is paired with an icon or trigger, position it on the outer edge so
   </div>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     .badge--icon {
       position: relative;
       display: inline-flex;

--- a/apps/beeq-docs/components/badge.mdx
+++ b/apps/beeq-docs/components/badge.mdx
@@ -237,7 +237,7 @@ When a badge is paired with an icon or trigger, position it on the outer edge so
   </div>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     .badge--icon {
       position: relative;
       display: inline-flex;
@@ -281,7 +281,7 @@ When a badge is paired with an icon or trigger, position it on the outer edge so
           <bq-badge>9</bq-badge>
         </div>
       `,
-      style: `
+      styles: [`
         .badge--icon {
           position: relative;
           display: inline-flex;
@@ -292,7 +292,7 @@ When a badge is paired with an icon or trigger, position it on the outer edge so
             inset-inline-end: -4px;
           }
         }
-      `,
+      `],
     })
     export class AppComponent {}
     ```

--- a/apps/beeq-docs/components/badge.mdx
+++ b/apps/beeq-docs/components/badge.mdx
@@ -122,7 +122,7 @@ Use the badge without slot content when you only need a small visual signal. `si
       imports: [BqBadge],
       template: `
         <bq-badge></bq-badge>
-            <bq-badge size="medium"></bq-badge>
+        <bq-badge size="medium"></bq-badge>
       `,
     })
     export class AppComponent {}
@@ -174,8 +174,8 @@ Add slot content when the badge needs to communicate a count. Keep the value sho
       standalone: true,
       imports: [BqBadge],
       template: `
-            <bq-badge>2</bq-badge>
-            <bq-badge>12</bq-badge>
+        <bq-badge>2</bq-badge>
+        <bq-badge>12</bq-badge>
       `,
     })
     export class AppComponent {}
@@ -272,10 +272,10 @@ When a badge is paired with an icon or trigger, position it on the outer edge so
       standalone: true,
       imports: [BqIcon, BqBadge],
       template: `
-            <div class="badge--icon" aria-label="Notifications">
-              <bq-icon name="bell-ringing" size="24"></bq-icon>
-              <bq-badge>9</bq-badge>
-            </div>
+        <div class="badge--icon" aria-label="Notifications">
+          <bq-icon name="bell-ringing" size="24"></bq-icon>
+          <bq-badge>9</bq-badge>
+        </div>
       `,
     })
     export class AppComponent {}

--- a/apps/beeq-docs/components/badge.mdx
+++ b/apps/beeq-docs/components/badge.mdx
@@ -311,17 +311,16 @@ When a badge is paired with an icon or trigger, position it on the outer edge so
 
 
     <style>
-    .badge--icon {
-      position: relative;
-      display: inline-flex;
+      .badge--icon {
+        position: relative;
+        display: inline-flex;
 
-      & bq-badge {
-        position: absolute;
-        inset-block-start: -4px;
-        inset-inline-end: -4px;
+        & bq-badge {
+          position: absolute;
+          inset-block-start: -4px;
+          inset-inline-end: -4px;
+        }
       }
-    }
-
     </style>
     ```
   </CodeGroup>

--- a/apps/beeq-docs/components/breadcrumb.mdx
+++ b/apps/beeq-docs/components/breadcrumb.mdx
@@ -170,11 +170,11 @@ Use a default breadcrumb to show the current page within a hierarchy. When `href
       imports: [BqBreadcrumb, BqBreadcrumbItem],
       template: `
         <bq-breadcrumb label="Breadcrumb">
-              <bq-breadcrumb-item>Home</bq-breadcrumb-item>
-              <bq-breadcrumb-item>Men's clothing</bq-breadcrumb-item>
-              <bq-breadcrumb-item>Shirt</bq-breadcrumb-item>
-              <bq-breadcrumb-item>Casual shirts</bq-breadcrumb-item>
-            </bq-breadcrumb>
+          <bq-breadcrumb-item>Home</bq-breadcrumb-item>
+          <bq-breadcrumb-item>Men's clothing</bq-breadcrumb-item>
+          <bq-breadcrumb-item>Shirt</bq-breadcrumb-item>
+          <bq-breadcrumb-item>Casual shirts</bq-breadcrumb-item>
+        </bq-breadcrumb>
       `,
     })
     export class AppComponent {}
@@ -248,12 +248,12 @@ Use the `separator` slot to replace the default `/` separator.
       standalone: true,
       imports: [BqBreadcrumb, BqIcon, BqBreadcrumbItem],
       template: `
-            <bq-breadcrumb label="Breadcrumb">
-              <bq-icon name="caret-right" size="12" slot="separator"></bq-icon>
-              <bq-breadcrumb-item href="/">Home</bq-breadcrumb-item>
-              <bq-breadcrumb-item href="/catalog">Catalog</bq-breadcrumb-item>
-              <bq-breadcrumb-item>Casual shirts</bq-breadcrumb-item>
-            </bq-breadcrumb>
+        <bq-breadcrumb label="Breadcrumb">
+          <bq-icon name="caret-right" size="12" slot="separator"></bq-icon>
+          <bq-breadcrumb-item href="/">Home</bq-breadcrumb-item>
+          <bq-breadcrumb-item href="/catalog">Catalog</bq-breadcrumb-item>
+          <bq-breadcrumb-item>Casual shirts</bq-breadcrumb-item>
+        </bq-breadcrumb>
       `,
     })
     export class AppComponent {}
@@ -338,15 +338,15 @@ Icons next to labels help users recognize categories at a glance. Use `size="16"
       imports: [BqBreadcrumb, BqBreadcrumbItem, BqIcon],
       template: `
         <bq-breadcrumb label="Breadcrumb">
-              <bq-breadcrumb-item aria-label="Home page">
-                <bq-icon name="house-line" size="16"></bq-icon>
-              </bq-breadcrumb-item>
-              <bq-breadcrumb-item>
-                <bq-icon name="shirt-folded" size="16"></bq-icon>
-                Men's Clothing
-              </bq-breadcrumb-item>
-              <bq-breadcrumb-item>Casual shirts</bq-breadcrumb-item>
-            </bq-breadcrumb>
+          <bq-breadcrumb-item aria-label="Home page">
+            <bq-icon name="house-line" size="16"></bq-icon>
+          </bq-breadcrumb-item>
+          <bq-breadcrumb-item>
+            <bq-icon name="shirt-folded" size="16"></bq-icon>
+            Men's Clothing
+          </bq-breadcrumb-item>
+          <bq-breadcrumb-item>Casual shirts</bq-breadcrumb-item>
+        </bq-breadcrumb>
       `,
     })
     export class AppComponent {}

--- a/apps/beeq-docs/components/breadcrumb.mdx
+++ b/apps/beeq-docs/components/breadcrumb.mdx
@@ -164,6 +164,7 @@ Use a default breadcrumb to show the current page within a hierarchy. When `href
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqBreadcrumb, BqBreadcrumbItem } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -243,6 +244,7 @@ Use the `separator` slot to replace the default `/` separator.
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqBreadcrumb, BqIcon, BqBreadcrumbItem } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -332,6 +334,7 @@ Icons next to labels help users recognize categories at a glance. Use `size="16"
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqBreadcrumb, BqBreadcrumbItem, BqIcon } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,

--- a/apps/beeq-docs/components/breadcrumb.mdx
+++ b/apps/beeq-docs/components/breadcrumb.mdx
@@ -161,16 +161,23 @@ Use a default breadcrumb to show the current page within a hierarchy. When `href
     </BqBreadcrumb>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqBreadcrumb, BqBreadcrumbItem } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-
-    <bq-breadcrumb label="Breadcrumb">
-      <bq-breadcrumb-item>Home</bq-breadcrumb-item>
-      <bq-breadcrumb-item>Men's clothing</bq-breadcrumb-item>
-      <bq-breadcrumb-item>Shirt</bq-breadcrumb-item>
-      <bq-breadcrumb-item>Casual shirts</bq-breadcrumb-item>
-    </bq-breadcrumb>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqBreadcrumb, BqBreadcrumbItem } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqBreadcrumb, BqBreadcrumbItem],
+      template: `
+        <bq-breadcrumb label="Breadcrumb">
+              <bq-breadcrumb-item>Home</bq-breadcrumb-item>
+              <bq-breadcrumb-item>Men's clothing</bq-breadcrumb-item>
+              <bq-breadcrumb-item>Shirt</bq-breadcrumb-item>
+              <bq-breadcrumb-item>Casual shirts</bq-breadcrumb-item>
+            </bq-breadcrumb>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -233,13 +240,23 @@ Use the `separator` slot to replace the default `/` separator.
     </BqBreadcrumb>
     ```
 
-    ```html Angular icon="angular"
-    <bq-breadcrumb label="Breadcrumb">
-      <bq-icon name="caret-right" size="12" slot="separator"></bq-icon>
-      <bq-breadcrumb-item href="/">Home</bq-breadcrumb-item>
-      <bq-breadcrumb-item href="/catalog">Catalog</bq-breadcrumb-item>
-      <bq-breadcrumb-item>Casual shirts</bq-breadcrumb-item>
-    </bq-breadcrumb>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqBreadcrumb, BqIcon, BqBreadcrumbItem } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqBreadcrumb, BqIcon, BqBreadcrumbItem],
+      template: `
+            <bq-breadcrumb label="Breadcrumb">
+              <bq-icon name="caret-right" size="12" slot="separator"></bq-icon>
+              <bq-breadcrumb-item href="/">Home</bq-breadcrumb-item>
+              <bq-breadcrumb-item href="/catalog">Catalog</bq-breadcrumb-item>
+              <bq-breadcrumb-item>Casual shirts</bq-breadcrumb-item>
+            </bq-breadcrumb>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -312,20 +329,27 @@ Icons next to labels help users recognize categories at a glance. Use `size="16"
     </BqBreadcrumb>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqBreadcrumb, BqBreadcrumbItem, BqIcon } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-
-    <bq-breadcrumb label="Breadcrumb">
-      <bq-breadcrumb-item aria-label="Home page">
-        <bq-icon name="house-line" size="16"></bq-icon>
-      </bq-breadcrumb-item>
-      <bq-breadcrumb-item>
-        <bq-icon name="shirt-folded" size="16"></bq-icon>
-        Men's Clothing
-      </bq-breadcrumb-item>
-      <bq-breadcrumb-item>Casual shirts</bq-breadcrumb-item>
-    </bq-breadcrumb>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqBreadcrumb, BqBreadcrumbItem, BqIcon } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqBreadcrumb, BqBreadcrumbItem, BqIcon],
+      template: `
+        <bq-breadcrumb label="Breadcrumb">
+              <bq-breadcrumb-item aria-label="Home page">
+                <bq-icon name="house-line" size="16"></bq-icon>
+              </bq-breadcrumb-item>
+              <bq-breadcrumb-item>
+                <bq-icon name="shirt-folded" size="16"></bq-icon>
+                Men's Clothing
+              </bq-breadcrumb-item>
+              <bq-breadcrumb-item>Casual shirts</bq-breadcrumb-item>
+            </bq-breadcrumb>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/button.mdx
+++ b/apps/beeq-docs/components/button.mdx
@@ -143,9 +143,9 @@ Primary also supports `ghost` and `danger` variants:
       standalone: true,
       imports: [BqButton],
       template: `
-            <bq-button>Primary standard</bq-button>
-            <bq-button variant="ghost">Primary ghost</bq-button>
-            <bq-button variant="danger">Primary danger</bq-button>
+        <bq-button>Primary standard</bq-button>
+        <bq-button variant="ghost">Primary ghost</bq-button>
+        <bq-button variant="danger">Primary danger</bq-button>
       `,
     })
     export class AppComponent {}
@@ -188,8 +188,8 @@ Lower-emphasis actions. Can stand alone or pair with a primary button to perform
       standalone: true,
       imports: [BqButton],
       template: `
-            <bq-button appearance="secondary">Secondary</bq-button>
-            <bq-button appearance="secondary" variant="ghost">Secondary ghost</bq-button>
+        <bq-button appearance="secondary">Secondary</bq-button>
+        <bq-button appearance="secondary" variant="ghost">Secondary ghost</bq-button>
       `,
     })
     export class AppComponent {}
@@ -233,9 +233,9 @@ Renders as an `<a>` element under the hood when `href` is provided. Still action
       standalone: true,
       imports: [BqButton],
       template: `
-            <bq-button appearance="link" href="https://www.example.com" target="_blank">
-              Link button
-            </bq-button>
+        <bq-button appearance="link" href="https://www.example.com" target="_blank">
+          Link button
+        </bq-button>
       `,
     })
     export class AppComponent {}
@@ -280,7 +280,7 @@ No background or border. Suitable for inline actions, subtle calls to action, or
       standalone: true,
       imports: [BqButton],
       template: `
-            <bq-button appearance="text">Text button</bq-button>
+        <bq-button appearance="text">Text button</bq-button>
       `,
     })
     export class AppComponent {}
@@ -331,9 +331,9 @@ Choose the size that best matches the context. Medium is the default and preferr
       standalone: true,
       imports: [BqButton],
       template: `
-            <bq-button size="small">Small</bq-button>
-            <bq-button size="medium">Medium</bq-button>
-            <bq-button size="large">Large</bq-button>
+        <bq-button size="small">Small</bq-button>
+        <bq-button size="medium">Medium</bq-button>
+        <bq-button size="large">Large</bq-button>
       `,
     })
     export class AppComponent {}
@@ -374,7 +374,7 @@ Use the `block` attribute to make the button stretch to its parent width.
       standalone: true,
       imports: [BqButton],
       template: `
-            <bq-button block>Full width button</bq-button>
+        <bq-button block>Full width button</bq-button>
       `,
     })
     export class AppComponent {}
@@ -419,10 +419,10 @@ Use the `border` property to control the corner radius.
       standalone: true,
       imports: [BqButton],
       template: `
-            <bq-button border="full">Primary</bq-button>
-            <bq-button variant="ghost" border="full">Ghost</bq-button>
-            <bq-button variant="danger" border="full">Danger</bq-button>
-            <bq-button appearance="secondary" border="full">Secondary</bq-button>
+        <bq-button border="full">Primary</bq-button>
+        <bq-button variant="ghost" border="full">Ghost</bq-button>
+        <bq-button variant="danger" border="full">Danger</bq-button>
+        <bq-button appearance="secondary" border="full">Secondary</bq-button>
       `,
     })
     export class AppComponent {}
@@ -479,10 +479,10 @@ The `disabled` attribute can be applied to any button variation. When disabled, 
       standalone: true,
       imports: [BqButton],
       template: `
-            <bq-button disabled>Primary</bq-button>
-            <bq-button variant="ghost" disabled>Ghost</bq-button>
-            <bq-button variant="danger" disabled>Danger</bq-button>
-            <bq-button appearance="secondary" disabled>Secondary</bq-button>
+        <bq-button disabled>Primary</bq-button>
+        <bq-button variant="ghost" disabled>Ghost</bq-button>
+        <bq-button variant="danger" disabled>Danger</bq-button>
+        <bq-button appearance="secondary" disabled>Secondary</bq-button>
       `,
     })
     export class AppComponent {}
@@ -530,8 +530,8 @@ Use the `loading` attribute to indicate something is being processed. Pair with 
       standalone: true,
       imports: [BqButton],
       template: `
-            <bq-button loading>Loading</bq-button>
-            <bq-button loading disabled>Loading disabled</bq-button>
+        <bq-button loading>Loading</bq-button>
+        <bq-button loading disabled>Loading disabled</bq-button>
       `,
     })
     export class AppComponent {}
@@ -589,17 +589,17 @@ Use the `prefix` or `suffix` slot to add icons. Icons should reinforce the label
       standalone: true,
       imports: [BqButton, BqIcon],
       template: `
-            <!-- import { BqButton, BqIcon } from "@beeq/angular/standalone" -->
-        
-            <bq-button>
-              <bq-icon name="arrow-circle-left" slot="prefix"></bq-icon>
-              Go back
-            </bq-button>
-        
-            <bq-button>
-              Next step
-              <bq-icon name="arrow-circle-right" slot="suffix"></bq-icon>
-            </bq-button>
+        <!-- import { BqButton, BqIcon } from "@beeq/angular/standalone" -->
+
+        <bq-button>
+          <bq-icon name="arrow-circle-left" slot="prefix"></bq-icon>
+          Go back
+        </bq-button>
+
+        <bq-button>
+          Next step
+          <bq-icon name="arrow-circle-right" slot="suffix"></bq-icon>
+        </bq-button>
       `,
     })
     export class AppComponent {}
@@ -663,15 +663,15 @@ Always provide a `label` so assistive technologies can announce the action corre
       standalone: true,
       imports: [BqButton, BqIcon],
       template: `
-            <bq-button only-icon label="Notifications">
-              <bq-icon name="bell-ringing"></bq-icon>
-            </bq-button>
-            <bq-button only-icon variant="ghost" label="Notifications">
-              <bq-icon name="bell-ringing"></bq-icon>
-            </bq-button>
-            <bq-button only-icon appearance="secondary" label="Notifications">
-              <bq-icon name="bell-ringing"></bq-icon>
-            </bq-button>
+        <bq-button only-icon label="Notifications">
+          <bq-icon name="bell-ringing"></bq-icon>
+        </bq-button>
+        <bq-button only-icon variant="ghost" label="Notifications">
+          <bq-icon name="bell-ringing"></bq-icon>
+        </bq-button>
+        <bq-button only-icon appearance="secondary" label="Notifications">
+          <bq-icon name="bell-ringing"></bq-icon>
+        </bq-button>
       `,
     })
     export class AppComponent {}

--- a/apps/beeq-docs/components/button.mdx
+++ b/apps/beeq-docs/components/button.mdx
@@ -90,6 +90,7 @@ The highest priority action in a view. Only one per screen or section.
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqButton } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -138,6 +139,7 @@ Primary also supports `ghost` and `danger` variants:
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqButton } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -183,6 +185,7 @@ Lower-emphasis actions. Can stand alone or pair with a primary button to perform
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqButton } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -228,6 +231,7 @@ Renders as an `<a>` element under the hood when `href` is provided. Still action
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqButton } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -275,6 +279,7 @@ No background or border. Suitable for inline actions, subtle calls to action, or
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqButton } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -326,6 +331,7 @@ Choose the size that best matches the context. Medium is the default and preferr
     ```ts Angular  icon="angular"
     import { Component } from "@angular/core";
     import { BqButton } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -369,6 +375,7 @@ Use the `block` attribute to make the button stretch to its parent width.
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqButton } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -414,6 +421,7 @@ Use the `border` property to control the corner radius.
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqButton } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -474,6 +482,7 @@ The `disabled` attribute can be applied to any button variation. When disabled, 
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqButton } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -525,6 +534,7 @@ Use the `loading` attribute to indicate something is being processed. Pair with 
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqButton } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -584,6 +594,7 @@ Use the `prefix` or `suffix` slot to add icons. Icons should reinforce the label
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqButton, BqIcon } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -658,6 +669,7 @@ Always provide a `label` so assistive technologies can announce the action corre
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqButton, BqIcon } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,

--- a/apps/beeq-docs/components/button.mdx
+++ b/apps/beeq-docs/components/button.mdx
@@ -56,7 +56,8 @@ Some patterns below are standalone `bq-button` usages, while others are composit
 ## Anatomy
 
 <Frame caption="Button anatomy">
-  <img src="/components/images/button/button-anatomy.svg" alt="Button anatomy: 1. Container, 2. Icon, 3. Label" />
+  <img className="block dark:hidden" src="/components/images/button/button-anatomy.svg" alt="Button anatomy: 1. Container, 2. Icon, 3. Label" />
+  <img className="hidden dark:block" src="/components/images/button/button-anatomy.svg" alt="Button anatomy: 1. Container, 2. Icon, 3. Label" />
 </Frame>
 
 A button can contain a label and optional leading or trailing icons.
@@ -86,11 +87,18 @@ The highest priority action in a view. Only one per screen or section.
 
     <BqButton>Primary button</BqButton>
     ```
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqButton } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-
-    <bq-button>Primary button</bq-button>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqButton } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqButton],
+      template: `
+        <bq-button>Primary button</bq-button>
+      `,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue icon="vuejs"
     <script setup lang="ts">
@@ -127,10 +135,20 @@ Primary also supports `ghost` and `danger` variants:
     <BqButton variant="ghost">Primary ghost</BqButton>
     <BqButton variant="danger">Primary danger</BqButton>
     ```
-    ```html Angular icon="angular"
-    <bq-button>Primary standard</bq-button>
-    <bq-button variant="ghost">Primary ghost</bq-button>
-    <bq-button variant="danger">Primary danger</bq-button>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqButton } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqButton],
+      template: `
+            <bq-button>Primary standard</bq-button>
+            <bq-button variant="ghost">Primary ghost</bq-button>
+            <bq-button variant="danger">Primary danger</bq-button>
+      `,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue icon="vuejs"
     <script setup lang="ts">
@@ -162,9 +180,19 @@ Lower-emphasis actions. Can stand alone or pair with a primary button to perform
     <BqButton appearance="secondary">Secondary</BqButton>
     <BqButton appearance="secondary" variant="ghost">Secondary ghost</BqButton>
     ```
-    ```html Angular icon="angular"
-    <bq-button appearance="secondary">Secondary</bq-button>
-    <bq-button appearance="secondary" variant="ghost">Secondary ghost</bq-button>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqButton } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqButton],
+      template: `
+            <bq-button appearance="secondary">Secondary</bq-button>
+            <bq-button appearance="secondary" variant="ghost">Secondary ghost</bq-button>
+      `,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue icon="vuejs"
     <script setup lang="ts">
@@ -197,10 +225,20 @@ Renders as an `<a>` element under the hood when `href` is provided. Still action
       Link button
     </BqButton>
     ```
-    ```html Angular icon="angular"
-    <bq-button appearance="link" href="https://www.example.com" target="_blank">
-      Link button
-    </bq-button>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqButton } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqButton],
+      template: `
+            <bq-button appearance="link" href="https://www.example.com" target="_blank">
+              Link button
+            </bq-button>
+      `,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue icon="vuejs"
     <script setup lang="ts">
@@ -234,8 +272,18 @@ No background or border. Suitable for inline actions, subtle calls to action, or
 
     <BqButton appearance="text">Text button</BqButton>
     ```
-    ```html Angular icon="angular"
-    <bq-button appearance="text">Text button</bq-button>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqButton } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqButton],
+      template: `
+            <bq-button appearance="text">Text button</bq-button>
+      `,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue icon="vuejs"
     <script setup lang="ts">
@@ -275,10 +323,20 @@ Choose the size that best matches the context. Medium is the default and preferr
     <BqButton size="medium">Medium</BqButton>
     <BqButton size="large">Large</BqButton>
     ```
-    ```html Angular  icon="angular"
-    <bq-button size="small">Small</bq-button>
-    <bq-button size="medium">Medium</bq-button>
-    <bq-button size="large">Large</bq-button>
+    ```ts Angular  icon="angular"
+    import { Component } from "@angular/core";
+    import { BqButton } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqButton],
+      template: `
+            <bq-button size="small">Small</bq-button>
+            <bq-button size="medium">Medium</bq-button>
+            <bq-button size="large">Large</bq-button>
+      `,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue icon="vuejs"
     <script setup lang="ts">
@@ -308,8 +366,18 @@ Use the `block` attribute to make the button stretch to its parent width.
 
     <BqButton block>Full width button</BqButton>
     ```
-    ```html Angular icon="angular"
-    <bq-button block>Full width button</bq-button>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqButton } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqButton],
+      template: `
+            <bq-button block>Full width button</bq-button>
+      `,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue icon="vuejs"
     <script setup lang="ts">
@@ -343,11 +411,21 @@ Use the `border` property to control the corner radius.
     <BqButton variant="danger" border="full">Danger</BqButton>
     <BqButton appearance="secondary" border="full">Secondary</BqButton>
     ```
-    ```html Angular icon="angular"
-    <bq-button border="full">Primary</bq-button>
-    <bq-button variant="ghost" border="full">Ghost</bq-button>
-    <bq-button variant="danger" border="full">Danger</bq-button>
-    <bq-button appearance="secondary" border="full">Secondary</bq-button>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqButton } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqButton],
+      template: `
+            <bq-button border="full">Primary</bq-button>
+            <bq-button variant="ghost" border="full">Ghost</bq-button>
+            <bq-button variant="danger" border="full">Danger</bq-button>
+            <bq-button appearance="secondary" border="full">Secondary</bq-button>
+      `,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue icon="vuejs"
     <script setup lang="ts">
@@ -369,7 +447,8 @@ Use the `border` property to control the corner radius.
 For each button appearance and variant, there are five visual states: **enabled**, **hover**, **focus**, **active**, **loading** and **disabled**.
 
 <Frame caption="Button states: enabled, hover, focus, active, loading, disabled">
-  <img src="/components/images/button/button-states.svg" alt="Button states: enabled, hover, focus, active, loading, disabled" />
+  <img className="block dark:hidden" src="/components/images/button/button-states.svg" alt="Button states: enabled, hover, focus, active, loading, disabled" />
+  <img className="hidden dark:block" src="/components/images/button/button-states.svg" alt="Button states: enabled, hover, focus, active, loading, disabled" />
 </Frame>
 
 ### Disabled
@@ -392,11 +471,21 @@ The `disabled` attribute can be applied to any button variation. When disabled, 
     <BqButton variant="danger" disabled>Danger</BqButton>
     <BqButton appearance="secondary" disabled>Secondary</BqButton>
     ```
-    ```html Angular icon="angular"
-    <bq-button disabled>Primary</bq-button>
-    <bq-button variant="ghost" disabled>Ghost</bq-button>
-    <bq-button variant="danger" disabled>Danger</bq-button>
-    <bq-button appearance="secondary" disabled>Secondary</bq-button>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqButton } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqButton],
+      template: `
+            <bq-button disabled>Primary</bq-button>
+            <bq-button variant="ghost" disabled>Ghost</bq-button>
+            <bq-button variant="danger" disabled>Danger</bq-button>
+            <bq-button appearance="secondary" disabled>Secondary</bq-button>
+      `,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue icon="vuejs"
     <script setup lang="ts">
@@ -433,9 +522,19 @@ Use the `loading` attribute to indicate something is being processed. Pair with 
     <BqButton loading>Loading</BqButton>
     <BqButton loading disabled>Loading disabled</BqButton>
     ```
-    ```html Angular icon="angular"
-    <bq-button loading>Loading</bq-button>
-    <bq-button loading disabled>Loading disabled</bq-button>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqButton } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqButton],
+      template: `
+            <bq-button loading>Loading</bq-button>
+            <bq-button loading disabled>Loading disabled</bq-button>
+      `,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue icon="vuejs"
     <script setup lang="ts">
@@ -482,18 +581,28 @@ Use the `prefix` or `suffix` slot to add icons. Icons should reinforce the label
       <BqIcon name="arrow-circle-right" slot="suffix" />
     </BqButton>
     ```
-    ```html Angular icon="angular"
-    <!-- import { BqButton, BqIcon } from "@beeq/angular/standalone" -->
-
-    <bq-button>
-      <bq-icon name="arrow-circle-left" slot="prefix"></bq-icon>
-      Go back
-    </bq-button>
-
-    <bq-button>
-      Next step
-      <bq-icon name="arrow-circle-right" slot="suffix"></bq-icon>
-    </bq-button>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqButton, BqIcon } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqButton, BqIcon],
+      template: `
+            <!-- import { BqButton, BqIcon } from "@beeq/angular/standalone" -->
+        
+            <bq-button>
+              <bq-icon name="arrow-circle-left" slot="prefix"></bq-icon>
+              Go back
+            </bq-button>
+        
+            <bq-button>
+              Next step
+              <bq-icon name="arrow-circle-right" slot="suffix"></bq-icon>
+            </bq-button>
+      `,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue icon="vuejs"
     <script setup lang="ts">
@@ -546,16 +655,26 @@ Always provide a `label` so assistive technologies can announce the action corre
       <BqIcon name="bell-ringing" />
     </BqButton>
     ```
-    ```html Angular icon="angular"
-    <bq-button only-icon label="Notifications">
-      <bq-icon name="bell-ringing"></bq-icon>
-    </bq-button>
-    <bq-button only-icon variant="ghost" label="Notifications">
-      <bq-icon name="bell-ringing"></bq-icon>
-    </bq-button>
-    <bq-button only-icon appearance="secondary" label="Notifications">
-      <bq-icon name="bell-ringing"></bq-icon>
-    </bq-button>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqButton, BqIcon } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqButton, BqIcon],
+      template: `
+            <bq-button only-icon label="Notifications">
+              <bq-icon name="bell-ringing"></bq-icon>
+            </bq-button>
+            <bq-button only-icon variant="ghost" label="Notifications">
+              <bq-icon name="bell-ringing"></bq-icon>
+            </bq-button>
+            <bq-button only-icon appearance="secondary" label="Notifications">
+              <bq-icon name="bell-ringing"></bq-icon>
+            </bq-button>
+      `,
+    })
+    export class AppComponent {}
     ```
     ```vue Vue icon="vuejs"
     <script setup lang="ts">

--- a/apps/beeq-docs/components/card.mdx
+++ b/apps/beeq-docs/components/card.mdx
@@ -169,7 +169,7 @@ A card with icon, title, description, and a call-to-action — use when users ne
   </bq-card>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     .card--default {
       max-width: 24rem;
       width: 100%;
@@ -382,7 +382,7 @@ Use a card list when you have a collection of items that share the same structur
   </bq-card>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     .card--highlights {
       width: 100%;
       max-width: 24rem;
@@ -652,7 +652,7 @@ A KPI card combining an icon, headline value, and trend indicator — ideal for 
   </bq-card>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     .card--overview {
       width: 100%;
       max-width: 24rem;
@@ -944,7 +944,7 @@ A compact horizontal card using `type="minimal"` that removes built-in padding, 
   </bq-card>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     .card--mini {
       width: 100%;
       max-width: 24rem;
@@ -1612,7 +1612,7 @@ When a card represents a link destination (for example, an article or product), 
   </a>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     .card-link {
       border-radius: var(--bq-radius--m);
       text-decoration: none;

--- a/apps/beeq-docs/components/card.mdx
+++ b/apps/beeq-docs/components/card.mdx
@@ -231,6 +231,7 @@ A card with icon, title, description, and a call-to-action — use when users ne
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqCard, BqIcon, BqButton } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -464,6 +465,7 @@ Use a card list when you have a collection of items that share the same structur
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqCard, BqIcon } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -736,6 +738,7 @@ A KPI card combining an icon, headline value, and trend indicator — ideal for 
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqCard, BqIcon } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -1028,6 +1031,7 @@ A compact horizontal card using `type="minimal"` that removes built-in padding, 
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqCard, BqIcon } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -1232,6 +1236,7 @@ A compact horizontal card using `type="minimal"` that removes built-in padding, 
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqCard } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -1374,6 +1379,7 @@ Use the `border` property to control the card corner radius.
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqCard } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -1682,6 +1688,7 @@ When a card represents a link destination (for example, an article or product), 
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqCard, BqIcon } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,

--- a/apps/beeq-docs/components/card.mdx
+++ b/apps/beeq-docs/components/card.mdx
@@ -301,26 +301,25 @@ A card with icon, title, description, and a call-to-action — use when users ne
 
 
     <style>
-    .card--default {
-      max-width: 24rem;
-      width: 100%;
+      .card--default {
+        max-width: 24rem;
+        width: 100%;
 
-      &::part(wrapper) {
-        display: flex;
-        flex-direction: column;
-        gap: var(--bq-spacing-m);
+        &::part(wrapper) {
+          display: flex;
+          flex-direction: column;
+          gap: var(--bq-spacing-m);
+        }
+
+        h6 {
+          font-size: var(--bq-font-size--m);
+          font-weight: var(--bq-font-weight--bold);
+        }
+
+        p {
+          margin-block-start: var(--bq-spacing-m);
+        }
       }
-
-      h6 {
-        font-size: var(--bq-font-size--m);
-        font-weight: var(--bq-font-weight--bold);
-      }
-
-      p {
-        margin-block-start: var(--bq-spacing-m);
-      }
-    }
-
     </style>
     ```
   </CodeGroup>
@@ -556,33 +555,32 @@ Use a card list when you have a collection of items that share the same structur
 
 
     <style>
-    .card--highlights {
-      width: 100%;
-      max-width: 24rem;
+      .card--highlights {
+        width: 100%;
+        max-width: 24rem;
 
-      &::part(wrapper) {
-        display: flex;
-        flex-direction: column;
-        gap: var(--bq-spacing-m);
-      }
-
-      & h6 {
-        font-size: var(--bq-font-size--l);
-        font-weight: var(--bq-font-weight--bold);
-      }
-
-      & section {
-        display: flex;
-        flex-direction: column;
-        gap: var(--bq-spacing-s);
-
-        & .item {
+        &::part(wrapper) {
           display: flex;
+          flex-direction: column;
+          gap: var(--bq-spacing-m);
+        }
+
+        & h6 {
+          font-size: var(--bq-font-size--l);
+          font-weight: var(--bq-font-weight--bold);
+        }
+
+        & section {
+          display: flex;
+          flex-direction: column;
           gap: var(--bq-spacing-s);
+
+          & .item {
+            display: flex;
+            gap: var(--bq-spacing-s);
+          }
         }
       }
-    }
-
     </style>
     ```
 </CodeGroup>
@@ -832,46 +830,45 @@ A KPI card combining an icon, headline value, and trend indicator — ideal for 
 
 
     <style>
-    .card--overview {
-      width: 100%;
-      max-width: 24rem;
+      .card--overview {
+        width: 100%;
+        max-width: 24rem;
 
-      &::part(wrapper) {
-        display: flex;
-        gap: var(--bq-spacing-m);
+        &::part(wrapper) {
+          display: flex;
+          gap: var(--bq-spacing-m);
+        }
+
+        & h4 {
+          font-size: var(--bq-font-size--xxl);
+        }
+
+        & .card--body {
+          display: flex;
+          flex-direction: column;
+          gap: var(--bq-spacing-xs2);
+        }
+
+        & .body__top {
+          display: flex;
+          align-items: center;
+          gap: var(--bq-spacing-xs2);
+        }
+
+        & .body__bottom {
+          display: flex;
+          align-items: flex-end;
+          gap: var(--bq-spacing-xs);
+        }
+
+        & .text-secondary {
+          color: var(--bq-text--secondary);
+        }
+
+        & .text-success {
+          color: var(--bq-text--success);
+        }
       }
-
-      & h4 {
-        font-size: var(--bq-font-size--xxl);
-      }
-
-      & .card--body {
-        display: flex;
-        flex-direction: column;
-        gap: var(--bq-spacing-xs2);
-      }
-
-      & .body__top {
-        display: flex;
-        align-items: center;
-        gap: var(--bq-spacing-xs2);
-      }
-
-      & .body__bottom {
-        display: flex;
-        align-items: flex-end;
-        gap: var(--bq-spacing-xs);
-      }
-
-      & .text-secondary {
-        color: var(--bq-text--secondary);
-      }
-
-      & .text-success {
-        color: var(--bq-text--success);
-      }
-    }
-
     </style>
     ```
   </CodeGroup>
@@ -1126,51 +1123,50 @@ A compact horizontal card using `type="minimal"` that removes built-in padding, 
 
 
     <style>
-    .card--mini {
-      width: 100%;
-      max-width: 24rem;
+      .card--mini {
+        width: 100%;
+        max-width: 24rem;
 
-      &::part(wrapper) {
-        display: flex;
-        overflow: clip;
+        &::part(wrapper) {
+          display: flex;
+          overflow: clip;
+        }
+
+        & .content--start {
+          display: flex;
+          align-items: center;
+          padding: var(--bq-spacing-l);
+          background-color: var(--bq-background--brand);
+        }
+
+        & .content--end {
+          display: flex;
+          flex: 1;
+          align-items: center;
+          justify-content: space-between;
+          padding: var(--bq-card--paddingMinimal);
+        }
+
+        & .body {
+          display: flex;
+          flex-direction: column;
+          padding-left: 0.5rem;
+        }
+
+        & h6 {
+          font-size: var(--bq-font-size--m);
+          font-weight: var(--bq-font-weight--medium);
+        }
+
+        & p {
+          font-size: var(--bq-font-size--xs);
+          color: var(--bq-text--secondary);
+        }
+
+        & .decorator {
+          padding: var(--bq-card--paddingMinimal);
+        }
       }
-
-      & .content--start {
-        display: flex;
-        align-items: center;
-        padding: var(--bq-spacing-l);
-        background-color: var(--bq-background--brand);
-      }
-
-      & .content--end {
-        display: flex;
-        flex: 1;
-        align-items: center;
-        justify-content: space-between;
-        padding: var(--bq-card--paddingMinimal);
-      }
-
-      & .body {
-        display: flex;
-        flex-direction: column;
-        padding-left: 0.5rem;
-      }
-
-      & h6 {
-        font-size: var(--bq-font-size--m);
-        font-weight: var(--bq-font-weight--medium);
-      }
-
-      & p {
-        font-size: var(--bq-font-size--xs);
-        color: var(--bq-text--secondary);
-      }
-
-      & .decorator {
-        padding: var(--bq-card--paddingMinimal);
-      }
-    }
-
     </style>
     ```
   </CodeGroup>
@@ -1774,37 +1770,36 @@ When a card represents a link destination (for example, an article or product), 
 
 
     <style>
-    .card-link {
-      border-radius: var(--bq-radius--m);
-      text-decoration: none;
-      cursor: pointer;
+      .card-link {
+        border-radius: var(--bq-radius--m);
+        text-decoration: none;
+        cursor: pointer;
 
-      &:hover {
-        & .card--mini::part(wrapper) {
-          transform: translateY(-0.125rem);
-          box-shadow: var(--bq-box-shadow--m);
-        }
-      }
-
-      &:focus-visible {
-        outline-offset: 2px;
-        outline: 2px solid var(--bq-focus);
-      }
-
-      .card--mini {
-        width: 100%;
-        max-width: 24rem;
-
-        &::part(wrapper) {
-          display: flex;
-          overflow: clip;
-          transition: box-shadow 0.2s ease-in-out, transform 0.2s ease-in-out;
+        &:hover {
+          & .card--mini::part(wrapper) {
+            transform: translateY(-0.125rem);
+            box-shadow: var(--bq-box-shadow--m);
+          }
         }
 
-        /** Same as the [Mini card example](#mini-card) */
-      }
-    }
+        &:focus-visible {
+          outline-offset: 2px;
+          outline: 2px solid var(--bq-focus);
+        }
 
+        .card--mini {
+          width: 100%;
+          max-width: 24rem;
+
+          &::part(wrapper) {
+            display: flex;
+            overflow: clip;
+            transition: box-shadow 0.2s ease-in-out, transform 0.2s ease-in-out;
+          }
+
+          /** Same as the [Mini card example](#mini-card) */
+        }
+      }
     </style>
     ```
   </CodeGroup>

--- a/apps/beeq-docs/components/card.mdx
+++ b/apps/beeq-docs/components/card.mdx
@@ -236,19 +236,19 @@ A card with icon, title, description, and a call-to-action — use when users ne
       imports: [BqCard, BqIcon, BqButton],
       template: `
         <bq-card class="card--default">
-                <div class="header">
-                  <bq-icon color="text--brand" size="56" name="star-bold"></bq-icon>
-                </div>
-                <div class="body">
-                  <h6>Designing with Intelligence: The AI-Driven Future</h6>
-                  <p>
-                    Uncover the synergy between design and artificial intelligence, where smart algorithms enhance user interfaces. Discover how AI-driven insights, automation, and personalization...
-                  </p>
-                </div>
-                <div class="footer">
-                  <bq-button appearance="link">Read more...</bq-button>
-                </div>
-              </bq-card>
+          <div class="header">
+            <bq-icon color="text--brand" size="56" name="star-bold"></bq-icon>
+          </div>
+          <div class="body">
+            <h6>Designing with Intelligence: The AI-Driven Future</h6>
+            <p>
+              Uncover the synergy between design and artificial intelligence, where smart algorithms enhance user interfaces. Discover how AI-driven insights, automation, and personalization...
+            </p>
+          </div>
+          <div class="footer">
+            <bq-button appearance="link">Read more...</bq-button>
+          </div>
+        </bq-card>
       `,
     })
     export class AppComponent {}
@@ -422,27 +422,27 @@ Use a card list when you have a collection of items that share the same structur
       standalone: true,
       imports: [BqCard, BqIcon],
       template: `
-            <bq-card class="card--highlights">
-              <h6>Title</h6>
-              <section>
-                <div class="item">
-                  <bq-icon name="star-bold"></bq-icon>
-                  Lorem Ipsum is simply dummy text
-                </div>
-                <div class="item">
-                  <bq-icon name="star-bold"></bq-icon>
-                  Lorem Ipsum is simply dummy text
-                </div>
-                <div class="item">
-                  <bq-icon name="star-bold"></bq-icon>
-                  Lorem Ipsum is simply dummy text
-                </div>
-                <div class="item">
-                  <bq-icon name="star-bold"></bq-icon>
-                  Lorem Ipsum is simply dummy text
-                </div>
-              </section>
-            </bq-card>
+        <bq-card class="card--highlights">
+          <h6>Title</h6>
+          <section>
+            <div class="item">
+              <bq-icon name="star-bold"></bq-icon>
+              Lorem Ipsum is simply dummy text
+            </div>
+            <div class="item">
+              <bq-icon name="star-bold"></bq-icon>
+              Lorem Ipsum is simply dummy text
+            </div>
+            <div class="item">
+              <bq-icon name="star-bold"></bq-icon>
+              Lorem Ipsum is simply dummy text
+            </div>
+            <div class="item">
+              <bq-icon name="star-bold"></bq-icon>
+              Lorem Ipsum is simply dummy text
+            </div>
+          </section>
+        </bq-card>
       `,
     })
     export class AppComponent {}
@@ -634,22 +634,22 @@ A KPI card combining an icon, headline value, and trend indicator — ideal for 
       standalone: true,
       imports: [BqCard, BqIcon],
       template: `
-            <bq-card class="card--overview">
-              <div class="card-thumbnail">
-                <bq-icon color="text--brand" size="56" name="star-bold"></bq-icon>
-              </div>
-              <div class="card--body">
-                <div class="body__top">
-                  <span class="text-secondary">Title</span>
-                  <bq-icon color="text--brand" size="16" name="star-bold"></bq-icon>
-                </div>
-                <div class="body__bottom">
-                  <h4>194</h4>
-                  <span class="text-success">+24%</span>
-                  <span class="text-secondary">than last mo.</span>
-                </div>
-              </div>
-            </bq-card>
+        <bq-card class="card--overview">
+          <div class="card-thumbnail">
+            <bq-icon color="text--brand" size="56" name="star-bold"></bq-icon>
+          </div>
+          <div class="card--body">
+            <div class="body__top">
+              <span class="text-secondary">Title</span>
+              <bq-icon color="text--brand" size="16" name="star-bold"></bq-icon>
+            </div>
+            <div class="body__bottom">
+              <h4>194</h4>
+              <span class="text-success">+24%</span>
+              <span class="text-secondary">than last mo.</span>
+            </div>
+          </div>
+        </bq-card>
       `,
     })
     export class AppComponent {}
@@ -840,20 +840,20 @@ A compact horizontal card using `type="minimal"` that removes built-in padding, 
       standalone: true,
       imports: [BqCard, BqIcon],
       template: `
-            <bq-card type="minimal" class="card--mini">
-              <div class="content--start">
-                <bq-icon color="text--alt" name="graduation-cap-bold"></bq-icon>
-              </div>
-              <div class="content--end">
-                <div class="body">
-                  <h6>Disciplines</h6>
-                  <p>Explore the extensive range of disciplines available at our university.</p>
-                </div>
-                <div class="decorator">
-                  <bq-icon color="text--brand" name="arrow-square-out"></bq-icon>
-                </div>
-              </div>
-            </bq-card>
+        <bq-card type="minimal" class="card--mini">
+          <div class="content--start">
+            <bq-icon color="text--alt" name="graduation-cap-bold"></bq-icon>
+          </div>
+          <div class="content--end">
+            <div class="body">
+              <h6>Disciplines</h6>
+              <p>Explore the extensive range of disciplines available at our university.</p>
+            </div>
+            <div class="decorator">
+              <bq-icon color="text--brand" name="arrow-square-out"></bq-icon>
+            </div>
+          </div>
+        </bq-card>
       `,
     })
     export class AppComponent {}
@@ -949,14 +949,14 @@ A compact horizontal card using `type="minimal"` that removes built-in padding, 
       standalone: true,
       imports: [BqCard],
       template: `
-            <div class="type-grid">
-              <bq-card type="default">
-                <p>Default — built-in padding applied automatically</p>
-              </bq-card>
-              <bq-card type="minimal">
-                <p>Minimal — no padding, you control the spacing</p>
-              </bq-card>
-            </div>
+        <div class="type-grid">
+          <bq-card type="default">
+            <p>Default — built-in padding applied automatically</p>
+          </bq-card>
+          <bq-card type="minimal">
+            <p>Minimal — no padding, you control the spacing</p>
+          </bq-card>
+        </div>
       `,
     })
     export class AppComponent {}
@@ -1091,27 +1091,27 @@ Use the `border` property to control the card corner radius.
       standalone: true,
       imports: [BqCard],
       template: `
-            <bq-card border="none">
-              <span>border="none"</span>
-            </bq-card>
-            <bq-card border="xs2">
-              <span>border="xs2"</span>
-            </bq-card>
-            <bq-card border="xs">
-              <span>border="xs"</span>
-            </bq-card>
-            <bq-card border="s">
-              <span>border="s"</span>
-            </bq-card>
-            <bq-card border="m">
-              <span>border="m"</span>
-            </bq-card>
-            <bq-card border="l">
-              <span>border="l"</span>
-            </bq-card>
-            <bq-card border="full">
-              <span>border="full"</span>
-            </bq-card>
+        <bq-card border="none">
+          <span>border="none"</span>
+        </bq-card>
+        <bq-card border="xs2">
+          <span>border="xs2"</span>
+        </bq-card>
+        <bq-card border="xs">
+          <span>border="xs"</span>
+        </bq-card>
+        <bq-card border="s">
+          <span>border="s"</span>
+        </bq-card>
+        <bq-card border="m">
+          <span>border="m"</span>
+        </bq-card>
+        <bq-card border="l">
+          <span>border="l"</span>
+        </bq-card>
+        <bq-card border="full">
+          <span>border="full"</span>
+        </bq-card>
       `,
     })
     export class AppComponent {}
@@ -1398,22 +1398,22 @@ When a card represents a link destination (for example, an article or product), 
       standalone: true,
       imports: [BqCard, BqIcon],
       template: `
-            <a href="https://example.com/article" class="card-link">
-              <bq-card type="minimal" class="card--mini">
-                <div class="content--start">
-                  <bq-icon color="text--alt" name="graduation-cap-bold"></bq-icon>
-                </div>
-                <div class="content--end">
-                  <div class="body">
-                    <h6>Disciplines</h6>
-                    <p>Explore the extensive range of disciplines available at our university.</p>
-                  </div>
-                  <div class="decorator">
-                    <bq-icon color="text--brand" name="arrow-square-out"></bq-icon>
-                  </div>
-                </div>
-              </bq-card>
-            </a>
+        <a href="https://example.com/article" class="card-link">
+          <bq-card type="minimal" class="card--mini">
+            <div class="content--start">
+              <bq-icon color="text--alt" name="graduation-cap-bold"></bq-icon>
+            </div>
+            <div class="content--end">
+              <div class="body">
+                <h6>Disciplines</h6>
+                <p>Explore the extensive range of disciplines available at our university.</p>
+              </div>
+              <div class="decorator">
+                <bq-icon color="text--brand" name="arrow-square-out"></bq-icon>
+              </div>
+            </div>
+          </bq-card>
+        </a>
       `,
     })
     export class AppComponent {}

--- a/apps/beeq-docs/components/card.mdx
+++ b/apps/beeq-docs/components/card.mdx
@@ -65,6 +65,11 @@ The Card pattern can support multiple presentation styles depending on the conte
 
 Cards are flexible containers, so their anatomy can vary depending on the content. In most cases, a card includes a container, an optional visual element, a content area, and optional supporting actions.
 
+<Frame className="px-4 py-4" caption="Card component anatomy">
+  <img className="block dark:hidden" src="/components/images/card/card-overview-light.svg" alt="BEEQ Card component anatomy" />
+  <img className="hidden dark:block" src="/components/images/card/card-overview-dark.svg" alt="BEEQ Card component anatomy" />
+</Frame>
+
 | Part | Element | Description |
 |---|---|---|
 | **1** | Container | The outer surface that groups the content into a single, scannable unit |
@@ -222,23 +227,31 @@ A card with icon, title, description, and a call-to-action — use when users ne
     </BqCard>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqButton, BqCard, BqIcon } from "@beeq/angular/standalone" -->
-
-    <bq-card class="card--default">
-        <div class="header">
-          <bq-icon color="text--brand" size="56" name="star-bold"></bq-icon>
-        </div>
-        <div class="body">
-          <h6>Designing with Intelligence: The AI-Driven Future</h6>
-          <p>
-            Uncover the synergy between design and artificial intelligence, where smart algorithms enhance user interfaces. Discover how AI-driven insights, automation, and personalization...
-          </p>
-        </div>
-        <div class="footer">
-          <bq-button appearance="link">Read more...</bq-button>
-        </div>
-      </bq-card>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqCard, BqIcon, BqButton } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqCard, BqIcon, BqButton],
+      template: `
+        <bq-card class="card--default">
+                <div class="header">
+                  <bq-icon color="text--brand" size="56" name="star-bold"></bq-icon>
+                </div>
+                <div class="body">
+                  <h6>Designing with Intelligence: The AI-Driven Future</h6>
+                  <p>
+                    Uncover the synergy between design and artificial intelligence, where smart algorithms enhance user interfaces. Discover how AI-driven insights, automation, and personalization...
+                  </p>
+                </div>
+                <div class="footer">
+                  <bq-button appearance="link">Read more...</bq-button>
+                </div>
+              </bq-card>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -401,28 +414,38 @@ Use a card list when you have a collection of items that share the same structur
     </BqCard>
     ```
 
-    ```html Angular icon="angular"
-    <bq-card class="card--highlights">
-      <h6>Title</h6>
-      <section>
-        <div class="item">
-          <bq-icon name="star-bold"></bq-icon>
-          Lorem Ipsum is simply dummy text
-        </div>
-        <div class="item">
-          <bq-icon name="star-bold"></bq-icon>
-          Lorem Ipsum is simply dummy text
-        </div>
-        <div class="item">
-          <bq-icon name="star-bold"></bq-icon>
-          Lorem Ipsum is simply dummy text
-        </div>
-        <div class="item">
-          <bq-icon name="star-bold"></bq-icon>
-          Lorem Ipsum is simply dummy text
-        </div>
-      </section>
-    </bq-card>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqCard, BqIcon } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqCard, BqIcon],
+      template: `
+            <bq-card class="card--highlights">
+              <h6>Title</h6>
+              <section>
+                <div class="item">
+                  <bq-icon name="star-bold"></bq-icon>
+                  Lorem Ipsum is simply dummy text
+                </div>
+                <div class="item">
+                  <bq-icon name="star-bold"></bq-icon>
+                  Lorem Ipsum is simply dummy text
+                </div>
+                <div class="item">
+                  <bq-icon name="star-bold"></bq-icon>
+                  Lorem Ipsum is simply dummy text
+                </div>
+                <div class="item">
+                  <bq-icon name="star-bold"></bq-icon>
+                  Lorem Ipsum is simply dummy text
+                </div>
+              </section>
+            </bq-card>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -603,23 +626,33 @@ A KPI card combining an icon, headline value, and trend indicator — ideal for 
     </BqCard>
     ```
 
-    ```html Angular icon="angular"
-    <bq-card class="card--overview">
-      <div class="card-thumbnail">
-        <bq-icon color="text--brand" size="56" name="star-bold"></bq-icon>
-      </div>
-      <div class="card--body">
-        <div class="body__top">
-          <span class="text-secondary">Title</span>
-          <bq-icon color="text--brand" size="16" name="star-bold"></bq-icon>
-        </div>
-        <div class="body__bottom">
-          <h4>194</h4>
-          <span class="text-success">+24%</span>
-          <span class="text-secondary">than last mo.</span>
-        </div>
-      </div>
-    </bq-card>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqCard, BqIcon } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqCard, BqIcon],
+      template: `
+            <bq-card class="card--overview">
+              <div class="card-thumbnail">
+                <bq-icon color="text--brand" size="56" name="star-bold"></bq-icon>
+              </div>
+              <div class="card--body">
+                <div class="body__top">
+                  <span class="text-secondary">Title</span>
+                  <bq-icon color="text--brand" size="16" name="star-bold"></bq-icon>
+                </div>
+                <div class="body__bottom">
+                  <h4>194</h4>
+                  <span class="text-success">+24%</span>
+                  <span class="text-secondary">than last mo.</span>
+                </div>
+              </div>
+            </bq-card>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -799,21 +832,31 @@ A compact horizontal card using `type="minimal"` that removes built-in padding, 
     </BqCard>
     ```
 
-    ```html Angular icon="angular"
-    <bq-card type="minimal" class="card--mini">
-      <div class="content--start">
-        <bq-icon color="text--alt" name="graduation-cap-bold"></bq-icon>
-      </div>
-      <div class="content--end">
-        <div class="body">
-          <h6>Disciplines</h6>
-          <p>Explore the extensive range of disciplines available at our university.</p>
-        </div>
-        <div class="decorator">
-          <bq-icon color="text--brand" name="arrow-square-out"></bq-icon>
-        </div>
-      </div>
-    </bq-card>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqCard, BqIcon } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqCard, BqIcon],
+      template: `
+            <bq-card type="minimal" class="card--mini">
+              <div class="content--start">
+                <bq-icon color="text--alt" name="graduation-cap-bold"></bq-icon>
+              </div>
+              <div class="content--end">
+                <div class="body">
+                  <h6>Disciplines</h6>
+                  <p>Explore the extensive range of disciplines available at our university.</p>
+                </div>
+                <div class="decorator">
+                  <bq-icon color="text--brand" name="arrow-square-out"></bq-icon>
+                </div>
+              </div>
+            </bq-card>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -898,15 +941,25 @@ A compact horizontal card using `type="minimal"` that removes built-in padding, 
     </div>
     ```
 
-    ```html Angular icon="angular"
-    <div class="type-grid">
-      <bq-card type="default">
-        <p>Default — built-in padding applied automatically</p>
-      </bq-card>
-      <bq-card type="minimal">
-        <p>Minimal — no padding, you control the spacing</p>
-      </bq-card>
-    </div>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqCard } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqCard],
+      template: `
+            <div class="type-grid">
+              <bq-card type="default">
+                <p>Default — built-in padding applied automatically</p>
+              </bq-card>
+              <bq-card type="minimal">
+                <p>Minimal — no padding, you control the spacing</p>
+              </bq-card>
+            </div>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -1030,28 +1083,38 @@ Use the `border` property to control the card corner radius.
     </BqCard>
     ```
 
-    ```html Angular icon="angular"
-    <bq-card border="none">
-      <span>border="none"</span>
-    </bq-card>
-    <bq-card border="xs2">
-      <span>border="xs2"</span>
-    </bq-card>
-    <bq-card border="xs">
-      <span>border="xs"</span>
-    </bq-card>
-    <bq-card border="s">
-      <span>border="s"</span>
-    </bq-card>
-    <bq-card border="m">
-      <span>border="m"</span>
-    </bq-card>
-    <bq-card border="l">
-      <span>border="l"</span>
-    </bq-card>
-    <bq-card border="full">
-      <span>border="full"</span>
-    </bq-card>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqCard } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqCard],
+      template: `
+            <bq-card border="none">
+              <span>border="none"</span>
+            </bq-card>
+            <bq-card border="xs2">
+              <span>border="xs2"</span>
+            </bq-card>
+            <bq-card border="xs">
+              <span>border="xs"</span>
+            </bq-card>
+            <bq-card border="s">
+              <span>border="s"</span>
+            </bq-card>
+            <bq-card border="m">
+              <span>border="m"</span>
+            </bq-card>
+            <bq-card border="l">
+              <span>border="l"</span>
+            </bq-card>
+            <bq-card border="full">
+              <span>border="full"</span>
+            </bq-card>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -1327,23 +1390,33 @@ When a card represents a link destination (for example, an article or product), 
     </a>
     ```
 
-    ```html Angular icon="angular"
-    <a href="https://example.com/article" class="card-link">
-      <bq-card type="minimal" class="card--mini">
-        <div class="content--start">
-          <bq-icon color="text--alt" name="graduation-cap-bold"></bq-icon>
-        </div>
-        <div class="content--end">
-          <div class="body">
-            <h6>Disciplines</h6>
-            <p>Explore the extensive range of disciplines available at our university.</p>
-          </div>
-          <div class="decorator">
-            <bq-icon color="text--brand" name="arrow-square-out"></bq-icon>
-          </div>
-        </div>
-      </bq-card>
-    </a>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqCard, BqIcon } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqCard, BqIcon],
+      template: `
+            <a href="https://example.com/article" class="card-link">
+              <bq-card type="minimal" class="card--mini">
+                <div class="content--start">
+                  <bq-icon color="text--alt" name="graduation-cap-bold"></bq-icon>
+                </div>
+                <div class="content--end">
+                  <div class="body">
+                    <h6>Disciplines</h6>
+                    <p>Explore the extensive range of disciplines available at our university.</p>
+                  </div>
+                  <div class="decorator">
+                    <bq-icon color="text--brand" name="arrow-square-out"></bq-icon>
+                  </div>
+                </div>
+              </bq-card>
+            </a>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/card.mdx
+++ b/apps/beeq-docs/components/card.mdx
@@ -169,7 +169,7 @@ A card with icon, title, description, and a call-to-action — use when users ne
   </bq-card>
 `}>
   <CodeGroup>
-    ```css CSS icon="css"
+    ```css styles.css icon="css" expandable
     .card--default {
       max-width: 24rem;
       width: 100%;
@@ -191,7 +191,7 @@ A card with icon, title, description, and a call-to-action — use when users ne
     }
     ```
 
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-card class="card--default">
       <div class="header">
         <bq-icon color="text--brand" size="56" name="star-bold"></bq-icon>
@@ -208,8 +208,9 @@ A card with icon, title, description, and a call-to-action — use when users ne
     </bq-card>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqButton, BqCard, BqIcon } from "@beeq/react";
+    import "./styles.css";
 
     <BqCard className="card--default">
       <div className="header">
@@ -227,7 +228,7 @@ A card with icon, title, description, and a call-to-action — use when users ne
     </BqCard>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqCard, BqIcon, BqButton } from "@beeq/angular/standalone";
     @Component({
@@ -250,11 +251,32 @@ A card with icon, title, description, and a call-to-action — use when users ne
           </div>
         </bq-card>
       `,
+      style: `
+        .card--default {
+          max-width: 24rem;
+          width: 100%;
+
+          &::part(wrapper) {
+            display: flex;
+            flex-direction: column;
+            gap: var(--bq-spacing-m);
+          }
+
+          h6 {
+            font-size: var(--bq-font-size--m);
+            font-weight: var(--bq-font-weight--bold);
+          }
+
+          p {
+            margin-block-start: var(--bq-spacing-m);
+          }
+        }
+      `,
     })
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqButton, BqCard, BqIcon } from "@beeq/vue";
     </script>
@@ -275,6 +297,30 @@ A card with icon, title, description, and a call-to-action — use when users ne
         </div>
       </BqCard>
     </template>
+
+
+    <style>
+    .card--default {
+      max-width: 24rem;
+      width: 100%;
+
+      &::part(wrapper) {
+        display: flex;
+        flex-direction: column;
+        gap: var(--bq-spacing-m);
+      }
+
+      h6 {
+        font-size: var(--bq-font-size--m);
+        font-weight: var(--bq-font-weight--bold);
+      }
+
+      p {
+        margin-block-start: var(--bq-spacing-m);
+      }
+    }
+
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -335,7 +381,7 @@ Use a card list when you have a collection of items that share the same structur
   </bq-card>
 `}>
   <CodeGroup>
-    ```css CSS icon="css"
+    ```css styles.css icon="css" expandable
     .card--highlights {
       width: 100%;
       max-width: 24rem;
@@ -364,7 +410,7 @@ Use a card list when you have a collection of items that share the same structur
     }
     ```
 
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-card class="card--highlights">
       <h6>Title</h6>
       <section>
@@ -388,8 +434,9 @@ Use a card list when you have a collection of items that share the same structur
     </bq-card>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqCard, BqIcon } from "@beeq/react";
+    import "./styles.css";
 
     <BqCard className="card--highlights">
       <h6>Title</h6>
@@ -414,7 +461,7 @@ Use a card list when you have a collection of items that share the same structur
     </BqCard>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqCard, BqIcon } from "@beeq/angular/standalone";
     @Component({
@@ -444,11 +491,39 @@ Use a card list when you have a collection of items that share the same structur
           </section>
         </bq-card>
       `,
+      style: `
+        .card--highlights {
+          width: 100%;
+          max-width: 24rem;
+
+          &::part(wrapper) {
+            display: flex;
+            flex-direction: column;
+            gap: var(--bq-spacing-m);
+          }
+
+          & h6 {
+            font-size: var(--bq-font-size--l);
+            font-weight: var(--bq-font-weight--bold);
+          }
+
+          & section {
+            display: flex;
+            flex-direction: column;
+            gap: var(--bq-spacing-s);
+
+            & .item {
+              display: flex;
+              gap: var(--bq-spacing-s);
+            }
+          }
+        }
+      `,
     })
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqCard, BqIcon } from "@beeq/vue";
     </script>
@@ -476,6 +551,37 @@ Use a card list when you have a collection of items that share the same structur
         </section>
       </BqCard>
     </template>
+
+
+    <style>
+    .card--highlights {
+      width: 100%;
+      max-width: 24rem;
+
+      &::part(wrapper) {
+        display: flex;
+        flex-direction: column;
+        gap: var(--bq-spacing-m);
+      }
+
+      & h6 {
+        font-size: var(--bq-font-size--l);
+        font-weight: var(--bq-font-weight--bold);
+      }
+
+      & section {
+        display: flex;
+        flex-direction: column;
+        gap: var(--bq-spacing-s);
+
+        & .item {
+          display: flex;
+          gap: var(--bq-spacing-s);
+        }
+      }
+    }
+
+    </style>
     ```
 </CodeGroup>
 </CodeLivePreview>
@@ -544,7 +650,7 @@ A KPI card combining an icon, headline value, and trend indicator — ideal for 
   </bq-card>
 `}>
   <CodeGroup>
-    ```css CSS icon="css" expandable
+    ```css styles.css icon="css" expandable
     .card--overview {
       width: 100%;
       max-width: 24rem;
@@ -586,7 +692,7 @@ A KPI card combining an icon, headline value, and trend indicator — ideal for 
     }
     ```
 
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-card class="card--overview">
       <div class="card-thumbnail">
         <bq-icon color="text--brand" size="56" name="star-bold"></bq-icon>
@@ -605,8 +711,9 @@ A KPI card combining an icon, headline value, and trend indicator — ideal for 
     </bq-card>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqCard, BqIcon } from "@beeq/react";
+    import "./styles.css";
 
     <BqCard className="card--overview">
       <div className="card-thumbnail">
@@ -626,7 +733,7 @@ A KPI card combining an icon, headline value, and trend indicator — ideal for 
     </BqCard>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqCard, BqIcon } from "@beeq/angular/standalone";
     @Component({
@@ -651,11 +758,52 @@ A KPI card combining an icon, headline value, and trend indicator — ideal for 
           </div>
         </bq-card>
       `,
+      style: `
+        .card--overview {
+          width: 100%;
+          max-width: 24rem;
+
+          &::part(wrapper) {
+            display: flex;
+            gap: var(--bq-spacing-m);
+          }
+
+          & h4 {
+            font-size: var(--bq-font-size--xxl);
+          }
+
+          & .card--body {
+            display: flex;
+            flex-direction: column;
+            gap: var(--bq-spacing-xs2);
+          }
+
+          & .body__top {
+            display: flex;
+            align-items: center;
+            gap: var(--bq-spacing-xs2);
+          }
+
+          & .body__bottom {
+            display: flex;
+            align-items: flex-end;
+            gap: var(--bq-spacing-xs);
+          }
+
+          & .text-secondary {
+            color: var(--bq-text--secondary);
+          }
+
+          & .text-success {
+            color: var(--bq-text--success);
+          }
+        }
+      `,
     })
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqCard, BqIcon } from "@beeq/vue";
     </script>
@@ -678,6 +826,50 @@ A KPI card combining an icon, headline value, and trend indicator — ideal for 
         </div>
       </BqCard>
     </template>
+
+
+    <style>
+    .card--overview {
+      width: 100%;
+      max-width: 24rem;
+
+      &::part(wrapper) {
+        display: flex;
+        gap: var(--bq-spacing-m);
+      }
+
+      & h4 {
+        font-size: var(--bq-font-size--xxl);
+      }
+
+      & .card--body {
+        display: flex;
+        flex-direction: column;
+        gap: var(--bq-spacing-xs2);
+      }
+
+      & .body__top {
+        display: flex;
+        align-items: center;
+        gap: var(--bq-spacing-xs2);
+      }
+
+      & .body__bottom {
+        display: flex;
+        align-items: flex-end;
+        gap: var(--bq-spacing-xs);
+      }
+
+      & .text-secondary {
+        color: var(--bq-text--secondary);
+      }
+
+      & .text-success {
+        color: var(--bq-text--success);
+      }
+    }
+
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -749,7 +941,7 @@ A compact horizontal card using `type="minimal"` that removes built-in padding, 
   </bq-card>
 `}>
   <CodeGroup>
-    ```css CSS icon="css" expandable
+    ```css styles.css icon="css" expandable
     .card--mini {
       width: 100%;
       max-width: 24rem;
@@ -796,7 +988,7 @@ A compact horizontal card using `type="minimal"` that removes built-in padding, 
     }
     ```
 
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-card type="minimal" class="card--mini">
       <div class="content--start">
         <bq-icon color="text--alt" name="graduation-cap-bold"></bq-icon>
@@ -813,8 +1005,9 @@ A compact horizontal card using `type="minimal"` that removes built-in padding, 
     </bq-card>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqCard, BqIcon } from "@beeq/react";
+    import "./styles.css";
 
     <BqCard type="minimal" className="card--mini">
       <div className="content--start">
@@ -832,7 +1025,7 @@ A compact horizontal card using `type="minimal"` that removes built-in padding, 
     </BqCard>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqCard, BqIcon } from "@beeq/angular/standalone";
     @Component({
@@ -855,11 +1048,57 @@ A compact horizontal card using `type="minimal"` that removes built-in padding, 
           </div>
         </bq-card>
       `,
+      style: `
+        .card--mini {
+          width: 100%;
+          max-width: 24rem;
+
+          &::part(wrapper) {
+            display: flex;
+            overflow: clip;
+          }
+
+          & .content--start {
+            display: flex;
+            align-items: center;
+            padding: var(--bq-spacing-l);
+            background-color: var(--bq-background--brand);
+          }
+
+          & .content--end {
+            display: flex;
+            flex: 1;
+            align-items: center;
+            justify-content: space-between;
+            padding: var(--bq-card--paddingMinimal);
+          }
+
+          & .body {
+            display: flex;
+            flex-direction: column;
+            padding-left: 0.5rem;
+          }
+
+          & h6 {
+            font-size: var(--bq-font-size--m);
+            font-weight: var(--bq-font-weight--medium);
+          }
+
+          & p {
+            font-size: var(--bq-font-size--xs);
+            color: var(--bq-text--secondary);
+          }
+
+          & .decorator {
+            padding: var(--bq-card--paddingMinimal);
+          }
+        }
+      `,
     })
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqCard, BqIcon } from "@beeq/vue";
     </script>
@@ -880,6 +1119,55 @@ A compact horizontal card using `type="minimal"` that removes built-in padding, 
         </div>
       </BqCard>
     </template>
+
+
+    <style>
+    .card--mini {
+      width: 100%;
+      max-width: 24rem;
+
+      &::part(wrapper) {
+        display: flex;
+        overflow: clip;
+      }
+
+      & .content--start {
+        display: flex;
+        align-items: center;
+        padding: var(--bq-spacing-l);
+        background-color: var(--bq-background--brand);
+      }
+
+      & .content--end {
+        display: flex;
+        flex: 1;
+        align-items: center;
+        justify-content: space-between;
+        padding: var(--bq-card--paddingMinimal);
+      }
+
+      & .body {
+        display: flex;
+        flex-direction: column;
+        padding-left: 0.5rem;
+      }
+
+      & h6 {
+        font-size: var(--bq-font-size--m);
+        font-weight: var(--bq-font-weight--medium);
+      }
+
+      & p {
+        font-size: var(--bq-font-size--xs);
+        color: var(--bq-text--secondary);
+      }
+
+      & .decorator {
+        padding: var(--bq-card--paddingMinimal);
+      }
+    }
+
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -917,7 +1205,7 @@ A compact horizontal card using `type="minimal"` that removes built-in padding, 
   </div>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <div class="type-grid">
       <bq-card type="default">
         <p>Default — built-in padding applied automatically</p>
@@ -928,7 +1216,7 @@ A compact horizontal card using `type="minimal"` that removes built-in padding, 
     </div>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqCard } from "@beeq/react";
 
     <div className="type-grid">
@@ -941,7 +1229,7 @@ A compact horizontal card using `type="minimal"` that removes built-in padding, 
     </div>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqCard } from "@beeq/angular/standalone";
     @Component({
@@ -962,7 +1250,7 @@ A compact horizontal card using `type="minimal"` that removes built-in padding, 
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqCard } from "@beeq/vue";
     </script>
@@ -1033,7 +1321,7 @@ Use the `border` property to control the card corner radius.
   </div>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-card border="none">
       <span>border="none"</span>
     </bq-card>
@@ -1057,7 +1345,7 @@ Use the `border` property to control the card corner radius.
     </bq-card>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqCard } from "@beeq/react";
 
     <BqCard border="none">
@@ -1083,7 +1371,7 @@ Use the `border` property to control the card corner radius.
     </BqCard>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqCard } from "@beeq/angular/standalone";
     @Component({
@@ -1117,7 +1405,7 @@ Use the `border` property to control the card corner radius.
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqCard } from "@beeq/vue";
     </script>
@@ -1317,7 +1605,7 @@ When a card represents a link destination (for example, an article or product), 
   </a>
 `}>
   <CodeGroup>
-    ```css CSS icon="css" expandable
+    ```css styles.css icon="css" expandable
     .card-link {
       border-radius: var(--bq-radius--m);
       text-decoration: none;
@@ -1350,7 +1638,7 @@ When a card represents a link destination (for example, an article or product), 
     }
     ```
 
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <a href="https://example.com/article" class="card-link">
       <bq-card type="minimal" class="card--mini">
         <div class="content--start">
@@ -1369,8 +1657,9 @@ When a card represents a link destination (for example, an article or product), 
     </a>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqCard, BqIcon } from "@beeq/react";
+    import "./styles.css";
 
     <a href="https://example.com/article" className="card-link">
       <BqCard type="minimal" className="card--mini">
@@ -1390,7 +1679,7 @@ When a card represents a link destination (for example, an article or product), 
     </a>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqCard, BqIcon } from "@beeq/angular/standalone";
     @Component({
@@ -1415,11 +1704,43 @@ When a card represents a link destination (for example, an article or product), 
           </bq-card>
         </a>
       `,
+      style: `
+        .card-link {
+          border-radius: var(--bq-radius--m);
+          text-decoration: none;
+          cursor: pointer;
+
+          &:hover {
+            & .card--mini::part(wrapper) {
+              transform: translateY(-0.125rem);
+              box-shadow: var(--bq-box-shadow--m);
+            }
+          }
+
+          &:focus-visible {
+            outline-offset: 2px;
+            outline: 2px solid var(--bq-focus);
+          }
+
+          .card--mini {
+            width: 100%;
+            max-width: 24rem;
+
+            &::part(wrapper) {
+              display: flex;
+              overflow: clip;
+              transition: box-shadow 0.2s ease-in-out, transform 0.2s ease-in-out;
+            }
+
+            /** Same as the [Mini card example](#mini-card) */
+          }
+        }
+      `,
     })
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqCard, BqIcon } from "@beeq/vue";
     </script>
@@ -1442,6 +1763,41 @@ When a card represents a link destination (for example, an article or product), 
         </BqCard>
       </a>
     </template>
+
+
+    <style>
+    .card-link {
+      border-radius: var(--bq-radius--m);
+      text-decoration: none;
+      cursor: pointer;
+
+      &:hover {
+        & .card--mini::part(wrapper) {
+          transform: translateY(-0.125rem);
+          box-shadow: var(--bq-box-shadow--m);
+        }
+      }
+
+      &:focus-visible {
+        outline-offset: 2px;
+        outline: 2px solid var(--bq-focus);
+      }
+
+      .card--mini {
+        width: 100%;
+        max-width: 24rem;
+
+        &::part(wrapper) {
+          display: flex;
+          overflow: clip;
+          transition: box-shadow 0.2s ease-in-out, transform 0.2s ease-in-out;
+        }
+
+        /** Same as the [Mini card example](#mini-card) */
+      }
+    }
+
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>

--- a/apps/beeq-docs/components/card.mdx
+++ b/apps/beeq-docs/components/card.mdx
@@ -169,7 +169,7 @@ A card with icon, title, description, and a call-to-action — use when users ne
   </bq-card>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     .card--default {
       max-width: 24rem;
       width: 100%;
@@ -252,7 +252,7 @@ A card with icon, title, description, and a call-to-action — use when users ne
           </div>
         </bq-card>
       `,
-      style: `
+      styles: [`
         .card--default {
           max-width: 24rem;
           width: 100%;
@@ -272,7 +272,7 @@ A card with icon, title, description, and a call-to-action — use when users ne
             margin-block-start: var(--bq-spacing-m);
           }
         }
-      `,
+      `],
     })
     export class AppComponent {}
     ```
@@ -382,7 +382,7 @@ Use a card list when you have a collection of items that share the same structur
   </bq-card>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     .card--highlights {
       width: 100%;
       max-width: 24rem;
@@ -493,7 +493,7 @@ Use a card list when you have a collection of items that share the same structur
           </section>
         </bq-card>
       `,
-      style: `
+      styles: [`
         .card--highlights {
           width: 100%;
           max-width: 24rem;
@@ -520,7 +520,7 @@ Use a card list when you have a collection of items that share the same structur
             }
           }
         }
-      `,
+      `],
     })
     export class AppComponent {}
     ```
@@ -652,7 +652,7 @@ A KPI card combining an icon, headline value, and trend indicator — ideal for 
   </bq-card>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     .card--overview {
       width: 100%;
       max-width: 24rem;
@@ -761,7 +761,7 @@ A KPI card combining an icon, headline value, and trend indicator — ideal for 
           </div>
         </bq-card>
       `,
-      style: `
+      styles: [`
         .card--overview {
           width: 100%;
           max-width: 24rem;
@@ -801,7 +801,7 @@ A KPI card combining an icon, headline value, and trend indicator — ideal for 
             color: var(--bq-text--success);
           }
         }
-      `,
+      `],
     })
     export class AppComponent {}
     ```
@@ -944,7 +944,7 @@ A compact horizontal card using `type="minimal"` that removes built-in padding, 
   </bq-card>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     .card--mini {
       width: 100%;
       max-width: 24rem;
@@ -1052,7 +1052,7 @@ A compact horizontal card using `type="minimal"` that removes built-in padding, 
           </div>
         </bq-card>
       `,
-      style: `
+      styles: [`
         .card--mini {
           width: 100%;
           max-width: 24rem;
@@ -1097,7 +1097,7 @@ A compact horizontal card using `type="minimal"` that removes built-in padding, 
             padding: var(--bq-card--paddingMinimal);
           }
         }
-      `,
+      `],
     })
     export class AppComponent {}
     ```
@@ -1352,6 +1352,7 @@ Use the `border` property to control the card corner radius.
 
     ```jsx React icon="react" expandable
     import { BqCard } from "@beeq/react";
+    import "./styles.css";
 
     <BqCard border="none">
       <span>border="none"</span>
@@ -1611,7 +1612,7 @@ When a card represents a link destination (for example, an article or product), 
   </a>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     .card-link {
       border-radius: var(--bq-radius--m);
       text-decoration: none;
@@ -1711,7 +1712,7 @@ When a card represents a link destination (for example, an article or product), 
           </bq-card>
         </a>
       `,
-      style: `
+      styles: [`
         .card-link {
           border-radius: var(--bq-radius--m);
           text-decoration: none;
@@ -1742,7 +1743,7 @@ When a card represents a link destination (for example, an article or product), 
             /** Same as the [Mini card example](#mini-card) */
           }
         }
-      `,
+      `],
     })
     export class AppComponent {}
     ```

--- a/apps/beeq-docs/components/checkbox.mdx
+++ b/apps/beeq-docs/components/checkbox.mdx
@@ -452,7 +452,7 @@ Use the indeterminate state when a parent checkbox controls a related set of chi
     ```js JavaScript icon="js" expandable
     const allCheckboxChange = (event) => {
       const interestCheckboxes = Array.from(
-        document.querySelectorAll('bq-checkbox[name="interest"]'),
+        previewRoot.querySelectorAll('bq-checkbox[name="interest"]'),
       );
 
       interestCheckboxes.forEach((interestCheckbox) => {
@@ -461,11 +461,11 @@ Use the indeterminate state when a parent checkbox controls a related set of chi
     };
 
     const interestCheckboxChange = () => {
-      const allInterestCheckbox = document.querySelector('bq-checkbox[name="all-interests"]');
+      const allInterestCheckbox = previewRoot.querySelector('bq-checkbox[name="all-interests"]');
       if (!allInterestCheckbox) return;
 
-      const interestCheckboxes = document.querySelectorAll('bq-checkbox[name="interest"]');
-      const onlyChecked = document.querySelectorAll(
+      const interestCheckboxes = previewRoot.querySelectorAll('bq-checkbox[name="interest"]');
+      const onlyChecked = previewRoot.querySelectorAll(
         'bq-checkbox[name="interest"][checked]',
       ).length;
 
@@ -474,9 +474,9 @@ Use the indeterminate state when a parent checkbox controls a related set of chi
       allInterestCheckbox.checked = onlyChecked === interestCheckboxes.length;
     };
 
-    const allInterestCheckbox = document.querySelector('bq-checkbox[name="all-interests"]');
+    const allInterestCheckbox = previewRoot.querySelector('bq-checkbox[name="all-interests"]');
     const interestCheckboxes = Array.from(
-      document.querySelectorAll('bq-checkbox[name="interest"]'),
+      previewRoot.querySelectorAll('bq-checkbox[name="interest"]'),
     );
 
     allInterestCheckbox?.addEventListener('bqChange', allCheckboxChange);

--- a/apps/beeq-docs/components/checkbox.mdx
+++ b/apps/beeq-docs/components/checkbox.mdx
@@ -148,6 +148,7 @@ Use the default checkbox for a straightforward binary choice with a short label.
     import { BqCheckbox } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqCheckbox],
       template: `
@@ -156,7 +157,7 @@ Use the default checkbox for a straightforward binary choice with a short label.
         </bq-checkbox>
       `
     })
-    export class DefaultCheckboxComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -212,6 +213,7 @@ Use a longer label when people need more context before deciding, but keep the c
     import { BqCheckbox } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqCheckbox],
       template: `
@@ -220,7 +222,7 @@ Use a longer label when people need more context before deciding, but keep the c
         </bq-checkbox>
       `
     })
-    export class LongLabelCheckboxComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -268,6 +270,7 @@ Use `background-on-hover` when the surrounding layout benefits from a larger per
     import { BqCheckbox } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqCheckbox],
       template: `
@@ -276,7 +279,7 @@ Use `background-on-hover` when the surrounding layout benefits from a larger per
         </bq-checkbox>
       `
     })
-    export class BackgroundOnHoverCheckboxComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -331,6 +334,7 @@ Use `checked` for a preselected default, and `disabled` when the option is curre
     import { BqCheckbox } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqCheckbox],
       template: `
@@ -342,7 +346,7 @@ Use `checked` for a preselected default, and `disabled` when the option is curre
         </bq-checkbox>
       `
     })
-    export class CheckedDisabledCheckboxComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -568,6 +572,7 @@ Use the indeterminate state when a parent checkbox controls a related set of chi
     import { BqCheckbox } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqCheckbox],
       template: `
@@ -615,7 +620,7 @@ Use the indeterminate state when a parent checkbox controls a related set of chi
         </div>
       `,
     })
-    export class IndeterminateCheckboxGroupComponent {
+    export class AppComponent {
       interests = { music: true, travel: false, sport: true };
 
       get allChecked() {

--- a/apps/beeq-docs/components/date-picker.mdx
+++ b/apps/beeq-docs/components/date-picker.mdx
@@ -1038,7 +1038,7 @@ Use `isDateDisallowed` to make specific dates unavailable for selection. This is
     ```
 
     ```js JavaScript icon="js"
-    const datePickerElem = document.querySelector('bq-date-picker[name="disallowed-dates"]');
+    const datePickerElem = previewRoot.querySelector('bq-date-picker[name="disallowed-dates"]');
     const disallowedDates = ['2026-12-01', '2026-12-25', '2026-12-26'];
 
     datePickerElem.isDateDisallowed = (date) => {
@@ -1168,7 +1168,7 @@ Use `formatOptions` when the selected date needs a more descriptive text format 
     ```
 
     ```js JavaScript icon="js"
-    const datePickerElem = document.querySelector('bq-date-picker[name="formatted-date"]');
+    const datePickerElem = previewRoot.querySelector('bq-date-picker[name="formatted-date"]');
 
     datePickerElem.formatOptions = {
       weekday: 'long',

--- a/apps/beeq-docs/components/date-picker.mdx
+++ b/apps/beeq-docs/components/date-picker.mdx
@@ -136,6 +136,7 @@ Use the default `single` type when users need to choose one date. This is the be
     import { BqDatePicker } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqDatePicker],
       template: `
@@ -144,7 +145,7 @@ Use the default `single` type when users need to choose one date. This is the be
         </bq-date-picker>
       `
     })
-    export class DefaultDatePickerComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -209,6 +210,7 @@ Use `type="range"` when users need a start and end date. Set `months="2"` so bot
     import { BqDatePicker } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqDatePicker],
       template: `
@@ -222,7 +224,7 @@ Use `type="range"` when users need a start and end date. Set `months="2"` so bot
         </bq-date-picker>
       `
     })
-    export class DateRangePickerComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -295,6 +297,7 @@ Use `type="multi"` when users need to pick several non-consecutive dates. Unlike
     import { BqDatePicker } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqDatePicker],
       template: `
@@ -309,7 +312,7 @@ Use `type="multi"` when users need to pick several non-consecutive dates. Unlike
         </bq-date-picker>
       `
     })
-    export class MultipleDatePickerComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -363,6 +366,7 @@ Use `disabled` when the date field should not be interactive, such as when acces
     import { BqDatePicker } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqDatePicker],
       template: `
@@ -371,7 +375,7 @@ Use `disabled` when the date field should not be interactive, such as when acces
         </bq-date-picker>
       `
     })
-    export class DisabledDatePickerComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -452,6 +456,7 @@ Use `validation-status` when the field should show immediate visual feedback aft
     import { BqDatePicker } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqDatePicker],
       template: `
@@ -468,7 +473,7 @@ Use `validation-status` when the field should show immediate visual feedback aft
         </bq-date-picker>
       `
     })
-    export class ValidationStatesDatePickerComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -550,6 +555,7 @@ Use an optional indicator when the date adds context but is not required to comp
     import { BqDatePicker } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqDatePicker],
       template: `
@@ -561,7 +567,7 @@ Use an optional indicator when the date adds context but is not required to comp
         </bq-date-picker>
       `
     })
-    export class LabelOptionalDatePickerComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -647,6 +653,7 @@ Combine the label slot with a tooltip when users may need a short explanation be
     import { BqDatePicker, BqIcon, BqTooltip } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqDatePicker, BqIcon, BqTooltip],
       template: `
@@ -662,7 +669,7 @@ Combine the label slot with a tooltip when users may need a short explanation be
         </bq-date-picker>
       `
     })
-    export class LabelTooltipDatePickerComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -718,13 +725,14 @@ Use a label-less date picker only when the surrounding context already makes the
     import { BqDatePicker } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqDatePicker],
       template: `
         <bq-date-picker name="date-no-label" placeholder="Select a date" value="2026-10-13"></bq-date-picker>
       `
     })
-    export class NoLabelDatePickerComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -805,6 +813,7 @@ Use `locale` to match date formatting and calendar conventions to regional expec
     import { BqDatePicker } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqDatePicker],
       template: `
@@ -821,7 +830,7 @@ Use `locale` to match date formatting and calendar conventions to regional expec
         </bq-date-picker>
       `
     })
-    export class LocaleDatePickerComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -896,6 +905,7 @@ Use `first-day-of-week` to align the calendar grid with regional or business exp
     import { BqDatePicker } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqDatePicker],
       template: `
@@ -908,7 +918,7 @@ Use `first-day-of-week` to align the calendar grid with regional or business exp
         </bq-date-picker>
       `
     })
-    export class FirstDayOfWeekDatePickerComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -968,6 +978,7 @@ By default, the calendar shows only the days of the displayed month. Enable `sho
     import { BqDatePicker } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqDatePicker],
       template: `
@@ -976,7 +987,7 @@ By default, the calendar shows only the days of the displayed month. Enable `sho
         </bq-date-picker>
       `
     })
-    export class OutsideDaysDatePickerComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -1071,6 +1082,7 @@ Use `isDateDisallowed` to make specific dates unavailable for selection. This is
     import { BqDatePicker } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqDatePicker],
       template: `
@@ -1083,7 +1095,7 @@ Use `isDateDisallowed` to make specific dates unavailable for selection. This is
         </bq-date-picker>
       `
     })
-    export class DisallowedDatesComponent {
+    export class AppComponent {
       disallowedDates = ['2026-12-01', '2026-12-25', '2026-12-26'];
 
       isDateDisallowed = (date: Date): boolean => {
@@ -1203,6 +1215,7 @@ Use `formatOptions` when the selected date needs a more descriptive text format 
     import { BqDatePicker } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqDatePicker],
       template: `
@@ -1216,7 +1229,7 @@ Use `formatOptions` when the selected date needs a more descriptive text format 
         </bq-date-picker>
       `
     })
-    export class CustomFormatDatePickerComponent {
+    export class AppComponent {
       formatOptions: Intl.DateTimeFormatOptions = {
         weekday: 'long',
         year: 'numeric',

--- a/apps/beeq-docs/components/dialog.mdx
+++ b/apps/beeq-docs/components/dialog.mdx
@@ -235,6 +235,7 @@ Use the `default` dialog when you want to overlay content for focused user engag
     import { BqButton, BqDialog, BqIcon } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqButton, BqDialog, BqIcon],
       template: `
@@ -256,7 +257,7 @@ Use the `default` dialog when you want to overlay content for focused user engag
         </bq-dialog>
       `,
     })
-    export class DialogExampleComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -416,6 +417,7 @@ Use `footer-appearance="highlight"` when emphasis on the footer is important.
     import { BqButton, BqDialog, BqIcon } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqButton, BqDialog, BqIcon],
       template: `
@@ -437,7 +439,7 @@ Use `footer-appearance="highlight"` when emphasis on the footer is important.
         </bq-dialog>
       `,
     })
-    export class HighlightFooterDialogComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -568,6 +570,7 @@ This kind of dialog omits the footer section for situations where a minimal and 
     import { BqButton, BqDialog, BqIcon } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqButton, BqDialog, BqIcon],
       template: `
@@ -583,7 +586,7 @@ This kind of dialog omits the footer section for situations where a minimal and 
         </bq-dialog>
       `,
     })
-    export class NoFooterDialogComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -736,6 +739,7 @@ Use `disable-backdrop` when you want to allow users to focus on the dialog conte
     import { BqButton, BqDialog, BqIcon } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqButton, BqDialog, BqIcon],
       template: `
@@ -757,7 +761,7 @@ Use `disable-backdrop` when you want to allow users to focus on the dialog conte
         </bq-dialog>
       `,
     })
-    export class NoBackdropDialogComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -957,6 +961,7 @@ Use this variant to confirm irreversible actions with clear messaging and focuse
     import { BqButton, BqDialog, BqIcon } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqButton, BqDialog, BqIcon],
       template: `
@@ -983,7 +988,7 @@ Use this variant to confirm irreversible actions with clear messaging and focuse
         </bq-dialog>
       `,
     })
-    export class ConfirmDialogComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/divider.mdx
+++ b/apps/beeq-docs/components/divider.mdx
@@ -151,6 +151,7 @@ The simplest use — no attributes or slot content required. The divider renders
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqDivider } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -227,6 +228,7 @@ Set `orientation="vertical"` when the divider separates side-by-side content, su
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqDivider } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -321,6 +323,7 @@ Use `dashed` for a lighter visual boundary. Adjust `stroke-dash-width`, `stroke-
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqDivider } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -399,6 +402,7 @@ Use `title-alignment` to place title content at the start, middle, or end of the
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqDivider } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -480,6 +484,7 @@ Use stroke attributes to match the divider to a specific visual treatment. Set `
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqDivider } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,

--- a/apps/beeq-docs/components/divider.mdx
+++ b/apps/beeq-docs/components/divider.mdx
@@ -138,18 +138,17 @@ The simplest use — no attributes or slot content required. The divider renders
   <bq-divider></bq-divider>
 `}>
   <CodeGroup>
-
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-divider></bq-divider>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqDivider } from "@beeq/react";
 
     <BqDivider />
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqDivider } from "@beeq/angular/standalone";
     @Component({
@@ -163,7 +162,7 @@ The simplest use — no attributes or slot content required. The divider renders
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqDivider } from "@beeq/vue";
     </script>
@@ -196,7 +195,7 @@ Set `orientation="vertical"` when the divider separates side-by-side content, su
   </div>
 `}>
   <CodeGroup>
-    ```css CSS icon="css"
+    ```css styles.css icon="css" expandable
     .divider--vertical-example {
       display: flex;
       align-items: center;
@@ -206,7 +205,7 @@ Set `orientation="vertical"` when the divider separates side-by-side content, su
     }
     ```
 
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <div class="divider--vertical-example">
       <span>Left</span>
       <bq-divider orientation="vertical"></bq-divider>
@@ -214,8 +213,9 @@ Set `orientation="vertical"` when the divider separates side-by-side content, su
     </div>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqDivider } from "@beeq/react";
+    import "./styles.css";
 
     <div className="divider--vertical-example">
       <span>Left</span>
@@ -224,7 +224,7 @@ Set `orientation="vertical"` when the divider separates side-by-side content, su
     </div>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqDivider } from "@beeq/angular/standalone";
     @Component({
@@ -238,11 +238,20 @@ Set `orientation="vertical"` when the divider separates side-by-side content, su
           <span>Right</span>
         </div>
       `,
+      style: `
+        .divider--vertical-example {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          block-size: 120px;
+          gap: var(--bq-spacing-m);
+        }
+      `,
     })
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqDivider } from "@beeq/vue";
     </script>
@@ -254,6 +263,18 @@ Set `orientation="vertical"` when the divider separates side-by-side content, su
         <span>Right</span>
       </div>
     </template>
+
+
+    <style>
+    .divider--vertical-example {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      block-size: 120px;
+      gap: var(--bq-spacing-m);
+    }
+
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -277,7 +298,7 @@ Use `dashed` for a lighter visual boundary. Adjust `stroke-dash-width`, `stroke-
   ></bq-divider>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-divider
       dashed
       stroke-dash-width="12"
@@ -286,7 +307,7 @@ Use `dashed` for a lighter visual boundary. Adjust `stroke-dash-width`, `stroke-
     ></bq-divider>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqDivider } from "@beeq/react";
 
     <BqDivider
@@ -297,7 +318,7 @@ Use `dashed` for a lighter visual boundary. Adjust `stroke-dash-width`, `stroke-
     />
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqDivider } from "@beeq/angular/standalone";
     @Component({
@@ -316,7 +337,7 @@ Use `dashed` for a lighter visual boundary. Adjust `stroke-dash-width`, `stroke-
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqDivider } from "@beeq/vue";
     </script>
@@ -354,27 +375,28 @@ Use `title-alignment` to place title content at the start, middle, or end of the
   </bq-divider>
 `}>
   <CodeGroup>
-    ```css CSS icon="css"
+    ```css styles.css icon="css" expandable
     bq-divider {
       white-space: nowrap;
     }
     ```
 
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-divider title-alignment="start">Text start</bq-divider>
     <bq-divider title-alignment="middle">Text middle</bq-divider>
     <bq-divider title-alignment="end">Text end</bq-divider>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqDivider } from "@beeq/react";
+    import "./styles.css";
 
     <BqDivider titleAlignment="start">Text start</BqDivider>
     <BqDivider titleAlignment="middle">Text middle</BqDivider>
     <BqDivider titleAlignment="end">Text end</BqDivider>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqDivider } from "@beeq/angular/standalone";
     @Component({
@@ -386,11 +408,16 @@ Use `title-alignment` to place title content at the start, middle, or end of the
         <bq-divider title-alignment="middle">Text middle</bq-divider>
         <bq-divider title-alignment="end">Text end</bq-divider>
       `,
+      style: `
+        bq-divider {
+          white-space: nowrap;
+        }
+      `,
     })
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqDivider } from "@beeq/vue";
     </script>
@@ -400,6 +427,13 @@ Use `title-alignment` to place title content at the start, middle, or end of the
       <BqDivider titleAlignment="middle">Text middle</BqDivider>
       <BqDivider titleAlignment="end">Text end</BqDivider>
     </template>
+
+
+    <style>
+    bq-divider {
+      white-space: nowrap;
+    }
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -419,7 +453,7 @@ Use stroke attributes to match the divider to a specific visual treatment. Set `
   </bq-divider>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-divider
       stroke-color="stroke--brand"
       stroke-thickness="2"
@@ -430,7 +464,7 @@ Use stroke attributes to match the divider to a specific visual treatment. Set `
     </bq-divider>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqDivider } from "@beeq/react";
 
     <BqDivider
@@ -443,7 +477,7 @@ Use stroke attributes to match the divider to a specific visual treatment. Set `
     </BqDivider>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqDivider } from "@beeq/angular/standalone";
     @Component({
@@ -464,7 +498,7 @@ Use stroke attributes to match the divider to a specific visual treatment. Set `
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqDivider } from "@beeq/vue";
     </script>

--- a/apps/beeq-docs/components/divider.mdx
+++ b/apps/beeq-docs/components/divider.mdx
@@ -196,7 +196,7 @@ Set `orientation="vertical"` when the divider separates side-by-side content, su
   </div>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     .divider--vertical-example {
       display: flex;
       align-items: center;
@@ -240,7 +240,7 @@ Set `orientation="vertical"` when the divider separates side-by-side content, su
           <span>Right</span>
         </div>
       `,
-      style: `
+      styles: [`
         .divider--vertical-example {
           display: flex;
           align-items: center;
@@ -248,7 +248,7 @@ Set `orientation="vertical"` when the divider separates side-by-side content, su
           block-size: 120px;
           gap: var(--bq-spacing-m);
         }
-      `,
+      `],
     })
     export class AppComponent {}
     ```
@@ -378,7 +378,7 @@ Use `title-alignment` to place title content at the start, middle, or end of the
   </bq-divider>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     bq-divider {
       white-space: nowrap;
     }
@@ -412,11 +412,11 @@ Use `title-alignment` to place title content at the start, middle, or end of the
         <bq-divider title-alignment="middle">Text middle</bq-divider>
         <bq-divider title-alignment="end">Text end</bq-divider>
       `,
-      style: `
+      styles: [`
         bq-divider {
           white-space: nowrap;
         }
-      `,
+      `],
     })
     export class AppComponent {}
     ```

--- a/apps/beeq-docs/components/divider.mdx
+++ b/apps/beeq-docs/components/divider.mdx
@@ -149,8 +149,18 @@ The simplest use — no attributes or slot content required. The divider renders
     <BqDivider />
     ```
 
-    ```html Angular icon="angular"
-    <bq-divider></bq-divider>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqDivider } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqDivider],
+      template: `
+            <bq-divider></bq-divider>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -214,12 +224,22 @@ Set `orientation="vertical"` when the divider separates side-by-side content, su
     </div>
     ```
 
-    ```html Angular icon="angular"
-    <div class="divider--vertical-example">
-      <span>Left</span>
-      <bq-divider orientation="vertical"></bq-divider>
-      <span>Right</span>
-    </div>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqDivider } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqDivider],
+      template: `
+            <div class="divider--vertical-example">
+              <span>Left</span>
+              <bq-divider orientation="vertical"></bq-divider>
+              <span>Right</span>
+            </div>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -277,13 +297,23 @@ Use `dashed` for a lighter visual boundary. Adjust `stroke-dash-width`, `stroke-
     />
     ```
 
-    ```html Angular icon="angular"
-    <bq-divider
-      dashed
-      stroke-dash-width="12"
-      stroke-dash-gap="7"
-      stroke-linecap="butt"
-    ></bq-divider>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqDivider } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqDivider],
+      template: `
+            <bq-divider
+              dashed
+              stroke-dash-width="12"
+              stroke-dash-gap="7"
+              stroke-linecap="butt"
+            ></bq-divider>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -344,10 +374,20 @@ Use `title-alignment` to place title content at the start, middle, or end of the
     <BqDivider titleAlignment="end">Text end</BqDivider>
     ```
 
-    ```html Angular icon="angular"
-    <bq-divider title-alignment="start">Text start</bq-divider>
-    <bq-divider title-alignment="middle">Text middle</bq-divider>
-    <bq-divider title-alignment="end">Text end</bq-divider>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqDivider } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqDivider],
+      template: `
+            <bq-divider title-alignment="start">Text start</bq-divider>
+            <bq-divider title-alignment="middle">Text middle</bq-divider>
+            <bq-divider title-alignment="end">Text end</bq-divider>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -403,15 +443,25 @@ Use stroke attributes to match the divider to a specific visual treatment. Set `
     </BqDivider>
     ```
 
-    ```html Angular icon="angular"
-    <bq-divider
-      stroke-color="stroke--brand"
-      stroke-thickness="2"
-      stroke-basis="96"
-      title-alignment="start"
-    >
-      Section
-    </bq-divider>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqDivider } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqDivider],
+      template: `
+            <bq-divider
+              stroke-color="stroke--brand"
+              stroke-thickness="2"
+              stroke-basis="96"
+              title-alignment="start"
+            >
+              Section
+            </bq-divider>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/divider.mdx
+++ b/apps/beeq-docs/components/divider.mdx
@@ -196,7 +196,7 @@ Set `orientation="vertical"` when the divider separates side-by-side content, su
   </div>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     .divider--vertical-example {
       display: flex;
       align-items: center;
@@ -378,7 +378,7 @@ Use `title-alignment` to place title content at the start, middle, or end of the
   </bq-divider>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     bq-divider {
       white-space: nowrap;
     }

--- a/apps/beeq-docs/components/divider.mdx
+++ b/apps/beeq-docs/components/divider.mdx
@@ -157,7 +157,7 @@ The simplest use — no attributes or slot content required. The divider renders
       standalone: true,
       imports: [BqDivider],
       template: `
-            <bq-divider></bq-divider>
+        <bq-divider></bq-divider>
       `,
     })
     export class AppComponent {}
@@ -232,11 +232,11 @@ Set `orientation="vertical"` when the divider separates side-by-side content, su
       standalone: true,
       imports: [BqDivider],
       template: `
-            <div class="divider--vertical-example">
-              <span>Left</span>
-              <bq-divider orientation="vertical"></bq-divider>
-              <span>Right</span>
-            </div>
+        <div class="divider--vertical-example">
+          <span>Left</span>
+          <bq-divider orientation="vertical"></bq-divider>
+          <span>Right</span>
+        </div>
       `,
     })
     export class AppComponent {}
@@ -305,12 +305,12 @@ Use `dashed` for a lighter visual boundary. Adjust `stroke-dash-width`, `stroke-
       standalone: true,
       imports: [BqDivider],
       template: `
-            <bq-divider
-              dashed
-              stroke-dash-width="12"
-              stroke-dash-gap="7"
-              stroke-linecap="butt"
-            ></bq-divider>
+        <bq-divider
+          dashed
+          stroke-dash-width="12"
+          stroke-dash-gap="7"
+          stroke-linecap="butt"
+          ></bq-divider>
       `,
     })
     export class AppComponent {}
@@ -382,9 +382,9 @@ Use `title-alignment` to place title content at the start, middle, or end of the
       standalone: true,
       imports: [BqDivider],
       template: `
-            <bq-divider title-alignment="start">Text start</bq-divider>
-            <bq-divider title-alignment="middle">Text middle</bq-divider>
-            <bq-divider title-alignment="end">Text end</bq-divider>
+        <bq-divider title-alignment="start">Text start</bq-divider>
+        <bq-divider title-alignment="middle">Text middle</bq-divider>
+        <bq-divider title-alignment="end">Text end</bq-divider>
       `,
     })
     export class AppComponent {}
@@ -451,14 +451,14 @@ Use stroke attributes to match the divider to a specific visual treatment. Set `
       standalone: true,
       imports: [BqDivider],
       template: `
-            <bq-divider
-              stroke-color="stroke--brand"
-              stroke-thickness="2"
-              stroke-basis="96"
-              title-alignment="start"
-            >
-              Section
-            </bq-divider>
+        <bq-divider
+          stroke-color="stroke--brand"
+          stroke-thickness="2"
+          stroke-basis="96"
+          title-alignment="start"
+          >
+          Section
+        </bq-divider>
       `,
     })
     export class AppComponent {}

--- a/apps/beeq-docs/components/divider.mdx
+++ b/apps/beeq-docs/components/divider.mdx
@@ -268,14 +268,13 @@ Set `orientation="vertical"` when the divider separates side-by-side content, su
 
 
     <style>
-    .divider--vertical-example {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      block-size: 120px;
-      gap: var(--bq-spacing-m);
-    }
-
+      .divider--vertical-example {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        block-size: 120px;
+        gap: var(--bq-spacing-m);
+      }
     </style>
     ```
   </CodeGroup>
@@ -434,10 +433,10 @@ Use `title-alignment` to place title content at the start, middle, or end of the
 
 
     <style>
-    bq-divider {
-      white-space: nowrap;
-    }
-    </style>
+      bq-divider {
+        white-space: nowrap;
+      }
+      </style>
     ```
   </CodeGroup>
 </CodeLivePreview>

--- a/apps/beeq-docs/components/drawer.mdx
+++ b/apps/beeq-docs/components/drawer.mdx
@@ -185,7 +185,7 @@ The default state of the drawer component displays a standard drawer with a head
   </script>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     .drawer-title {
       display: flex;
       align-items: center;
@@ -421,7 +421,7 @@ The no-footer variant removes the footer section, providing a cleaner interface 
   </script>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     .drawer-title {
       display: flex;
       align-items: center;
@@ -631,7 +631,7 @@ The `position` prop allows you to specify the edge from which the drawer appears
   </script>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     .drawer-title {
       display: flex;
       align-items: center;
@@ -880,7 +880,7 @@ The backdrop variant adds a semi-transparent overlay behind the drawer, helping 
   </script>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     .drawer-title {
       display: flex;
       align-items: center;
@@ -1133,7 +1133,7 @@ Replace the default footer divider by slotting a custom element into `slot="foot
   </script>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     .drawer-title {
       display: flex;
       align-items: center;
@@ -1375,7 +1375,7 @@ By default, clicking outside the panel or pressing `Esc` closes the drawer. Set 
   </script>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     .drawer-content {
       padding: var(--bq-spacing-m) 0;
     }

--- a/apps/beeq-docs/components/drawer.mdx
+++ b/apps/beeq-docs/components/drawer.mdx
@@ -185,7 +185,7 @@ The default state of the drawer component displays a standard drawer with a head
   </script>
 `}>
   <CodeGroup>
-    ```css CSS icon="css3"
+    ```css styles.css icon="css" expandable
     .drawer-title {
       display: flex;
       align-items: center;
@@ -210,7 +210,7 @@ The default state of the drawer component displays a standard drawer with a head
     }
     ```
 
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-button>Open Drawer</bq-button>
 
     <bq-drawer position="end">
@@ -226,15 +226,16 @@ The default state of the drawer component displays a standard drawer with a head
     </bq-drawer>
     ```
 
-    ```javascript JavaScript icon="js"
+    ```javascript JavaScript icon="js" expandable
     const btn = document.querySelector('bq-button');
     const drawer = document.querySelector('bq-drawer');
     btn.addEventListener('bqClick', () => drawer.show());
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { useRef } from "react";
     import { BqButton, BqDrawer, BqIcon } from "@beeq/react";
+    import "./styles.css";
 
     export default function App() {
       const drawerRef = useRef(null);
@@ -259,7 +260,7 @@ The default state of the drawer component displays a standard drawer with a head
     }
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqButton, BqDrawer, BqIcon } from "@beeq/angular/standalone";
 
@@ -282,11 +283,35 @@ The default state of the drawer component displays a standard drawer with a head
           </div>
         </bq-drawer>
       `,
+      style: `
+            .drawer-title {
+              display: flex;
+              align-items: center;
+              gap: var(--bq-spacing-xs);
+            }
+
+            .drawer-description {
+              display: flex;
+              height: 100%;
+              align-items: center;
+              justify-content: center;
+              border-radius: var(--bq-radius--xs);
+              border: 1px dashed var(--bq-stroke--brand);
+              background-color: var(--bq-red-100);
+            }
+
+            .drawer-footer {
+              display: flex;
+              justify-content: center;
+              gap: var(--bq-spacing-xs);
+              flex: 1;
+            }
+      `,
     })
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { ref } from "vue";
     import { BqButton, BqDrawer, BqIcon } from "@beeq/vue";
@@ -309,6 +334,31 @@ The default state of the drawer component displays a standard drawer with a head
         </div>
       </BqDrawer>
     </template>
+
+    <style>
+    .drawer-title {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+
+    .drawer-description {
+      display: flex;
+      height: 100%;
+      align-items: center;
+      justify-content: center;
+      border-radius: var(--bq-radius--xs);
+      border: 1px dashed var(--bq-stroke--brand);
+      background-color: var(--bq-red-100);
+    }
+
+    .drawer-footer {
+      display: flex;
+      justify-content: center;
+      gap: var(--bq-spacing-xs);
+      flex: 1;
+    }
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -371,7 +421,7 @@ The no-footer variant removes the footer section, providing a cleaner interface 
   </script>
 `}>
   <CodeGroup>
-    ```css CSS icon="css3"
+    ```css styles.css icon="css" expandable
     .drawer-title {
       display: flex;
       align-items: center;
@@ -389,7 +439,7 @@ The no-footer variant removes the footer section, providing a cleaner interface 
     }
     ```
 
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-button>Open Drawer</bq-button>
 
     <bq-drawer position="end">
@@ -401,15 +451,16 @@ The no-footer variant removes the footer section, providing a cleaner interface 
     </bq-drawer>
     ```
 
-    ```javascript JavaScript icon="js"
+    ```javascript JavaScript icon="js" expandable
     const btn = document.querySelector('bq-button');
     const drawer = document.querySelector('bq-drawer');
     btn.addEventListener('bqClick', () => drawer.show());
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { useRef } from "react";
     import { BqButton, BqDrawer, BqIcon } from "@beeq/react";
+    import "./styles.css";
 
     export default function App() {
       const drawerRef = useRef(null);
@@ -430,7 +481,7 @@ The no-footer variant removes the footer section, providing a cleaner interface 
     }
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqButton, BqDrawer, BqIcon } from "@beeq/angular/standalone";
 
@@ -449,11 +500,28 @@ The no-footer variant removes the footer section, providing a cleaner interface 
           <div class="drawer-description">Content</div>
         </bq-drawer>
       `,
+      style: `
+            .drawer-title {
+              display: flex;
+              align-items: center;
+              gap: var(--bq-spacing-xs);
+            }
+
+            .drawer-description {
+              display: flex;
+              height: 100%;
+              align-items: center;
+              justify-content: center;
+              border-radius: var(--bq-radius--xs);
+              border: 1px dashed var(--bq-stroke--brand);
+              background-color: var(--bq-red-100);
+            }
+      `,
     })
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { ref } from "vue";
     import { BqButton, BqDrawer, BqIcon } from "@beeq/vue";
@@ -472,6 +540,24 @@ The no-footer variant removes the footer section, providing a cleaner interface 
         <div class="drawer-description">Content</div>
       </BqDrawer>
     </template>
+
+    <style>
+    .drawer-title {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+
+    .drawer-description {
+      display: flex;
+      height: 100%;
+      align-items: center;
+      justify-content: center;
+      border-radius: var(--bq-radius--xs);
+      border: 1px dashed var(--bq-stroke--brand);
+      background-color: var(--bq-red-100);
+    }
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -545,7 +631,7 @@ The `position` prop allows you to specify the edge from which the drawer appears
   </script>
 `}>
   <CodeGroup>
-    ```css CSS icon="css3"
+    ```css styles.css icon="css" expandable
     .drawer-title {
       display: flex;
       align-items: center;
@@ -570,7 +656,7 @@ The `position` prop allows you to specify the edge from which the drawer appears
     }
     ```
 
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-button>Open Drawer</bq-button>
 
     <bq-drawer position="start">
@@ -586,15 +672,16 @@ The `position` prop allows you to specify the edge from which the drawer appears
     </bq-drawer>
     ```
 
-    ```javascript JavaScript icon="js"
+    ```javascript JavaScript icon="js" expandable
     const btn = document.querySelector('bq-button');
     const drawer = document.querySelector('bq-drawer');
     btn.addEventListener('bqClick', () => drawer.show());
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { useRef } from "react";
     import { BqButton, BqDrawer, BqIcon } from "@beeq/react";
+    import "./styles.css";
 
     export default function App() {
       const drawerRef = useRef(null);
@@ -619,7 +706,7 @@ The `position` prop allows you to specify the edge from which the drawer appears
     }
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqButton, BqDrawer, BqIcon } from "@beeq/angular/standalone";
 
@@ -642,11 +729,35 @@ The `position` prop allows you to specify the edge from which the drawer appears
           </div>
         </bq-drawer>
       `,
+      style: `
+            .drawer-title {
+              display: flex;
+              align-items: center;
+              gap: var(--bq-spacing-xs);
+            }
+
+            .drawer-description {
+              display: flex;
+              height: 100%;
+              align-items: center;
+              justify-content: center;
+              border-radius: var(--bq-radius--xs);
+              border: 1px dashed var(--bq-stroke--brand);
+              background-color: var(--bq-red-100);
+            }
+
+            .drawer-footer {
+              display: flex;
+              justify-content: center;
+              gap: var(--bq-spacing-xs);
+              flex: 1;
+            }
+      `,
     })
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { ref } from "vue";
     import { BqButton, BqDrawer, BqIcon } from "@beeq/vue";
@@ -669,6 +780,31 @@ The `position` prop allows you to specify the edge from which the drawer appears
         </div>
       </BqDrawer>
     </template>
+
+    <style>
+    .drawer-title {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+
+    .drawer-description {
+      display: flex;
+      height: 100%;
+      align-items: center;
+      justify-content: center;
+      border-radius: var(--bq-radius--xs);
+      border: 1px dashed var(--bq-stroke--brand);
+      background-color: var(--bq-red-100);
+    }
+
+    .drawer-footer {
+      display: flex;
+      justify-content: center;
+      gap: var(--bq-spacing-xs);
+      flex: 1;
+    }
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -744,7 +880,7 @@ The backdrop variant adds a semi-transparent overlay behind the drawer, helping 
   </script>
 `}>
   <CodeGroup>
-    ```css CSS icon="css3"
+    ```css styles.css icon="css" expandable
     .drawer-title {
       display: flex;
       align-items: center;
@@ -769,7 +905,7 @@ The backdrop variant adds a semi-transparent overlay behind the drawer, helping 
     }
     ```
 
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-button>Open Drawer</bq-button>
 
     <bq-drawer position="end" enable-backdrop>
@@ -785,15 +921,16 @@ The backdrop variant adds a semi-transparent overlay behind the drawer, helping 
     </bq-drawer>
     ```
 
-    ```javascript JavaScript icon="js"
+    ```javascript JavaScript icon="js" expandable
     const btn = document.querySelector('bq-button');
     const drawer = document.querySelector('bq-drawer');
     btn.addEventListener('bqClick', () => drawer.show());
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { useRef } from "react";
     import { BqButton, BqDrawer, BqIcon } from "@beeq/react";
+    import "./styles.css";
 
     export default function App() {
       const drawerRef = useRef(null);
@@ -818,7 +955,7 @@ The backdrop variant adds a semi-transparent overlay behind the drawer, helping 
     }
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqButton, BqDrawer, BqIcon } from "@beeq/angular/standalone";
 
@@ -841,11 +978,35 @@ The backdrop variant adds a semi-transparent overlay behind the drawer, helping 
           </div>
         </bq-drawer>
       `,
+      style: `
+            .drawer-title {
+              display: flex;
+              align-items: center;
+              gap: var(--bq-spacing-xs);
+            }
+
+            .drawer-description {
+              display: flex;
+              height: 100%;
+              align-items: center;
+              justify-content: center;
+              border-radius: var(--bq-radius--xs);
+              border: 1px dashed var(--bq-stroke--brand);
+              background-color: var(--bq-red-100);
+            }
+
+            .drawer-footer {
+              display: flex;
+              justify-content: center;
+              gap: var(--bq-spacing-xs);
+              flex: 1;
+            }
+      `,
     })
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { ref } from "vue";
     import { BqButton, BqDrawer, BqIcon } from "@beeq/vue";
@@ -868,6 +1029,31 @@ The backdrop variant adds a semi-transparent overlay behind the drawer, helping 
         </div>
       </BqDrawer>
     </template>
+
+    <style>
+    .drawer-title {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+
+    .drawer-description {
+      display: flex;
+      height: 100%;
+      align-items: center;
+      justify-content: center;
+      border-radius: var(--bq-radius--xs);
+      border: 1px dashed var(--bq-stroke--brand);
+      background-color: var(--bq-red-100);
+    }
+
+    .drawer-footer {
+      display: flex;
+      justify-content: center;
+      gap: var(--bq-spacing-xs);
+      flex: 1;
+    }
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -947,7 +1133,7 @@ Replace the default footer divider by slotting a custom element into `slot="foot
   </script>
 `}>
   <CodeGroup>
-    ```css CSS icon="css3"
+    ```css styles.css icon="css" expandable
     .drawer-title {
       display: flex;
       align-items: center;
@@ -977,7 +1163,7 @@ Replace the default footer divider by slotting a custom element into `slot="foot
     }
     ```
 
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-button>Open Drawer</bq-button>
 
     <bq-drawer position="end" enable-backdrop>
@@ -994,15 +1180,16 @@ Replace the default footer divider by slotting a custom element into `slot="foot
     </bq-drawer>
     ```
 
-    ```javascript JavaScript icon="js"
+    ```javascript JavaScript icon="js" expandable
     const btn = document.querySelector('bq-button');
     const drawer = document.querySelector('bq-drawer');
     btn.addEventListener('bqClick', () => drawer.show());
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { useRef } from "react";
     import { BqButton, BqDivider, BqDrawer, BqIcon } from "@beeq/react";
+    import "./styles.css";
 
     export default function App() {
       const drawerRef = useRef(null);
@@ -1028,7 +1215,7 @@ Replace the default footer divider by slotting a custom element into `slot="foot
     }
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqButton, BqDivider, BqDrawer, BqIcon } from "@beeq/angular/standalone";
 
@@ -1052,11 +1239,40 @@ Replace the default footer divider by slotting a custom element into `slot="foot
           </div>
         </bq-drawer>
       `,
+      style: `
+            .drawer-title {
+              display: flex;
+              align-items: center;
+              gap: var(--bq-spacing-xs);
+            }
+
+            .drawer-description {
+              display: flex;
+              height: 100%;
+              align-items: center;
+              justify-content: center;
+              border-radius: var(--bq-radius--xs);
+              border: 1px dashed var(--bq-stroke--brand);
+              background-color: var(--bq-red-100);
+            }
+
+            .drawer-footer-divider {
+              display: block;
+              margin-bottom: var(--bq-spacing-m);
+            }
+
+            .drawer-footer {
+              display: flex;
+              justify-content: center;
+              gap: var(--bq-spacing-xs);
+              flex: 1;
+            }
+      `,
     })
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { ref } from "vue";
     import { BqButton, BqDivider, BqDrawer, BqIcon } from "@beeq/vue";
@@ -1080,6 +1296,36 @@ Replace the default footer divider by slotting a custom element into `slot="foot
         </div>
       </BqDrawer>
     </template>
+
+    <style>
+    .drawer-title {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+
+    .drawer-description {
+      display: flex;
+      height: 100%;
+      align-items: center;
+      justify-content: center;
+      border-radius: var(--bq-radius--xs);
+      border: 1px dashed var(--bq-stroke--brand);
+      background-color: var(--bq-red-100);
+    }
+
+    .drawer-footer-divider {
+      display: block;
+      margin-bottom: var(--bq-spacing-m);
+    }
+
+    .drawer-footer {
+      display: flex;
+      justify-content: center;
+      gap: var(--bq-spacing-xs);
+      flex: 1;
+    }
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -1129,13 +1375,13 @@ By default, clicking outside the panel or pressing `Esc` closes the drawer. Set 
   </script>
 `}>
   <CodeGroup>
-    ```css CSS icon="css3"
+    ```css styles.css icon="css" expandable
     .drawer-content {
       padding: var(--bq-spacing-m) 0;
     }
     ```
 
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-button>Open locked drawer</bq-button>
 
     <bq-drawer position="end" enable-backdrop close-on-click-outside close-on-esc>
@@ -1146,15 +1392,16 @@ By default, clicking outside the panel or pressing `Esc` closes the drawer. Set 
     </bq-drawer>
     ```
 
-    ```javascript JavaScript icon="js"
+    ```javascript JavaScript icon="js" expandable
     const btn = document.querySelector('bq-button');
     const drawer = document.querySelector('bq-drawer');
     btn.addEventListener('bqClick', () => drawer.show());
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { useRef } from "react";
     import { BqButton, BqDrawer } from "@beeq/react";
+    import "./styles.css";
 
     export default function App() {
       const drawerRef = useRef(null);
@@ -1174,7 +1421,7 @@ By default, clicking outside the panel or pressing `Esc` closes the drawer. Set 
     }
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqButton, BqDrawer } from "@beeq/angular/standalone";
 
@@ -1192,11 +1439,16 @@ By default, clicking outside the panel or pressing `Esc` closes the drawer. Set 
           </div>
         </bq-drawer>
       `,
+      style: `
+            .drawer-content {
+              padding: var(--bq-spacing-m) 0;
+            }
+      `,
     })
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { ref } from "vue";
     import { BqButton, BqDrawer } from "@beeq/vue";
@@ -1214,6 +1466,12 @@ By default, clicking outside the panel or pressing `Esc` closes the drawer. Set 
         </div>
       </BqDrawer>
     </template>
+
+    <style>
+    .drawer-content {
+      padding: var(--bq-spacing-m) 0;
+    }
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>

--- a/apps/beeq-docs/components/drawer.mdx
+++ b/apps/beeq-docs/components/drawer.mdx
@@ -185,7 +185,7 @@ The default state of the drawer component displays a standard drawer with a head
   </script>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     .drawer-title {
       display: flex;
       align-items: center;
@@ -283,7 +283,7 @@ The default state of the drawer component displays a standard drawer with a head
           </div>
         </bq-drawer>
       `,
-      style: `
+      styles: [`
             .drawer-title {
               display: flex;
               align-items: center;
@@ -306,7 +306,7 @@ The default state of the drawer component displays a standard drawer with a head
               gap: var(--bq-spacing-xs);
               flex: 1;
             }
-      `,
+      `],
     })
     export class AppComponent {}
     ```
@@ -421,7 +421,7 @@ The no-footer variant removes the footer section, providing a cleaner interface 
   </script>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     .drawer-title {
       display: flex;
       align-items: center;
@@ -500,7 +500,7 @@ The no-footer variant removes the footer section, providing a cleaner interface 
           <div class="drawer-description">Content</div>
         </bq-drawer>
       `,
-      style: `
+      styles: [`
             .drawer-title {
               display: flex;
               align-items: center;
@@ -516,7 +516,7 @@ The no-footer variant removes the footer section, providing a cleaner interface 
               border: 1px dashed var(--bq-stroke--brand);
               background-color: var(--bq-red-100);
             }
-      `,
+      `],
     })
     export class AppComponent {}
     ```
@@ -631,7 +631,7 @@ The `position` prop allows you to specify the edge from which the drawer appears
   </script>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     .drawer-title {
       display: flex;
       align-items: center;
@@ -729,7 +729,7 @@ The `position` prop allows you to specify the edge from which the drawer appears
           </div>
         </bq-drawer>
       `,
-      style: `
+      styles: [`
             .drawer-title {
               display: flex;
               align-items: center;
@@ -752,7 +752,7 @@ The `position` prop allows you to specify the edge from which the drawer appears
               gap: var(--bq-spacing-xs);
               flex: 1;
             }
-      `,
+      `],
     })
     export class AppComponent {}
     ```
@@ -880,7 +880,7 @@ The backdrop variant adds a semi-transparent overlay behind the drawer, helping 
   </script>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     .drawer-title {
       display: flex;
       align-items: center;
@@ -978,7 +978,7 @@ The backdrop variant adds a semi-transparent overlay behind the drawer, helping 
           </div>
         </bq-drawer>
       `,
-      style: `
+      styles: [`
             .drawer-title {
               display: flex;
               align-items: center;
@@ -1001,7 +1001,7 @@ The backdrop variant adds a semi-transparent overlay behind the drawer, helping 
               gap: var(--bq-spacing-xs);
               flex: 1;
             }
-      `,
+      `],
     })
     export class AppComponent {}
     ```
@@ -1133,7 +1133,7 @@ Replace the default footer divider by slotting a custom element into `slot="foot
   </script>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     .drawer-title {
       display: flex;
       align-items: center;
@@ -1239,7 +1239,7 @@ Replace the default footer divider by slotting a custom element into `slot="foot
           </div>
         </bq-drawer>
       `,
-      style: `
+      styles: [`
             .drawer-title {
               display: flex;
               align-items: center;
@@ -1267,7 +1267,7 @@ Replace the default footer divider by slotting a custom element into `slot="foot
               gap: var(--bq-spacing-xs);
               flex: 1;
             }
-      `,
+      `],
     })
     export class AppComponent {}
     ```
@@ -1375,7 +1375,7 @@ By default, clicking outside the panel or pressing `Esc` closes the drawer. Set 
   </script>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     .drawer-content {
       padding: var(--bq-spacing-m) 0;
     }
@@ -1439,11 +1439,11 @@ By default, clicking outside the panel or pressing `Esc` closes the drawer. Set 
           </div>
         </bq-drawer>
       `,
-      style: `
+      styles: [`
             .drawer-content {
               padding: var(--bq-spacing-m) 0;
             }
-      `,
+      `],
     })
     export class AppComponent {}
     ```

--- a/apps/beeq-docs/components/drawer.mdx
+++ b/apps/beeq-docs/components/drawer.mdx
@@ -336,28 +336,28 @@ The default state of the drawer component displays a standard drawer with a head
     </template>
 
     <style>
-    .drawer-title {
-      display: flex;
-      align-items: center;
-      gap: var(--bq-spacing-xs);
-    }
+      .drawer-title {
+        display: flex;
+        align-items: center;
+        gap: var(--bq-spacing-xs);
+      }
 
-    .drawer-description {
-      display: flex;
-      height: 100%;
-      align-items: center;
-      justify-content: center;
-      border-radius: var(--bq-radius--xs);
-      border: 1px dashed var(--bq-stroke--brand);
-      background-color: var(--bq-red-100);
-    }
+      .drawer-description {
+        display: flex;
+        height: 100%;
+        align-items: center;
+        justify-content: center;
+        border-radius: var(--bq-radius--xs);
+        border: 1px dashed var(--bq-stroke--brand);
+        background-color: var(--bq-red-100);
+      }
 
-    .drawer-footer {
-      display: flex;
-      justify-content: center;
-      gap: var(--bq-spacing-xs);
-      flex: 1;
-    }
+      .drawer-footer {
+        display: flex;
+        justify-content: center;
+        gap: var(--bq-spacing-xs);
+        flex: 1;
+      }
     </style>
     ```
   </CodeGroup>
@@ -542,21 +542,21 @@ The no-footer variant removes the footer section, providing a cleaner interface 
     </template>
 
     <style>
-    .drawer-title {
-      display: flex;
-      align-items: center;
-      gap: var(--bq-spacing-xs);
-    }
+      .drawer-title {
+        display: flex;
+        align-items: center;
+        gap: var(--bq-spacing-xs);
+      }
 
-    .drawer-description {
-      display: flex;
-      height: 100%;
-      align-items: center;
-      justify-content: center;
-      border-radius: var(--bq-radius--xs);
-      border: 1px dashed var(--bq-stroke--brand);
-      background-color: var(--bq-red-100);
-    }
+      .drawer-description {
+        display: flex;
+        height: 100%;
+        align-items: center;
+        justify-content: center;
+        border-radius: var(--bq-radius--xs);
+        border: 1px dashed var(--bq-stroke--brand);
+        background-color: var(--bq-red-100);
+      }
     </style>
     ```
   </CodeGroup>
@@ -730,28 +730,28 @@ The `position` prop allows you to specify the edge from which the drawer appears
         </bq-drawer>
       `,
       styles: [`
-            .drawer-title {
-              display: flex;
-              align-items: center;
-              gap: var(--bq-spacing-xs);
-            }
+        .drawer-title {
+          display: flex;
+          align-items: center;
+          gap: var(--bq-spacing-xs);
+        }
 
-            .drawer-description {
-              display: flex;
-              height: 100%;
-              align-items: center;
-              justify-content: center;
-              border-radius: var(--bq-radius--xs);
-              border: 1px dashed var(--bq-stroke--brand);
-              background-color: var(--bq-red-100);
-            }
+        .drawer-description {
+          display: flex;
+          height: 100%;
+          align-items: center;
+          justify-content: center;
+          border-radius: var(--bq-radius--xs);
+          border: 1px dashed var(--bq-stroke--brand);
+          background-color: var(--bq-red-100);
+        }
 
-            .drawer-footer {
-              display: flex;
-              justify-content: center;
-              gap: var(--bq-spacing-xs);
-              flex: 1;
-            }
+        .drawer-footer {
+          display: flex;
+          justify-content: center;
+          gap: var(--bq-spacing-xs);
+          flex: 1;
+        }
       `],
     })
     export class AppComponent {}
@@ -782,28 +782,28 @@ The `position` prop allows you to specify the edge from which the drawer appears
     </template>
 
     <style>
-    .drawer-title {
-      display: flex;
-      align-items: center;
-      gap: var(--bq-spacing-xs);
-    }
+      .drawer-title {
+        display: flex;
+        align-items: center;
+        gap: var(--bq-spacing-xs);
+      }
 
-    .drawer-description {
-      display: flex;
-      height: 100%;
-      align-items: center;
-      justify-content: center;
-      border-radius: var(--bq-radius--xs);
-      border: 1px dashed var(--bq-stroke--brand);
-      background-color: var(--bq-red-100);
-    }
+      .drawer-description {
+        display: flex;
+        height: 100%;
+        align-items: center;
+        justify-content: center;
+        border-radius: var(--bq-radius--xs);
+        border: 1px dashed var(--bq-stroke--brand);
+        background-color: var(--bq-red-100);
+      }
 
-    .drawer-footer {
-      display: flex;
-      justify-content: center;
-      gap: var(--bq-spacing-xs);
-      flex: 1;
-    }
+      .drawer-footer {
+        display: flex;
+        justify-content: center;
+        gap: var(--bq-spacing-xs);
+        flex: 1;
+      }
     </style>
     ```
   </CodeGroup>
@@ -979,28 +979,28 @@ The backdrop variant adds a semi-transparent overlay behind the drawer, helping 
         </bq-drawer>
       `,
       styles: [`
-            .drawer-title {
-              display: flex;
-              align-items: center;
-              gap: var(--bq-spacing-xs);
-            }
+        .drawer-title {
+          display: flex;
+          align-items: center;
+          gap: var(--bq-spacing-xs);
+        }
 
-            .drawer-description {
-              display: flex;
-              height: 100%;
-              align-items: center;
-              justify-content: center;
-              border-radius: var(--bq-radius--xs);
-              border: 1px dashed var(--bq-stroke--brand);
-              background-color: var(--bq-red-100);
-            }
+        .drawer-description {
+          display: flex;
+          height: 100%;
+          align-items: center;
+          justify-content: center;
+          border-radius: var(--bq-radius--xs);
+          border: 1px dashed var(--bq-stroke--brand);
+          background-color: var(--bq-red-100);
+        }
 
-            .drawer-footer {
-              display: flex;
-              justify-content: center;
-              gap: var(--bq-spacing-xs);
-              flex: 1;
-            }
+        .drawer-footer {
+          display: flex;
+          justify-content: center;
+          gap: var(--bq-spacing-xs);
+          flex: 1;
+        }
       `],
     })
     export class AppComponent {}
@@ -1031,28 +1031,28 @@ The backdrop variant adds a semi-transparent overlay behind the drawer, helping 
     </template>
 
     <style>
-    .drawer-title {
-      display: flex;
-      align-items: center;
-      gap: var(--bq-spacing-xs);
-    }
+      .drawer-title {
+        display: flex;
+        align-items: center;
+        gap: var(--bq-spacing-xs);
+      }
 
-    .drawer-description {
-      display: flex;
-      height: 100%;
-      align-items: center;
-      justify-content: center;
-      border-radius: var(--bq-radius--xs);
-      border: 1px dashed var(--bq-stroke--brand);
-      background-color: var(--bq-red-100);
-    }
+      .drawer-description {
+        display: flex;
+        height: 100%;
+        align-items: center;
+        justify-content: center;
+        border-radius: var(--bq-radius--xs);
+        border: 1px dashed var(--bq-stroke--brand);
+        background-color: var(--bq-red-100);
+      }
 
-    .drawer-footer {
-      display: flex;
-      justify-content: center;
-      gap: var(--bq-spacing-xs);
-      flex: 1;
-    }
+      .drawer-footer {
+        display: flex;
+        justify-content: center;
+        gap: var(--bq-spacing-xs);
+        flex: 1;
+      }
     </style>
     ```
   </CodeGroup>
@@ -1240,33 +1240,33 @@ Replace the default footer divider by slotting a custom element into `slot="foot
         </bq-drawer>
       `,
       styles: [`
-            .drawer-title {
-              display: flex;
-              align-items: center;
-              gap: var(--bq-spacing-xs);
-            }
+        .drawer-title {
+          display: flex;
+          align-items: center;
+          gap: var(--bq-spacing-xs);
+        }
 
-            .drawer-description {
-              display: flex;
-              height: 100%;
-              align-items: center;
-              justify-content: center;
-              border-radius: var(--bq-radius--xs);
-              border: 1px dashed var(--bq-stroke--brand);
-              background-color: var(--bq-red-100);
-            }
+        .drawer-description {
+          display: flex;
+          height: 100%;
+          align-items: center;
+          justify-content: center;
+          border-radius: var(--bq-radius--xs);
+          border: 1px dashed var(--bq-stroke--brand);
+          background-color: var(--bq-red-100);
+        }
 
-            .drawer-footer-divider {
-              display: block;
-              margin-bottom: var(--bq-spacing-m);
-            }
+        .drawer-footer-divider {
+          display: block;
+          margin-bottom: var(--bq-spacing-m);
+        }
 
-            .drawer-footer {
-              display: flex;
-              justify-content: center;
-              gap: var(--bq-spacing-xs);
-              flex: 1;
-            }
+        .drawer-footer {
+          display: flex;
+          justify-content: center;
+          gap: var(--bq-spacing-xs);
+          flex: 1;
+        }
       `],
     })
     export class AppComponent {}
@@ -1298,33 +1298,33 @@ Replace the default footer divider by slotting a custom element into `slot="foot
     </template>
 
     <style>
-    .drawer-title {
-      display: flex;
-      align-items: center;
-      gap: var(--bq-spacing-xs);
-    }
+      .drawer-title {
+        display: flex;
+        align-items: center;
+        gap: var(--bq-spacing-xs);
+      }
 
-    .drawer-description {
-      display: flex;
-      height: 100%;
-      align-items: center;
-      justify-content: center;
-      border-radius: var(--bq-radius--xs);
-      border: 1px dashed var(--bq-stroke--brand);
-      background-color: var(--bq-red-100);
-    }
+      .drawer-description {
+        display: flex;
+        height: 100%;
+        align-items: center;
+        justify-content: center;
+        border-radius: var(--bq-radius--xs);
+        border: 1px dashed var(--bq-stroke--brand);
+        background-color: var(--bq-red-100);
+      }
 
-    .drawer-footer-divider {
-      display: block;
-      margin-bottom: var(--bq-spacing-m);
-    }
+      .drawer-footer-divider {
+        display: block;
+        margin-bottom: var(--bq-spacing-m);
+      }
 
-    .drawer-footer {
-      display: flex;
-      justify-content: center;
-      gap: var(--bq-spacing-xs);
-      flex: 1;
-    }
+      .drawer-footer {
+        display: flex;
+        justify-content: center;
+        gap: var(--bq-spacing-xs);
+        flex: 1;
+      }
     </style>
     ```
   </CodeGroup>
@@ -1440,9 +1440,9 @@ By default, clicking outside the panel or pressing `Esc` closes the drawer. Set 
         </bq-drawer>
       `,
       styles: [`
-            .drawer-content {
-              padding: var(--bq-spacing-m) 0;
-            }
+        .drawer-content {
+          padding: var(--bq-spacing-m) 0;
+        }
       `],
     })
     export class AppComponent {}
@@ -1468,10 +1468,10 @@ By default, clicking outside the panel or pressing `Esc` closes the drawer. Set 
     </template>
 
     <style>
-    .drawer-content {
-      padding: var(--bq-spacing-m) 0;
-    }
-    </style>
+      .drawer-content {
+        padding: var(--bq-spacing-m) 0;
+      }
+      </style>
     ```
   </CodeGroup>
 </CodeLivePreview>

--- a/apps/beeq-docs/components/dropdown.mdx
+++ b/apps/beeq-docs/components/dropdown.mdx
@@ -219,6 +219,7 @@ The trigger can be any appropriate interactive element, but in most cases a `bq-
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqDropdown, BqButton, BqIcon, BqOptionList, BqOption } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -462,6 +463,7 @@ Use the `placement` attribute when you need fine-grained control over the panel 
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqDropdown, BqButton, BqIcon, BqOptionList, BqOption } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -735,6 +737,7 @@ Use a custom trigger when the dropdown needs a more specific visual entry point,
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqDropdown, BqButton, BqIcon, BqOptionList, BqOption, BqAvatar } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -952,6 +955,7 @@ Use `keep-open-on-select` when the dropdown should stay open after a selection i
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqDropdown, BqButton, BqIcon, BqOptionList, BqOption } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -1121,6 +1125,7 @@ Use option groups when you need to categorize and group options under specific h
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqDropdown, BqButton, BqIcon, BqOptionList, BqOptionGroup, BqOption } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -1244,6 +1249,7 @@ Use `same-width` when the panel should match the trigger width. Use `panel-heigh
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqDropdown, BqButton, BqIcon, BqOptionList, BqOption } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,

--- a/apps/beeq-docs/components/dropdown.mdx
+++ b/apps/beeq-docs/components/dropdown.mdx
@@ -225,38 +225,38 @@ The trigger can be any appropriate interactive element, but in most cases a `bq-
       imports: [BqDropdown, BqButton, BqIcon, BqOptionList, BqOption],
       template: `
         <bq-dropdown>
-              <bq-button slot="trigger">
-                Dropdown
-                <bq-icon name="caret-down" slot="suffix"></bq-icon>
-              </bq-button>
-        
-              <bq-option-list>
-                <bq-option value="users">
-                  <bq-icon name="users" slot="prefix"></bq-icon>
-                  <span>Users</span>
-                </bq-option>
-        
-                <bq-option value="profile">
-                  <bq-icon name="user" slot="prefix"></bq-icon>
-                  <span>My profile</span>
-                </bq-option>
-        
-                <bq-option value="dashboard">
-                  <bq-icon name="sliders" slot="prefix"></bq-icon>
-                  <span>Dashboard</span>
-                </bq-option>
-        
-                <bq-option value="settings">
-                  <bq-icon name="gear" slot="prefix"></bq-icon>
-                  <span>Settings</span>
-                </bq-option>
-        
-                <bq-option value="logout">
-                  <span>Logout</span>
-                  <bq-icon name="sign-out" slot="suffix"></bq-icon>
-                </bq-option>
-              </bq-option-list>
-            </bq-dropdown>
+          <bq-button slot="trigger">
+            Dropdown
+            <bq-icon name="caret-down" slot="suffix"></bq-icon>
+          </bq-button>
+
+          <bq-option-list>
+            <bq-option value="users">
+              <bq-icon name="users" slot="prefix"></bq-icon>
+              <span>Users</span>
+            </bq-option>
+
+            <bq-option value="profile">
+              <bq-icon name="user" slot="prefix"></bq-icon>
+              <span>My profile</span>
+            </bq-option>
+
+            <bq-option value="dashboard">
+              <bq-icon name="sliders" slot="prefix"></bq-icon>
+              <span>Dashboard</span>
+            </bq-option>
+
+            <bq-option value="settings">
+              <bq-icon name="gear" slot="prefix"></bq-icon>
+              <span>Settings</span>
+            </bq-option>
+
+            <bq-option value="logout">
+              <span>Logout</span>
+              <bq-icon name="sign-out" slot="suffix"></bq-icon>
+            </bq-option>
+          </bq-option-list>
+        </bq-dropdown>
       `,
     })
     export class AppComponent {}
@@ -467,47 +467,47 @@ Use the `placement` attribute when you need fine-grained control over the panel 
       standalone: true,
       imports: [BqDropdown, BqButton, BqIcon, BqOptionList, BqOption],
       template: `
-            <bq-dropdown placement="bottom-start">
-              <bq-button slot="trigger">
-                Bottom start
-                <bq-icon name="caret-down" slot="suffix"></bq-icon>
-              </bq-button>
-              <bq-option-list>
-                <bq-option value="users">
-                  <bq-icon name="users" slot="prefix"></bq-icon>
-                  <span>Users</span>
-                </bq-option>
-                <bq-option value="profile">
-                  <bq-icon name="user" slot="prefix"></bq-icon>
-                  <span>My profile</span>
-                </bq-option>
-                <bq-option value="dashboard">
-                  <bq-icon name="sliders" slot="prefix"></bq-icon>
-                  <span>Dashboard</span>
-                </bq-option>
-              </bq-option-list>
-            </bq-dropdown>
-        
-            <bq-dropdown placement="bottom-end">
-              <bq-button slot="trigger">
-                Bottom end
-                <bq-icon name="caret-down" slot="suffix"></bq-icon>
-              </bq-button>
-              <bq-option-list>
-                <bq-option value="users">
-                  <bq-icon name="users" slot="prefix"></bq-icon>
-                  <span>Users</span>
-                </bq-option>
-                <bq-option value="profile">
-                  <bq-icon name="user" slot="prefix"></bq-icon>
-                  <span>My profile</span>
-                </bq-option>
-                <bq-option value="dashboard">
-                  <bq-icon name="sliders" slot="prefix"></bq-icon>
-                  <span>Dashboard</span>
-                </bq-option>
-              </bq-option-list>
-            </bq-dropdown>
+        <bq-dropdown placement="bottom-start">
+          <bq-button slot="trigger">
+            Bottom start
+            <bq-icon name="caret-down" slot="suffix"></bq-icon>
+          </bq-button>
+          <bq-option-list>
+            <bq-option value="users">
+              <bq-icon name="users" slot="prefix"></bq-icon>
+              <span>Users</span>
+            </bq-option>
+            <bq-option value="profile">
+              <bq-icon name="user" slot="prefix"></bq-icon>
+              <span>My profile</span>
+            </bq-option>
+            <bq-option value="dashboard">
+              <bq-icon name="sliders" slot="prefix"></bq-icon>
+              <span>Dashboard</span>
+            </bq-option>
+          </bq-option-list>
+        </bq-dropdown>
+
+        <bq-dropdown placement="bottom-end">
+          <bq-button slot="trigger">
+            Bottom end
+            <bq-icon name="caret-down" slot="suffix"></bq-icon>
+          </bq-button>
+          <bq-option-list>
+            <bq-option value="users">
+              <bq-icon name="users" slot="prefix"></bq-icon>
+              <span>Users</span>
+            </bq-option>
+            <bq-option value="profile">
+              <bq-icon name="user" slot="prefix"></bq-icon>
+              <span>My profile</span>
+            </bq-option>
+            <bq-option value="dashboard">
+              <bq-icon name="sliders" slot="prefix"></bq-icon>
+              <span>Dashboard</span>
+            </bq-option>
+          </bq-option-list>
+        </bq-dropdown>
       `,
     })
     export class AppComponent {}
@@ -740,50 +740,50 @@ Use a custom trigger when the dropdown needs a more specific visual entry point,
       standalone: true,
       imports: [BqDropdown, BqButton, BqIcon, BqOptionList, BqOption, BqAvatar],
       template: `
-            <bq-dropdown>
-              <bq-button appearance="secondary" size="medium" type="button" variant="standard" only-icon slot="trigger">
-                <bq-icon name="dots-three-vertical"></bq-icon>
-              </bq-button>
-              <bq-option-list>
-                <bq-option value="edit">
-                  <bq-icon name="pencil-simple" slot="prefix"></bq-icon>
-                  <span>Edit</span>
-                </bq-option>
-                <bq-option value="duplicate">
-                  <bq-icon name="copy" slot="prefix"></bq-icon>
-                  <span>Duplicate</span>
-                </bq-option>
-                <bq-option value="archive">
-                  <bq-icon name="archive" slot="prefix"></bq-icon>
-                  <span>Archive</span>
-                </bq-option>
-              </bq-option-list>
-            </bq-dropdown>
-        
-            <bq-dropdown>
-              <bq-button appearance="text" border="full" size="small" only-icon slot="trigger">
-                <bq-avatar
-                  alt-text="User profile"
-                  image="https://images.unsplash.com/photo-1524593689594-aae2f26b75ab?auto=format&fit=crop&w=1000&q=80"
-                  initials="BQ"
-                  label="User profile menu"
-                ></bq-avatar>
-              </bq-button>
-              <bq-option-list>
-                <bq-option value="profile">
-                  <bq-icon name="user" slot="prefix"></bq-icon>
-                  <span>My profile</span>
-                </bq-option>
-                <bq-option value="settings">
-                  <bq-icon name="gear" slot="prefix"></bq-icon>
-                  <span>Settings</span>
-                </bq-option>
-                <bq-option value="logout">
-                  <span>Logout</span>
-                  <bq-icon name="sign-out" slot="suffix"></bq-icon>
-                </bq-option>
-              </bq-option-list>
-            </bq-dropdown>
+        <bq-dropdown>
+          <bq-button appearance="secondary" size="medium" type="button" variant="standard" only-icon slot="trigger">
+            <bq-icon name="dots-three-vertical"></bq-icon>
+          </bq-button>
+          <bq-option-list>
+            <bq-option value="edit">
+              <bq-icon name="pencil-simple" slot="prefix"></bq-icon>
+              <span>Edit</span>
+            </bq-option>
+            <bq-option value="duplicate">
+              <bq-icon name="copy" slot="prefix"></bq-icon>
+              <span>Duplicate</span>
+            </bq-option>
+            <bq-option value="archive">
+              <bq-icon name="archive" slot="prefix"></bq-icon>
+              <span>Archive</span>
+            </bq-option>
+          </bq-option-list>
+        </bq-dropdown>
+
+        <bq-dropdown>
+          <bq-button appearance="text" border="full" size="small" only-icon slot="trigger">
+            <bq-avatar
+              alt-text="User profile"
+              image="https://images.unsplash.com/photo-1524593689594-aae2f26b75ab?auto=format&fit=crop&w=1000&q=80"
+              initials="BQ"
+              label="User profile menu"
+              ></bq-avatar>
+            </bq-button>
+            <bq-option-list>
+              <bq-option value="profile">
+                <bq-icon name="user" slot="prefix"></bq-icon>
+                <span>My profile</span>
+              </bq-option>
+              <bq-option value="settings">
+                <bq-icon name="gear" slot="prefix"></bq-icon>
+                <span>Settings</span>
+              </bq-option>
+              <bq-option value="logout">
+                <span>Logout</span>
+                <bq-icon name="sign-out" slot="suffix"></bq-icon>
+              </bq-option>
+            </bq-option-list>
+          </bq-dropdown>
       `,
     })
     export class AppComponent {}
@@ -957,34 +957,34 @@ Use `keep-open-on-select` when the dropdown should stay open after a selection i
       standalone: true,
       imports: [BqDropdown, BqButton, BqIcon, BqOptionList, BqOption],
       template: `
-            <bq-dropdown keep-open-on-select>
-              <bq-button slot="trigger">
-                Dropdown
-                <bq-icon name="caret-down" slot="suffix"></bq-icon>
-              </bq-button>
-              <bq-option-list>
-                <bq-option value="users">
-                  <bq-icon name="users" slot="prefix"></bq-icon>
-                  <span>Users</span>
-                </bq-option>
-                <bq-option value="profile">
-                  <bq-icon name="user" slot="prefix"></bq-icon>
-                  <span>My profile</span>
-                </bq-option>
-                <bq-option value="dashboard">
-                  <bq-icon name="sliders" slot="prefix"></bq-icon>
-                  <span>Dashboard</span>
-                </bq-option>
-                <bq-option value="settings">
-                  <bq-icon name="gear" slot="prefix"></bq-icon>
-                  <span>Settings</span>
-                </bq-option>
-                <bq-option value="logout">
-                  <span>Logout</span>
-                  <bq-icon name="sign-out" slot="suffix"></bq-icon>
-                </bq-option>
-              </bq-option-list>
-            </bq-dropdown>
+        <bq-dropdown keep-open-on-select>
+          <bq-button slot="trigger">
+            Dropdown
+            <bq-icon name="caret-down" slot="suffix"></bq-icon>
+          </bq-button>
+          <bq-option-list>
+            <bq-option value="users">
+              <bq-icon name="users" slot="prefix"></bq-icon>
+              <span>Users</span>
+            </bq-option>
+            <bq-option value="profile">
+              <bq-icon name="user" slot="prefix"></bq-icon>
+              <span>My profile</span>
+            </bq-option>
+            <bq-option value="dashboard">
+              <bq-icon name="sliders" slot="prefix"></bq-icon>
+              <span>Dashboard</span>
+            </bq-option>
+            <bq-option value="settings">
+              <bq-icon name="gear" slot="prefix"></bq-icon>
+              <span>Settings</span>
+            </bq-option>
+            <bq-option value="logout">
+              <span>Logout</span>
+              <bq-icon name="sign-out" slot="suffix"></bq-icon>
+            </bq-option>
+          </bq-option-list>
+        </bq-dropdown>
       `,
     })
     export class AppComponent {}
@@ -1126,29 +1126,29 @@ Use option groups when you need to categorize and group options under specific h
       standalone: true,
       imports: [BqDropdown, BqButton, BqIcon, BqOptionList, BqOptionGroup, BqOption],
       template: `
-            <bq-dropdown>
-              <bq-button slot="trigger">
-                Dropdown
-                <bq-icon name="caret-down" slot="suffix"></bq-icon>
-              </bq-button>
-              <bq-option-list>
-                <bq-option-group>
-                  <span slot="header-label">Configuration</span>
-                  <bq-option value="users">
-                    <bq-icon name="users" slot="prefix"></bq-icon>
-                    <span>Users</span>
-                  </bq-option>
-                  <bq-option value="profile">
-                    <bq-icon name="user" slot="prefix"></bq-icon>
-                    <span>My profile</span>
-                  </bq-option>
-                  <bq-option value="settings">
-                    <bq-icon name="gear" slot="prefix"></bq-icon>
-                    <span>Settings</span>
-                  </bq-option>
-                </bq-option-group>
-              </bq-option-list>
-            </bq-dropdown>
+        <bq-dropdown>
+          <bq-button slot="trigger">
+            Dropdown
+            <bq-icon name="caret-down" slot="suffix"></bq-icon>
+          </bq-button>
+          <bq-option-list>
+            <bq-option-group>
+              <span slot="header-label">Configuration</span>
+              <bq-option value="users">
+                <bq-icon name="users" slot="prefix"></bq-icon>
+                <span>Users</span>
+              </bq-option>
+              <bq-option value="profile">
+                <bq-icon name="user" slot="prefix"></bq-icon>
+                <span>My profile</span>
+              </bq-option>
+              <bq-option value="settings">
+                <bq-icon name="gear" slot="prefix"></bq-icon>
+                <span>Settings</span>
+              </bq-option>
+            </bq-option-group>
+          </bq-option-list>
+        </bq-dropdown>
       `,
     })
     export class AppComponent {}
@@ -1249,17 +1249,17 @@ Use `same-width` when the panel should match the trigger width. Use `panel-heigh
       standalone: true,
       imports: [BqDropdown, BqButton, BqIcon, BqOptionList, BqOption],
       template: `
-            <bq-dropdown same-width panel-height="16rem">
-              <bq-button slot="trigger">
-                Choose a region
-                <bq-icon name="caret-down" slot="suffix"></bq-icon>
-              </bq-button>
-              <bq-option-list>
-                <bq-option value="emea"><span>Europe, Middle East &amp; Africa</span></bq-option>
-                <bq-option value="amer"><span>Americas</span></bq-option>
-                <bq-option value="apac"><span>Asia &amp; Pacific</span></bq-option>
-              </bq-option-list>
-            </bq-dropdown>
+        <bq-dropdown same-width panel-height="16rem">
+          <bq-button slot="trigger">
+            Choose a region
+            <bq-icon name="caret-down" slot="suffix"></bq-icon>
+          </bq-button>
+          <bq-option-list>
+            <bq-option value="emea"><span>Europe, Middle East &amp; Africa</span></bq-option>
+            <bq-option value="amer"><span>Americas</span></bq-option>
+            <bq-option value="apac"><span>Asia &amp; Pacific</span></bq-option>
+          </bq-option-list>
+        </bq-dropdown>
       `,
     })
     export class AppComponent {}

--- a/apps/beeq-docs/components/dropdown.mdx
+++ b/apps/beeq-docs/components/dropdown.mdx
@@ -216,43 +216,50 @@ The trigger can be any appropriate interactive element, but in most cases a `bq-
     </BqDropdown>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqButton, BqDropdown, BqIcon, BqOption, BqOptionList } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-
-    <bq-dropdown>
-      <bq-button slot="trigger">
-        Dropdown
-        <bq-icon name="caret-down" slot="suffix"></bq-icon>
-      </bq-button>
-
-      <bq-option-list>
-        <bq-option value="users">
-          <bq-icon name="users" slot="prefix"></bq-icon>
-          <span>Users</span>
-        </bq-option>
-
-        <bq-option value="profile">
-          <bq-icon name="user" slot="prefix"></bq-icon>
-          <span>My profile</span>
-        </bq-option>
-
-        <bq-option value="dashboard">
-          <bq-icon name="sliders" slot="prefix"></bq-icon>
-          <span>Dashboard</span>
-        </bq-option>
-
-        <bq-option value="settings">
-          <bq-icon name="gear" slot="prefix"></bq-icon>
-          <span>Settings</span>
-        </bq-option>
-
-        <bq-option value="logout">
-          <span>Logout</span>
-          <bq-icon name="sign-out" slot="suffix"></bq-icon>
-        </bq-option>
-      </bq-option-list>
-    </bq-dropdown>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqDropdown, BqButton, BqIcon, BqOptionList, BqOption } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqDropdown, BqButton, BqIcon, BqOptionList, BqOption],
+      template: `
+        <bq-dropdown>
+              <bq-button slot="trigger">
+                Dropdown
+                <bq-icon name="caret-down" slot="suffix"></bq-icon>
+              </bq-button>
+        
+              <bq-option-list>
+                <bq-option value="users">
+                  <bq-icon name="users" slot="prefix"></bq-icon>
+                  <span>Users</span>
+                </bq-option>
+        
+                <bq-option value="profile">
+                  <bq-icon name="user" slot="prefix"></bq-icon>
+                  <span>My profile</span>
+                </bq-option>
+        
+                <bq-option value="dashboard">
+                  <bq-icon name="sliders" slot="prefix"></bq-icon>
+                  <span>Dashboard</span>
+                </bq-option>
+        
+                <bq-option value="settings">
+                  <bq-icon name="gear" slot="prefix"></bq-icon>
+                  <span>Settings</span>
+                </bq-option>
+        
+                <bq-option value="logout">
+                  <span>Logout</span>
+                  <bq-icon name="sign-out" slot="suffix"></bq-icon>
+                </bq-option>
+              </bq-option-list>
+            </bq-dropdown>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -452,48 +459,58 @@ Use the `placement` attribute when you need fine-grained control over the panel 
     </BqDropdown>
     ```
 
-    ```html Angular icon="angular" expandable
-    <bq-dropdown placement="bottom-start">
-      <bq-button slot="trigger">
-        Bottom start
-        <bq-icon name="caret-down" slot="suffix"></bq-icon>
-      </bq-button>
-      <bq-option-list>
-        <bq-option value="users">
-          <bq-icon name="users" slot="prefix"></bq-icon>
-          <span>Users</span>
-        </bq-option>
-        <bq-option value="profile">
-          <bq-icon name="user" slot="prefix"></bq-icon>
-          <span>My profile</span>
-        </bq-option>
-        <bq-option value="dashboard">
-          <bq-icon name="sliders" slot="prefix"></bq-icon>
-          <span>Dashboard</span>
-        </bq-option>
-      </bq-option-list>
-    </bq-dropdown>
-
-    <bq-dropdown placement="bottom-end">
-      <bq-button slot="trigger">
-        Bottom end
-        <bq-icon name="caret-down" slot="suffix"></bq-icon>
-      </bq-button>
-      <bq-option-list>
-        <bq-option value="users">
-          <bq-icon name="users" slot="prefix"></bq-icon>
-          <span>Users</span>
-        </bq-option>
-        <bq-option value="profile">
-          <bq-icon name="user" slot="prefix"></bq-icon>
-          <span>My profile</span>
-        </bq-option>
-        <bq-option value="dashboard">
-          <bq-icon name="sliders" slot="prefix"></bq-icon>
-          <span>Dashboard</span>
-        </bq-option>
-      </bq-option-list>
-    </bq-dropdown>
+    ```ts Angular icon="angular" expandable
+    import { Component } from "@angular/core";
+    import { BqDropdown, BqButton, BqIcon, BqOptionList, BqOption } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqDropdown, BqButton, BqIcon, BqOptionList, BqOption],
+      template: `
+            <bq-dropdown placement="bottom-start">
+              <bq-button slot="trigger">
+                Bottom start
+                <bq-icon name="caret-down" slot="suffix"></bq-icon>
+              </bq-button>
+              <bq-option-list>
+                <bq-option value="users">
+                  <bq-icon name="users" slot="prefix"></bq-icon>
+                  <span>Users</span>
+                </bq-option>
+                <bq-option value="profile">
+                  <bq-icon name="user" slot="prefix"></bq-icon>
+                  <span>My profile</span>
+                </bq-option>
+                <bq-option value="dashboard">
+                  <bq-icon name="sliders" slot="prefix"></bq-icon>
+                  <span>Dashboard</span>
+                </bq-option>
+              </bq-option-list>
+            </bq-dropdown>
+        
+            <bq-dropdown placement="bottom-end">
+              <bq-button slot="trigger">
+                Bottom end
+                <bq-icon name="caret-down" slot="suffix"></bq-icon>
+              </bq-button>
+              <bq-option-list>
+                <bq-option value="users">
+                  <bq-icon name="users" slot="prefix"></bq-icon>
+                  <span>Users</span>
+                </bq-option>
+                <bq-option value="profile">
+                  <bq-icon name="user" slot="prefix"></bq-icon>
+                  <span>My profile</span>
+                </bq-option>
+                <bq-option value="dashboard">
+                  <bq-icon name="sliders" slot="prefix"></bq-icon>
+                  <span>Dashboard</span>
+                </bq-option>
+              </bq-option-list>
+            </bq-dropdown>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs" expandable
@@ -715,51 +732,61 @@ Use a custom trigger when the dropdown needs a more specific visual entry point,
     </BqDropdown>
     ```
 
-    ```html Angular icon="angular" expandable
-    <bq-dropdown>
-      <bq-button appearance="secondary" size="medium" type="button" variant="standard" only-icon slot="trigger">
-        <bq-icon name="dots-three-vertical"></bq-icon>
-      </bq-button>
-      <bq-option-list>
-        <bq-option value="edit">
-          <bq-icon name="pencil-simple" slot="prefix"></bq-icon>
-          <span>Edit</span>
-        </bq-option>
-        <bq-option value="duplicate">
-          <bq-icon name="copy" slot="prefix"></bq-icon>
-          <span>Duplicate</span>
-        </bq-option>
-        <bq-option value="archive">
-          <bq-icon name="archive" slot="prefix"></bq-icon>
-          <span>Archive</span>
-        </bq-option>
-      </bq-option-list>
-    </bq-dropdown>
-
-    <bq-dropdown>
-      <bq-button appearance="text" border="full" size="small" only-icon slot="trigger">
-        <bq-avatar
-          alt-text="User profile"
-          image="https://images.unsplash.com/photo-1524593689594-aae2f26b75ab?auto=format&fit=crop&w=1000&q=80"
-          initials="BQ"
-          label="User profile menu"
-        ></bq-avatar>
-      </bq-button>
-      <bq-option-list>
-        <bq-option value="profile">
-          <bq-icon name="user" slot="prefix"></bq-icon>
-          <span>My profile</span>
-        </bq-option>
-        <bq-option value="settings">
-          <bq-icon name="gear" slot="prefix"></bq-icon>
-          <span>Settings</span>
-        </bq-option>
-        <bq-option value="logout">
-          <span>Logout</span>
-          <bq-icon name="sign-out" slot="suffix"></bq-icon>
-        </bq-option>
-      </bq-option-list>
-    </bq-dropdown>
+    ```ts Angular icon="angular" expandable
+    import { Component } from "@angular/core";
+    import { BqDropdown, BqButton, BqIcon, BqOptionList, BqOption, BqAvatar } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqDropdown, BqButton, BqIcon, BqOptionList, BqOption, BqAvatar],
+      template: `
+            <bq-dropdown>
+              <bq-button appearance="secondary" size="medium" type="button" variant="standard" only-icon slot="trigger">
+                <bq-icon name="dots-three-vertical"></bq-icon>
+              </bq-button>
+              <bq-option-list>
+                <bq-option value="edit">
+                  <bq-icon name="pencil-simple" slot="prefix"></bq-icon>
+                  <span>Edit</span>
+                </bq-option>
+                <bq-option value="duplicate">
+                  <bq-icon name="copy" slot="prefix"></bq-icon>
+                  <span>Duplicate</span>
+                </bq-option>
+                <bq-option value="archive">
+                  <bq-icon name="archive" slot="prefix"></bq-icon>
+                  <span>Archive</span>
+                </bq-option>
+              </bq-option-list>
+            </bq-dropdown>
+        
+            <bq-dropdown>
+              <bq-button appearance="text" border="full" size="small" only-icon slot="trigger">
+                <bq-avatar
+                  alt-text="User profile"
+                  image="https://images.unsplash.com/photo-1524593689594-aae2f26b75ab?auto=format&fit=crop&w=1000&q=80"
+                  initials="BQ"
+                  label="User profile menu"
+                ></bq-avatar>
+              </bq-button>
+              <bq-option-list>
+                <bq-option value="profile">
+                  <bq-icon name="user" slot="prefix"></bq-icon>
+                  <span>My profile</span>
+                </bq-option>
+                <bq-option value="settings">
+                  <bq-icon name="gear" slot="prefix"></bq-icon>
+                  <span>Settings</span>
+                </bq-option>
+                <bq-option value="logout">
+                  <span>Logout</span>
+                  <bq-icon name="sign-out" slot="suffix"></bq-icon>
+                </bq-option>
+              </bq-option-list>
+            </bq-dropdown>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs" expandable
@@ -922,35 +949,45 @@ Use `keep-open-on-select` when the dropdown should stay open after a selection i
     </BqDropdown>
     ```
 
-    ```html Angular icon="angular"
-    <bq-dropdown keep-open-on-select>
-      <bq-button slot="trigger">
-        Dropdown
-        <bq-icon name="caret-down" slot="suffix"></bq-icon>
-      </bq-button>
-      <bq-option-list>
-        <bq-option value="users">
-          <bq-icon name="users" slot="prefix"></bq-icon>
-          <span>Users</span>
-        </bq-option>
-        <bq-option value="profile">
-          <bq-icon name="user" slot="prefix"></bq-icon>
-          <span>My profile</span>
-        </bq-option>
-        <bq-option value="dashboard">
-          <bq-icon name="sliders" slot="prefix"></bq-icon>
-          <span>Dashboard</span>
-        </bq-option>
-        <bq-option value="settings">
-          <bq-icon name="gear" slot="prefix"></bq-icon>
-          <span>Settings</span>
-        </bq-option>
-        <bq-option value="logout">
-          <span>Logout</span>
-          <bq-icon name="sign-out" slot="suffix"></bq-icon>
-        </bq-option>
-      </bq-option-list>
-    </bq-dropdown>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqDropdown, BqButton, BqIcon, BqOptionList, BqOption } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqDropdown, BqButton, BqIcon, BqOptionList, BqOption],
+      template: `
+            <bq-dropdown keep-open-on-select>
+              <bq-button slot="trigger">
+                Dropdown
+                <bq-icon name="caret-down" slot="suffix"></bq-icon>
+              </bq-button>
+              <bq-option-list>
+                <bq-option value="users">
+                  <bq-icon name="users" slot="prefix"></bq-icon>
+                  <span>Users</span>
+                </bq-option>
+                <bq-option value="profile">
+                  <bq-icon name="user" slot="prefix"></bq-icon>
+                  <span>My profile</span>
+                </bq-option>
+                <bq-option value="dashboard">
+                  <bq-icon name="sliders" slot="prefix"></bq-icon>
+                  <span>Dashboard</span>
+                </bq-option>
+                <bq-option value="settings">
+                  <bq-icon name="gear" slot="prefix"></bq-icon>
+                  <span>Settings</span>
+                </bq-option>
+                <bq-option value="logout">
+                  <span>Logout</span>
+                  <bq-icon name="sign-out" slot="suffix"></bq-icon>
+                </bq-option>
+              </bq-option-list>
+            </bq-dropdown>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs" expandable
@@ -1081,30 +1118,40 @@ Use option groups when you need to categorize and group options under specific h
     </BqDropdown>
     ```
 
-    ```html Angular icon="angular" expandable
-    <bq-dropdown>
-      <bq-button slot="trigger">
-        Dropdown
-        <bq-icon name="caret-down" slot="suffix"></bq-icon>
-      </bq-button>
-      <bq-option-list>
-        <bq-option-group>
-          <span slot="header-label">Configuration</span>
-          <bq-option value="users">
-            <bq-icon name="users" slot="prefix"></bq-icon>
-            <span>Users</span>
-          </bq-option>
-          <bq-option value="profile">
-            <bq-icon name="user" slot="prefix"></bq-icon>
-            <span>My profile</span>
-          </bq-option>
-          <bq-option value="settings">
-            <bq-icon name="gear" slot="prefix"></bq-icon>
-            <span>Settings</span>
-          </bq-option>
-        </bq-option-group>
-      </bq-option-list>
-    </bq-dropdown>
+    ```ts Angular icon="angular" expandable
+    import { Component } from "@angular/core";
+    import { BqDropdown, BqButton, BqIcon, BqOptionList, BqOptionGroup, BqOption } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqDropdown, BqButton, BqIcon, BqOptionList, BqOptionGroup, BqOption],
+      template: `
+            <bq-dropdown>
+              <bq-button slot="trigger">
+                Dropdown
+                <bq-icon name="caret-down" slot="suffix"></bq-icon>
+              </bq-button>
+              <bq-option-list>
+                <bq-option-group>
+                  <span slot="header-label">Configuration</span>
+                  <bq-option value="users">
+                    <bq-icon name="users" slot="prefix"></bq-icon>
+                    <span>Users</span>
+                  </bq-option>
+                  <bq-option value="profile">
+                    <bq-icon name="user" slot="prefix"></bq-icon>
+                    <span>My profile</span>
+                  </bq-option>
+                  <bq-option value="settings">
+                    <bq-icon name="gear" slot="prefix"></bq-icon>
+                    <span>Settings</span>
+                  </bq-option>
+                </bq-option-group>
+              </bq-option-list>
+            </bq-dropdown>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs" expandable
@@ -1194,18 +1241,28 @@ Use `same-width` when the panel should match the trigger width. Use `panel-heigh
     </BqDropdown>
     ```
 
-    ```html Angular icon="angular"
-    <bq-dropdown same-width panel-height="16rem">
-      <bq-button slot="trigger">
-        Choose a region
-        <bq-icon name="caret-down" slot="suffix"></bq-icon>
-      </bq-button>
-      <bq-option-list>
-        <bq-option value="emea"><span>Europe, Middle East &amp; Africa</span></bq-option>
-        <bq-option value="amer"><span>Americas</span></bq-option>
-        <bq-option value="apac"><span>Asia &amp; Pacific</span></bq-option>
-      </bq-option-list>
-    </bq-dropdown>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqDropdown, BqButton, BqIcon, BqOptionList, BqOption } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqDropdown, BqButton, BqIcon, BqOptionList, BqOption],
+      template: `
+            <bq-dropdown same-width panel-height="16rem">
+              <bq-button slot="trigger">
+                Choose a region
+                <bq-icon name="caret-down" slot="suffix"></bq-icon>
+              </bq-button>
+              <bq-option-list>
+                <bq-option value="emea"><span>Europe, Middle East &amp; Africa</span></bq-option>
+                <bq-option value="amer"><span>Americas</span></bq-option>
+                <bq-option value="apac"><span>Asia &amp; Pacific</span></bq-option>
+              </bq-option-list>
+            </bq-dropdown>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/empty-state.mdx
+++ b/apps/beeq-docs/components/empty-state.mdx
@@ -119,11 +119,18 @@ Use the default variant when you want the cleanest possible presentation and the
     <BqEmptyState>Title</BqEmptyState>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqEmptyState } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-
-    <bq-empty-state>Title</bq-empty-state>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqEmptyState } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqEmptyState],
+      template: `
+        <bq-empty-state>Title</bq-empty-state>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -198,18 +205,28 @@ Use body content when the empty state needs a short explanation or a little more
     </BqEmptyState>
     ```
 
-    ```html Angular icon="angular"
-    <bq-empty-state>
-      Title
-      <span slot="body">Description</span>
-    </bq-empty-state>
-    <bq-empty-state>
-      Title
-      <span slot="body">
-        Description
-        <a class="bq-link" href="https://example.com">Link</a>
-      </span>
-    </bq-empty-state>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqEmptyState } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqEmptyState],
+      template: `
+            <bq-empty-state>
+              Title
+              <span slot="body">Description</span>
+            </bq-empty-state>
+            <bq-empty-state>
+              Title
+              <span slot="body">
+                Description
+                <a class="bq-link" href="https://example.com">Link</a>
+              </span>
+            </bq-empty-state>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -351,38 +368,48 @@ Use the footer when the empty state should help people recover immediately. Pref
     </>
     ```
 
-    ```html Angular icon="angular"
-    <bq-empty-state size="medium">
-      Title
-      <span slot="body">
-        Description
-        <a class="bq-link" href="https://example.com">Link</a>
-      </span>
-      <div slot="footer">
-        <bq-button appearance="primary" size="small">Button</bq-button>
-      </div>
-    </bq-empty-state>
-    <bq-empty-state size="medium">
-      Title
-      <span slot="body">
-        Description
-        <a class="bq-link" href="https://example.com">Link</a>
-      </span>
-      <div slot="footer">
-        <bq-button size="small" variant="ghost">Button</bq-button>
-      </div>
-    </bq-empty-state>
-    <bq-empty-state size="medium">
-      Title
-      <span slot="body">
-        Description
-        <a class="bq-link" href="https://example.com">Link</a>
-      </span>
-      <div slot="footer">
-        <bq-button size="small" variant="ghost">Button</bq-button>
-        <bq-button appearance="primary" size="small">Button</bq-button>
-      </div>
-    </bq-empty-state>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqEmptyState, BqButton } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqEmptyState, BqButton],
+      template: `
+            <bq-empty-state size="medium">
+              Title
+              <span slot="body">
+                Description
+                <a class="bq-link" href="https://example.com">Link</a>
+              </span>
+              <div slot="footer">
+                <bq-button appearance="primary" size="small">Button</bq-button>
+              </div>
+            </bq-empty-state>
+            <bq-empty-state size="medium">
+              Title
+              <span slot="body">
+                Description
+                <a class="bq-link" href="https://example.com">Link</a>
+              </span>
+              <div slot="footer">
+                <bq-button size="small" variant="ghost">Button</bq-button>
+              </div>
+            </bq-empty-state>
+            <bq-empty-state size="medium">
+              Title
+              <span slot="body">
+                Description
+                <a class="bq-link" href="https://example.com">Link</a>
+              </span>
+              <div slot="footer">
+                <bq-button size="small" variant="ghost">Button</bq-button>
+                <bq-button appearance="primary" size="small">Button</bq-button>
+              </div>
+            </bq-empty-state>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/empty-state.mdx
+++ b/apps/beeq-docs/components/empty-state.mdx
@@ -213,17 +213,17 @@ Use body content when the empty state needs a short explanation or a little more
       standalone: true,
       imports: [BqEmptyState],
       template: `
-            <bq-empty-state>
-              Title
-              <span slot="body">Description</span>
-            </bq-empty-state>
-            <bq-empty-state>
-              Title
-              <span slot="body">
-                Description
-                <a class="bq-link" href="https://example.com">Link</a>
-              </span>
-            </bq-empty-state>
+        <bq-empty-state>
+          Title
+          <span slot="body">Description</span>
+        </bq-empty-state>
+        <bq-empty-state>
+          Title
+          <span slot="body">
+            Description
+            <a class="bq-link" href="https://example.com">Link</a>
+          </span>
+        </bq-empty-state>
       `,
     })
     export class AppComponent {}
@@ -376,37 +376,37 @@ Use the footer when the empty state should help people recover immediately. Pref
       standalone: true,
       imports: [BqEmptyState, BqButton],
       template: `
-            <bq-empty-state size="medium">
-              Title
-              <span slot="body">
-                Description
-                <a class="bq-link" href="https://example.com">Link</a>
-              </span>
-              <div slot="footer">
-                <bq-button appearance="primary" size="small">Button</bq-button>
-              </div>
-            </bq-empty-state>
-            <bq-empty-state size="medium">
-              Title
-              <span slot="body">
-                Description
-                <a class="bq-link" href="https://example.com">Link</a>
-              </span>
-              <div slot="footer">
-                <bq-button size="small" variant="ghost">Button</bq-button>
-              </div>
-            </bq-empty-state>
-            <bq-empty-state size="medium">
-              Title
-              <span slot="body">
-                Description
-                <a class="bq-link" href="https://example.com">Link</a>
-              </span>
-              <div slot="footer">
-                <bq-button size="small" variant="ghost">Button</bq-button>
-                <bq-button appearance="primary" size="small">Button</bq-button>
-              </div>
-            </bq-empty-state>
+        <bq-empty-state size="medium">
+          Title
+          <span slot="body">
+            Description
+            <a class="bq-link" href="https://example.com">Link</a>
+          </span>
+          <div slot="footer">
+            <bq-button appearance="primary" size="small">Button</bq-button>
+          </div>
+        </bq-empty-state>
+        <bq-empty-state size="medium">
+          Title
+          <span slot="body">
+            Description
+            <a class="bq-link" href="https://example.com">Link</a>
+          </span>
+          <div slot="footer">
+            <bq-button size="small" variant="ghost">Button</bq-button>
+          </div>
+        </bq-empty-state>
+        <bq-empty-state size="medium">
+          Title
+          <span slot="body">
+            Description
+            <a class="bq-link" href="https://example.com">Link</a>
+          </span>
+          <div slot="footer">
+            <bq-button size="small" variant="ghost">Button</bq-button>
+            <bq-button appearance="primary" size="small">Button</bq-button>
+          </div>
+        </bq-empty-state>
       `,
     })
     export class AppComponent {}

--- a/apps/beeq-docs/components/empty-state.mdx
+++ b/apps/beeq-docs/components/empty-state.mdx
@@ -122,6 +122,7 @@ Use the default variant when you want the cleanest possible presentation and the
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqEmptyState } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -208,6 +209,7 @@ Use body content when the empty state needs a short explanation or a little more
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqEmptyState } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -371,6 +373,7 @@ Use the footer when the empty state should help people recover immediately. Pref
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqEmptyState, BqButton } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,

--- a/apps/beeq-docs/components/icon.mdx
+++ b/apps/beeq-docs/components/icon.mdx
@@ -175,10 +175,10 @@ Adjust `size` when the icon needs to match the surrounding text or visual emphas
       standalone: true,
       imports: [BqIcon],
       template: `
-            <bq-icon name="bell-ringing" size="16"></bq-icon>
-            <bq-icon name="bell-ringing"></bq-icon>
-            <bq-icon name="bell-ringing" size="32"></bq-icon>
-            <bq-icon name="bell-ringing" size="40"></bq-icon>
+        <bq-icon name="bell-ringing" size="16"></bq-icon>
+        <bq-icon name="bell-ringing"></bq-icon>
+        <bq-icon name="bell-ringing" size="32"></bq-icon>
+        <bq-icon name="bell-ringing" size="40"></bq-icon>
       `,
     })
     export class AppComponent {}
@@ -236,10 +236,10 @@ An icon inherits color from its parent by default, but you can also assign a tok
       standalone: true,
       imports: [BqIcon],
       template: `
-            <bq-icon name="info"></bq-icon>
-            <bq-icon name="star" color="text--success"></bq-icon>
-            <bq-icon name="warning-circle" color="text--warning"></bq-icon>
-            <bq-icon name="x-circle" color="text--danger"></bq-icon>
+        <bq-icon name="info"></bq-icon>
+        <bq-icon name="star" color="text--success"></bq-icon>
+        <bq-icon name="warning-circle" color="text--warning"></bq-icon>
+        <bq-icon name="x-circle" color="text--danger"></bq-icon>
       `,
     })
     export class AppComponent {}
@@ -309,12 +309,12 @@ Use icon-name suffixes like `-thin`, `-light`, `-bold`, `-duotone`, and `-fill` 
       standalone: true,
       imports: [BqIcon],
       template: `
-            <bq-icon name="heart"></bq-icon>
-            <bq-icon name="heart-thin"></bq-icon>
-            <bq-icon name="heart-light"></bq-icon>
-            <bq-icon name="heart-bold"></bq-icon>
-            <bq-icon name="heart-duotone"></bq-icon>
-            <bq-icon name="heart-fill"></bq-icon>
+        <bq-icon name="heart"></bq-icon>
+        <bq-icon name="heart-thin"></bq-icon>
+        <bq-icon name="heart-light"></bq-icon>
+        <bq-icon name="heart-bold"></bq-icon>
+        <bq-icon name="heart-duotone"></bq-icon>
+        <bq-icon name="heart-fill"></bq-icon>
       `,
     })
     export class AppComponent {}
@@ -377,11 +377,11 @@ Use `src` when you want to load a custom icon from a local or CORS-enabled endpo
       standalone: true,
       imports: [BqIcon],
       template: `
-            <bq-icon
-              src="https://storybook.beeq.design/assets/wallet.svg"
-              label="Wallet icon"
-              size="256"
-            ></bq-icon>
+        <bq-icon
+          src="https://storybook.beeq.design/assets/wallet.svg"
+          label="Wallet icon"
+          size="256"
+          ></bq-icon>
       `,
     })
     export class AppComponent {}

--- a/apps/beeq-docs/components/icon.mdx
+++ b/apps/beeq-docs/components/icon.mdx
@@ -108,11 +108,18 @@ Use the default icon when you need a simple visual cue inside navigation, action
     <BqIcon name="bell-ringing" />
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqIcon } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-
-    <bq-icon name="bell-ringing"></bq-icon>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqIcon } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqIcon],
+      template: `
+        <bq-icon name="bell-ringing"></bq-icon>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -160,11 +167,21 @@ Adjust `size` when the icon needs to match the surrounding text or visual emphas
     </>
     ```
 
-    ```html Angular icon="angular"
-    <bq-icon name="bell-ringing" size="16"></bq-icon>
-    <bq-icon name="bell-ringing"></bq-icon>
-    <bq-icon name="bell-ringing" size="32"></bq-icon>
-    <bq-icon name="bell-ringing" size="40"></bq-icon>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqIcon } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqIcon],
+      template: `
+            <bq-icon name="bell-ringing" size="16"></bq-icon>
+            <bq-icon name="bell-ringing"></bq-icon>
+            <bq-icon name="bell-ringing" size="32"></bq-icon>
+            <bq-icon name="bell-ringing" size="40"></bq-icon>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -211,11 +228,21 @@ An icon inherits color from its parent by default, but you can also assign a tok
     </>
     ```
 
-    ```html Angular icon="angular"
-    <bq-icon name="info"></bq-icon>
-    <bq-icon name="star" color="text--success"></bq-icon>
-    <bq-icon name="warning-circle" color="text--warning"></bq-icon>
-    <bq-icon name="x-circle" color="text--danger"></bq-icon>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqIcon } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqIcon],
+      template: `
+            <bq-icon name="info"></bq-icon>
+            <bq-icon name="star" color="text--success"></bq-icon>
+            <bq-icon name="warning-circle" color="text--warning"></bq-icon>
+            <bq-icon name="x-circle" color="text--danger"></bq-icon>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -274,13 +301,23 @@ Use icon-name suffixes like `-thin`, `-light`, `-bold`, `-duotone`, and `-fill` 
     </>
     ```
 
-    ```html Angular icon="angular"
-    <bq-icon name="heart"></bq-icon>
-    <bq-icon name="heart-thin"></bq-icon>
-    <bq-icon name="heart-light"></bq-icon>
-    <bq-icon name="heart-bold"></bq-icon>
-    <bq-icon name="heart-duotone"></bq-icon>
-    <bq-icon name="heart-fill"></bq-icon>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqIcon } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqIcon],
+      template: `
+            <bq-icon name="heart"></bq-icon>
+            <bq-icon name="heart-thin"></bq-icon>
+            <bq-icon name="heart-light"></bq-icon>
+            <bq-icon name="heart-bold"></bq-icon>
+            <bq-icon name="heart-duotone"></bq-icon>
+            <bq-icon name="heart-fill"></bq-icon>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -332,12 +369,22 @@ Use `src` when you want to load a custom icon from a local or CORS-enabled endpo
     />
     ```
 
-    ```html Angular icon="angular"
-    <bq-icon
-      src="https://storybook.beeq.design/assets/wallet.svg"
-      label="Wallet icon"
-      size="256"
-    ></bq-icon>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqIcon } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqIcon],
+      template: `
+            <bq-icon
+              src="https://storybook.beeq.design/assets/wallet.svg"
+              label="Wallet icon"
+              size="256"
+            ></bq-icon>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/icon.mdx
+++ b/apps/beeq-docs/components/icon.mdx
@@ -111,6 +111,7 @@ Use the default icon when you need a simple visual cue inside navigation, action
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqIcon } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -170,6 +171,7 @@ Adjust `size` when the icon needs to match the surrounding text or visual emphas
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqIcon } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -231,6 +233,7 @@ An icon inherits color from its parent by default, but you can also assign a tok
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqIcon } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -304,6 +307,7 @@ Use icon-name suffixes like `-thin`, `-light`, `-bold`, `-duotone`, and `-fill` 
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqIcon } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -372,6 +376,7 @@ Use `src` when you want to load a custom icon from a local or CORS-enabled endpo
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqIcon } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,

--- a/apps/beeq-docs/components/input.mdx
+++ b/apps/beeq-docs/components/input.mdx
@@ -180,6 +180,7 @@ Use the default type of input when you want to provide a simple, versatile field
     import { BqIcon, BqInput } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqInput],
       template: `
@@ -192,7 +193,7 @@ Use the default type of input when you want to provide a simple, versatile field
         </bq-input>
       `
     })
-    export class DefaultInputComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -267,6 +268,7 @@ Use the `value` attribute to provide a convenient solution for scenarios where t
     import { BqIcon, BqInput } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqInput],
       template: `
@@ -279,7 +281,7 @@ Use the `value` attribute to provide a convenient solution for scenarios where t
         </bq-input>
       `
     })
-    export class ValueInputComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -357,6 +359,7 @@ Use the prefix slot when you want to place an icon before the input value to pro
     import { BqIcon, BqInput } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqInput],
       template: `
@@ -370,7 +373,7 @@ Use the prefix slot when you want to place an icon before the input value to pro
         </bq-input>
       `
     })
-    export class PrefixInputComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -449,6 +452,7 @@ Use the suffix slot when you want to add an icon after the input field for extra
     import { BqIcon, BqInput } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqInput],
       template: `
@@ -462,7 +466,7 @@ Use the suffix slot when you want to add an icon after the input field for extra
         </bq-input>
       `
     })
-    export class SuffixInputComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -544,6 +548,7 @@ This variant combines both prefix and suffix features within the same input.
     import { BqIcon, BqInput } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqInput],
       template: `
@@ -558,7 +563,7 @@ This variant combines both prefix and suffix features within the same input.
         </bq-input>
       `
     })
-    export class PrefixSuffixInputComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -641,6 +646,7 @@ Use the `disabled` attribute when the input field should be visible but non-edit
     import { BqIcon, BqInput } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqInput],
       template: `
@@ -655,7 +661,7 @@ Use the `disabled` attribute when the input field should be visible but non-edit
         </bq-input>
       `
     })
-    export class DisabledInputComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -803,6 +809,7 @@ Use this variant for validation feedback by setting `validation-status` to `erro
     import { BqIcon, BqInput } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqInput],
       template: `
@@ -837,7 +844,7 @@ Use this variant for validation feedback by setting `validation-status` to `erro
         </bq-input>
       `
     })
-    export class ValidationInputComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -981,6 +988,7 @@ Use this style when you want to include an optional marker to provide additional
     import { BqIcon, BqInput } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqInput],
       template: `
@@ -996,7 +1004,7 @@ Use this style when you want to include an optional marker to provide additional
         </bq-input>
       `
     })
-    export class LabelOptionalInputComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -1155,6 +1163,7 @@ Use this style when you want to include an informational tooltip alongside the i
     import { BqIcon, BqInput, BqTooltip } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqInput, BqTooltip],
       template: `
@@ -1176,7 +1185,7 @@ Use this style when you want to include an informational tooltip alongside the i
         </bq-input>
       `
     })
-    export class LabelTooltipInputComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -1263,6 +1272,7 @@ Use this variant when the surrounding context already makes the field purpose cl
     import { BqIcon, BqInput } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqInput],
       template: `
@@ -1276,7 +1286,7 @@ Use this variant when the surrounding context already makes the field purpose cl
         </bq-input>
       `
     })
-    export class NoLabelInputComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -1346,6 +1356,7 @@ Use this variant when the field does not require supplementary guidance.
     import { BqIcon, BqInput } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqInput],
       template: `
@@ -1356,7 +1367,7 @@ Use this variant when the field does not require supplementary guidance.
         </bq-input>
       `
     })
-    export class NoHelperTextInputComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/input.mdx
+++ b/apps/beeq-docs/components/input.mdx
@@ -932,7 +932,7 @@ Use this style when you want to include an optional marker to provide additional
   </bq-input>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     .label-row {
       display: flex;
       flex: 1 1 0%;
@@ -1135,7 +1135,7 @@ Use this style when you want to include an informational tooltip alongside the i
   </bq-input>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     bq-tooltip {
       margin-inline-start: var(--bq-spacing-xs);
 

--- a/apps/beeq-docs/components/input.mdx
+++ b/apps/beeq-docs/components/input.mdx
@@ -1050,27 +1050,26 @@ Use this style when you want to include an optional marker to provide additional
 
 
     <style>
-    .label-row {
-      display: flex;
-      flex: 1 1 0%;
-
-      & > label {
+      .label-row {
         display: flex;
-        flex-grow: 1;
+        flex: 1 1 0%;
+
+        & > label {
+          display: flex;
+          flex-grow: 1;
+          align-items: center;
+        }
+
+        & > span {
+          color: var(--bq-text--secondary);
+        }
+      }
+
+      bq-input span[slot="helper-text"] {
+        display: flex;
         align-items: center;
+        gap: var(--bq-spacing-xs);
       }
-
-      & > span {
-        color: var(--bq-text--secondary);
-      }
-    }
-
-    bq-input span[slot="helper-text"] {
-      display: flex;
-      align-items: center;
-      gap: var(--bq-spacing-xs);
-    }
-
     </style>
     ```
   </CodeGroup>
@@ -1293,35 +1292,34 @@ Use this style when you want to include an informational tooltip alongside the i
 
 
     <style>
-    bq-tooltip {
-      margin-inline-start: var(--bq-spacing-xs);
+      bq-tooltip {
+        margin-inline-start: var(--bq-spacing-xs);
 
-      &::part(trigger) {
-        display: flex;
+        &::part(trigger) {
+          display: flex;
+        }
       }
-    }
 
-    .label-row {
-      display: flex;
-      flex: 1 1 0%;
-
-      & > label {
+      .label-row {
         display: flex;
-        flex-grow: 1;
+        flex: 1 1 0%;
+
+        & > label {
+          display: flex;
+          flex-grow: 1;
+          align-items: center;
+        }
+
+        & > span {
+          color: var(--bq-text--secondary);
+        }
+      }
+
+      bq-input span[slot="helper-text"] {
+        display: flex;
         align-items: center;
+        gap: var(--bq-spacing-xs);
       }
-
-      & > span {
-        color: var(--bq-text--secondary);
-      }
-    }
-
-    bq-input span[slot="helper-text"] {
-      display: flex;
-      align-items: center;
-      gap: var(--bq-spacing-xs);
-    }
-
     </style>
     ```
   </CodeGroup>

--- a/apps/beeq-docs/components/input.mdx
+++ b/apps/beeq-docs/components/input.mdx
@@ -932,7 +932,7 @@ Use this style when you want to include an optional marker to provide additional
   </bq-input>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     .label-row {
       display: flex;
       flex: 1 1 0%;
@@ -1003,8 +1003,8 @@ Use this style when you want to include an optional marker to provide additional
             Helper text
           </span>
         </bq-input>
-      `
-      style: `
+      `,
+      styles: [`
         .label-row {
           display: flex;
           flex: 1 1 0%;
@@ -1025,7 +1025,7 @@ Use this style when you want to include an optional marker to provide additional
           align-items: center;
           gap: var(--bq-spacing-xs);
         }
-      `,
+      `],
     })
     export class AppComponent {}
     ```
@@ -1135,7 +1135,7 @@ Use this style when you want to include an informational tooltip alongside the i
   </bq-input>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     bq-tooltip {
       margin-inline-start: var(--bq-spacing-xs);
 
@@ -1232,8 +1232,8 @@ Use this style when you want to include an informational tooltip alongside the i
             Helper text
           </span>
         </bq-input>
-      `
-      style: `
+      `,
+      styles: [`
         bq-tooltip {
           margin-inline-start: var(--bq-spacing-xs);
 
@@ -1262,7 +1262,7 @@ Use this style when you want to include an informational tooltip alongside the i
           align-items: center;
           gap: var(--bq-spacing-xs);
         }
-      `,
+      `],
     })
     export class AppComponent {}
     ```

--- a/apps/beeq-docs/components/input.mdx
+++ b/apps/beeq-docs/components/input.mdx
@@ -153,7 +153,7 @@ Use the default type of input when you want to provide a simple, versatile field
   </bq-input>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-input name="bq-input" placeholder="Placeholder">
         <label class="flex flex-grow items-center" slot="label">Input label</label>
         <span slot="helper-text">
@@ -175,7 +175,7 @@ Use the default type of input when you want to provide a simple, versatile field
     </BqInput>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqInput } from "@beeq/angular/standalone";
 
@@ -196,7 +196,7 @@ Use the default type of input when you want to provide a simple, versatile field
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqIcon, BqInput } from "@beeq/vue";
     </script>
@@ -241,7 +241,7 @@ Use the `value` attribute to provide a convenient solution for scenarios where t
   </bq-input>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-input name="bq-input" placeholder="Placeholder" value="Hello World!">
         <label class="flex flex-grow items-center" slot="label">Input label</label>
         <span slot="helper-text">
@@ -263,7 +263,7 @@ Use the `value` attribute to provide a convenient solution for scenarios where t
     </BqInput>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqInput } from "@beeq/angular/standalone";
 
@@ -284,7 +284,7 @@ Use the `value` attribute to provide a convenient solution for scenarios where t
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqIcon, BqInput } from "@beeq/vue";
     </script>
@@ -330,7 +330,7 @@ Use the prefix slot when you want to place an icon before the input value to pro
   </bq-input>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-input name="bq-input" placeholder="Placeholder">
       <label class="flex flex-grow items-center" slot="label">Input label</label>
       <bq-icon name="user-circle" slot="prefix"></bq-icon>
@@ -354,7 +354,7 @@ Use the prefix slot when you want to place an icon before the input value to pro
     </BqInput>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqInput } from "@beeq/angular/standalone";
 
@@ -376,7 +376,7 @@ Use the prefix slot when you want to place an icon before the input value to pro
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqIcon, BqInput } from "@beeq/vue";
     </script>
@@ -423,7 +423,7 @@ Use the suffix slot when you want to add an icon after the input field for extra
   </bq-input>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-input name="bq-input" placeholder="Placeholder">
         <label class="flex flex-grow items-center" slot="label">Input label</label>
         <bq-icon name="gear" slot="suffix"></bq-icon>
@@ -447,7 +447,7 @@ Use the suffix slot when you want to add an icon after the input field for extra
     </BqInput>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqInput } from "@beeq/angular/standalone";
 
@@ -469,7 +469,7 @@ Use the suffix slot when you want to add an icon after the input field for extra
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqIcon, BqInput } from "@beeq/vue";
     </script>
@@ -517,7 +517,7 @@ This variant combines both prefix and suffix features within the same input.
   </bq-input>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-input name="bq-input" placeholder="Placeholder">
         <label class="flex flex-grow items-center" slot="label">Input label</label>
         <bq-icon name="user-circle" slot="prefix"></bq-icon>
@@ -543,7 +543,7 @@ This variant combines both prefix and suffix features within the same input.
     </BqInput>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqInput } from "@beeq/angular/standalone";
 
@@ -566,7 +566,7 @@ This variant combines both prefix and suffix features within the same input.
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqIcon, BqInput } from "@beeq/vue";
     </script>
@@ -615,7 +615,7 @@ Use the `disabled` attribute when the input field should be visible but non-edit
   </bq-input>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-input disabled name="bq-input" placeholder="Placeholder">
       <label class="flex flex-grow items-center" slot="label">Input label</label>
       <bq-icon name="user-circle" slot="prefix"></bq-icon>
@@ -641,7 +641,7 @@ Use the `disabled` attribute when the input field should be visible but non-edit
     </BqInput>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqInput } from "@beeq/angular/standalone";
 
@@ -664,7 +664,7 @@ Use the `disabled` attribute when the input field should be visible but non-edit
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqIcon, BqInput } from "@beeq/vue";
     </script>
@@ -736,7 +736,7 @@ Use this variant for validation feedback by setting `validation-status` to `erro
   </bq-input>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-input name="bq-input-error" placeholder="Placeholder" validation-status="error">
         <label class="flex flex-grow items-center" slot="label">Input label</label>
         <bq-icon name="user-circle" slot="prefix"></bq-icon>
@@ -804,7 +804,7 @@ Use this variant for validation feedback by setting `validation-status` to `erro
     </>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqInput } from "@beeq/angular/standalone";
 
@@ -847,7 +847,7 @@ Use this variant for validation feedback by setting `validation-status` to `erro
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqIcon, BqInput } from "@beeq/vue";
     </script>
@@ -932,7 +932,7 @@ Use this style when you want to include an optional marker to provide additional
   </bq-input>
 `}>
   <CodeGroup>
-    ```css CSS icon="css"
+    ```css styles.css icon="css" expandable
     .label-row {
       display: flex;
       flex: 1 1 0%;
@@ -955,7 +955,7 @@ Use this style when you want to include an optional marker to provide additional
     }
     ```
 
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-input name="bq-input" placeholder="Placeholder">
         <div class="label-row" slot="label">
             <label>Input label</label>
@@ -970,6 +970,7 @@ Use this style when you want to include an optional marker to provide additional
 
     ```jsx React icon="react"
     import { BqIcon, BqInput } from "@beeq/react";
+    import "./styles.css";
 
     <BqInput name="bq-input" placeholder="Placeholder">
       <div className="label-row" slot="label">
@@ -983,7 +984,7 @@ Use this style when you want to include an optional marker to provide additional
     </BqInput>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqInput } from "@beeq/angular/standalone";
 
@@ -1003,11 +1004,33 @@ Use this style when you want to include an optional marker to provide additional
           </span>
         </bq-input>
       `
+      style: `
+        .label-row {
+          display: flex;
+          flex: 1 1 0%;
+
+          & > label {
+            display: flex;
+            flex-grow: 1;
+            align-items: center;
+          }
+
+          & > span {
+            color: var(--bq-text--secondary);
+          }
+        }
+
+        bq-input span[slot="helper-text"] {
+          display: flex;
+          align-items: center;
+          gap: var(--bq-spacing-xs);
+        }
+      `,
     })
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqIcon, BqInput } from "@beeq/vue";
     </script>
@@ -1024,6 +1047,31 @@ Use this style when you want to include an optional marker to provide additional
         </span>
       </BqInput>
     </template>
+
+
+    <style>
+    .label-row {
+      display: flex;
+      flex: 1 1 0%;
+
+      & > label {
+        display: flex;
+        flex-grow: 1;
+        align-items: center;
+      }
+
+      & > span {
+        color: var(--bq-text--secondary);
+      }
+    }
+
+    bq-input span[slot="helper-text"] {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -1087,7 +1135,7 @@ Use this style when you want to include an informational tooltip alongside the i
   </bq-input>
 `}>
   <CodeGroup>
-    ```css CSS icon="css"
+    ```css styles.css icon="css" expandable
     bq-tooltip {
       margin-inline-start: var(--bq-spacing-xs);
 
@@ -1118,7 +1166,7 @@ Use this style when you want to include an informational tooltip alongside the i
     }
     ```
 
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-input name="bq-input" placeholder="Placeholder">
         <div class="label-row" slot="label">
             <label>
@@ -1139,6 +1187,7 @@ Use this style when you want to include an informational tooltip alongside the i
 
     ```jsx React icon="react"
     import { BqIcon, BqInput, BqTooltip } from "@beeq/react";
+    import "./styles.css";
 
     <BqInput name="bq-input" placeholder="Placeholder">
       <div className="label-row" slot="label">
@@ -1158,7 +1207,7 @@ Use this style when you want to include an informational tooltip alongside the i
     </BqInput>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqInput, BqTooltip } from "@beeq/angular/standalone";
 
@@ -1184,11 +1233,41 @@ Use this style when you want to include an informational tooltip alongside the i
           </span>
         </bq-input>
       `
+      style: `
+        bq-tooltip {
+          margin-inline-start: var(--bq-spacing-xs);
+
+          &::part(trigger) {
+            display: flex;
+          }
+        }
+
+        .label-row {
+          display: flex;
+          flex: 1 1 0%;
+
+          & > label {
+            display: flex;
+            flex-grow: 1;
+            align-items: center;
+          }
+
+          & > span {
+            color: var(--bq-text--secondary);
+          }
+        }
+
+        bq-input span[slot="helper-text"] {
+          display: flex;
+          align-items: center;
+          gap: var(--bq-spacing-xs);
+        }
+      `,
     })
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqIcon, BqInput, BqTooltip } from "@beeq/vue";
     </script>
@@ -1211,6 +1290,39 @@ Use this style when you want to include an informational tooltip alongside the i
         </span>
       </BqInput>
     </template>
+
+
+    <style>
+    bq-tooltip {
+      margin-inline-start: var(--bq-spacing-xs);
+
+      &::part(trigger) {
+        display: flex;
+      }
+    }
+
+    .label-row {
+      display: flex;
+      flex: 1 1 0%;
+
+      & > label {
+        display: flex;
+        flex-grow: 1;
+        align-items: center;
+      }
+
+      & > span {
+        color: var(--bq-text--secondary);
+      }
+    }
+
+    bq-input span[slot="helper-text"] {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+    }
+
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -1243,7 +1355,7 @@ Use this variant when the surrounding context already makes the field purpose cl
   </bq-input>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-input name="bq-input" placeholder="Placeholder">
         <bq-icon name="user-circle" slot="prefix"></bq-icon>
         <bq-icon name="gear" slot="suffix"></bq-icon>
@@ -1267,7 +1379,7 @@ Use this variant when the surrounding context already makes the field purpose cl
     </BqInput>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqInput } from "@beeq/angular/standalone";
 
@@ -1289,7 +1401,7 @@ Use this variant when the surrounding context already makes the field purpose cl
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqIcon, BqInput } from "@beeq/vue";
     </script>
@@ -1333,7 +1445,7 @@ Use this variant when the field does not require supplementary guidance.
   </bq-input>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-input name="bq-input" placeholder="Placeholder">
         <label slot="label">Input label</label>
         <bq-icon name="user-circle" slot="prefix"></bq-icon>
@@ -1351,7 +1463,7 @@ Use this variant when the field does not require supplementary guidance.
     </BqInput>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqInput } from "@beeq/angular/standalone";
 
@@ -1370,7 +1482,7 @@ Use this variant when the field does not require supplementary guidance.
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqIcon, BqInput } from "@beeq/vue";
     </script>

--- a/apps/beeq-docs/components/notification.mdx
+++ b/apps/beeq-docs/components/notification.mdx
@@ -199,7 +199,7 @@ Use the default `info` notification for standard messages and updates.
     ```
 
     ```js JavaScript icon="js"
-    const notifications = document.querySelectorAll("bq-notification");
+    const notifications = previewRoot.querySelectorAll("bq-notification");
 
     notifications.forEach((notification) => {
       notification.addEventListener("bqHide", () => {
@@ -369,7 +369,7 @@ Use semantic `type` values to communicate severity and intent clearly.
     ```
 
     ```js JavaScript icon="js"
-    const notifications = document.querySelectorAll("bq-notification");
+    const notifications = previewRoot.querySelectorAll("bq-notification");
 
     notifications.forEach((notification) => {
       notification.addEventListener("bqHide", () => {
@@ -531,7 +531,7 @@ Use the `icon` slot to replace the default type icon with a custom `bq-icon`.
     ```
 
     ```js JavaScript icon="js"
-    const notifications = document.querySelectorAll("bq-notification");
+    const notifications = previewRoot.querySelectorAll("bq-notification");
 
     notifications.forEach((notification) => {
       notification.addEventListener("bqHide", () => {
@@ -751,7 +751,7 @@ Use the `toast()` method to render notifications in a fixed-position portal that
     ```
 
     ```js JavaScript icon="js"
-    const openBtn = document.querySelector("#notification-stacked-btn");
+    const openBtn = previewRoot.querySelector("#notification-stacked-btn");
 
     const NOTIFICATION_TYPES = ["error", "info", "neutral", "success", "warning"];
     const getRandomType = () => NOTIFICATION_TYPES[Math.floor(Math.random() * NOTIFICATION_TYPES.length)];

--- a/apps/beeq-docs/components/page-title.mdx
+++ b/apps/beeq-docs/components/page-title.mdx
@@ -132,13 +132,20 @@ Use the default composition when the title alone provides enough context.
     </BqPageTitle>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqPageTitle } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-
-    <bq-page-title>
-      Title
-    </bq-page-title>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqPageTitle } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqPageTitle],
+      template: `
+        <bq-page-title>
+              Title
+            </bq-page-title>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -191,16 +198,23 @@ Use a back action when the page is part of a flow or nested navigation path.
     </BqPageTitle>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqButton, BqIcon, BqPageTitle } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-
-    <bq-page-title>
-      <bq-button appearance="link" slot="back" only-icon>
-        <bq-icon color="text--primary" name="arrow-left" weight="bold" title="Navigate back to the previous page"></bq-icon>
-      </bq-button>
-      Title
-    </bq-page-title>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqPageTitle, BqButton, BqIcon } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqPageTitle, BqButton, BqIcon],
+      template: `
+        <bq-page-title>
+              <bq-button appearance="link" slot="back" only-icon>
+                <bq-icon color="text--primary" name="arrow-left" weight="bold" title="Navigate back to the previous page"></bq-icon>
+              </bq-button>
+              Title
+            </bq-page-title>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -263,17 +277,24 @@ Add a subtitle when people need a little more context before acting.
     </BqPageTitle>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqButton, BqIcon, BqPageTitle } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-
-    <bq-page-title>
-      <bq-button appearance="link" slot="back" only-icon>
-        <bq-icon color="text--primary" name="arrow-left" weight="bold" title="Navigate back to the previous page"></bq-icon>
-      </bq-button>
-      Title
-      <div slot="sub-title">Sub-title</div>
-    </bq-page-title>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqPageTitle, BqButton, BqIcon } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqPageTitle, BqButton, BqIcon],
+      template: `
+        <bq-page-title>
+              <bq-button appearance="link" slot="back" only-icon>
+                <bq-icon color="text--primary" name="arrow-left" weight="bold" title="Navigate back to the previous page"></bq-icon>
+              </bq-button>
+              Title
+              <div slot="sub-title">Sub-title</div>
+            </bq-page-title>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -352,19 +373,26 @@ Use the suffix slot for page-level actions when back navigation is not relevant 
     </BqPageTitle>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqButton, BqIcon, BqPageTitle } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-
-    <bq-page-title>
-      Dashboard users
-      <div slot="suffix">
-        <bq-button>
-          <bq-icon name="plus" aria-hidden="true" slot="prefix"></bq-icon>
-          Add user
-        </bq-button>
-      </div>
-    </bq-page-title>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqPageTitle, BqButton, BqIcon } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqPageTitle, BqButton, BqIcon],
+      template: `
+        <bq-page-title>
+              Dashboard users
+              <div slot="suffix">
+                <bq-button>
+                  <bq-icon name="plus" aria-hidden="true" slot="prefix"></bq-icon>
+                  Add user
+                </bq-button>
+              </div>
+            </bq-page-title>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -480,25 +508,32 @@ Use the suffix slot when the title area needs page-level actions such as edit or
     </BqPageTitle>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqButton, BqIcon, BqPageTitle } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-
-    <bq-page-title>
-      <bq-button appearance="link" slot="back" only-icon>
-        <bq-icon color="text--primary" name="arrow-left" weight="bold" title="Navigate back to the previous page"></bq-icon>
-      </bq-button>
-      Title
-      <div slot="sub-title">Sub-title</div>
-      <div slot="suffix">
-        <bq-button appearance="text" size="small" only-icon>
-          <bq-icon name="pencil-simple-bold" color="text--brand" aria-label="Edit"></bq-icon>
-        </bq-button>
-        <bq-button appearance="text" size="small" only-icon>
-          <bq-icon name="download-simple-bold" color="text--brand" aria-label="Download"></bq-icon>
-        </bq-button>
-      </div>
-    </bq-page-title>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqPageTitle, BqButton, BqIcon } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqPageTitle, BqButton, BqIcon],
+      template: `
+        <bq-page-title>
+              <bq-button appearance="link" slot="back" only-icon>
+                <bq-icon color="text--primary" name="arrow-left" weight="bold" title="Navigate back to the previous page"></bq-icon>
+              </bq-button>
+              Title
+              <div slot="sub-title">Sub-title</div>
+              <div slot="suffix">
+                <bq-button appearance="text" size="small" only-icon>
+                  <bq-icon name="pencil-simple-bold" color="text--brand" aria-label="Edit"></bq-icon>
+                </bq-button>
+                <bq-button appearance="text" size="small" only-icon>
+                  <bq-icon name="download-simple-bold" color="text--brand" aria-label="Download"></bq-icon>
+                </bq-button>
+              </div>
+            </bq-page-title>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/page-title.mdx
+++ b/apps/beeq-docs/components/page-title.mdx
@@ -462,7 +462,7 @@ Use the suffix slot when the title area needs page-level actions such as edit or
   `}
 >
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     bq-page-title {
       inline-size: 100% !important;
 
@@ -542,7 +542,7 @@ Use the suffix slot when the title area needs page-level actions such as edit or
           </div>
         </bq-page-title>
       `,
-      style: `
+      styles: [`
         bq-page-title {
           inline-size: 100% !important;
 
@@ -556,7 +556,7 @@ Use the suffix slot when the title area needs page-level actions such as edit or
             padding: var(--bq-spacing-xs2);
           }
         }
-      `,
+      `],
     })
     export class AppComponent {}
     ```

--- a/apps/beeq-docs/components/page-title.mdx
+++ b/apps/beeq-docs/components/page-title.mdx
@@ -135,6 +135,7 @@ Use the default composition when the title alone provides enough context.
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqPageTitle } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -205,6 +206,7 @@ Use a back action when the page is part of a flow or nested navigation path.
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqPageTitle, BqButton, BqIcon } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -284,6 +286,7 @@ Add a subtitle when people need a little more context before acting.
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqPageTitle, BqButton, BqIcon } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -380,6 +383,7 @@ Use the suffix slot for page-level actions when back navigation is not relevant 
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqPageTitle, BqButton, BqIcon } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -516,6 +520,7 @@ Use the suffix slot when the title area needs page-level actions such as edit or
     ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqPageTitle, BqButton, BqIcon } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,

--- a/apps/beeq-docs/components/page-title.mdx
+++ b/apps/beeq-docs/components/page-title.mdx
@@ -586,20 +586,19 @@ Use the suffix slot when the title area needs page-level actions such as edit or
 
 
     <style>
-    bq-page-title {
-      inline-size: 100% !important;
+      bq-page-title {
+        inline-size: 100% !important;
 
-      & [slot="suffix"] {
-        display: flex;
-        flex-grow: 1;
-        justify-content: end;
+        & [slot="suffix"] {
+          display: flex;
+          flex-grow: 1;
+          justify-content: end;
+        }
+
+        & [slot="suffix"] bq-button {
+          padding: var(--bq-spacing-xs2);
+        }
       }
-
-      & [slot="suffix"] bq-button {
-        padding: var(--bq-spacing-xs2);
-      }
-    }
-
     </style>
     ```
   </CodeGroup>

--- a/apps/beeq-docs/components/page-title.mdx
+++ b/apps/beeq-docs/components/page-title.mdx
@@ -118,13 +118,13 @@ Use the default composition when the title alone provides enough context.
   `}
 >
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-page-title>
       Title
     </bq-page-title>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqPageTitle } from "@beeq/react";
 
     <BqPageTitle>
@@ -132,7 +132,7 @@ Use the default composition when the title alone provides enough context.
     </BqPageTitle>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqPageTitle } from "@beeq/angular/standalone";
     @Component({
@@ -148,7 +148,7 @@ Use the default composition when the title alone provides enough context.
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqPageTitle } from "@beeq/vue";
     </script>
@@ -175,10 +175,14 @@ Use a back action when the page is part of a flow or nested navigation path.
   </style>
     <bq-page-title>
       <bq-button appearance="link" slot="back" only-icon>
+        <bq-icon color="text--primary" name="arrow-left" weight="bold" title="Navigate back to the previous page"></bq-icon>
+      </bq-button>
+      Title
+    </bq-page-title>
   `}
 >
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-page-title>
       <bq-button appearance="link" slot="back" only-icon>
         <bq-icon color="text--primary" name="arrow-left" weight="bold" title="Navigate back to the previous page"></bq-icon>
@@ -187,7 +191,7 @@ Use a back action when the page is part of a flow or nested navigation path.
     </bq-page-title>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqButton, BqIcon, BqPageTitle } from "@beeq/react";
 
     <BqPageTitle>
@@ -198,7 +202,7 @@ Use a back action when the page is part of a flow or nested navigation path.
     </BqPageTitle>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqPageTitle, BqButton, BqIcon } from "@beeq/angular/standalone";
     @Component({
@@ -217,7 +221,7 @@ Use a back action when the page is part of a flow or nested navigation path.
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqButton, BqIcon, BqPageTitle } from "@beeq/vue";
     </script>
@@ -255,7 +259,7 @@ Add a subtitle when people need a little more context before acting.
   `}
 >
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-page-title>
       <bq-button appearance="link" slot="back" only-icon>
         <bq-icon color="text--primary" name="arrow-left" weight="bold" title="Navigate back to the previous page"></bq-icon>
@@ -265,7 +269,7 @@ Add a subtitle when people need a little more context before acting.
     </bq-page-title>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqButton, BqIcon, BqPageTitle } from "@beeq/react";
 
     <BqPageTitle>
@@ -277,7 +281,7 @@ Add a subtitle when people need a little more context before acting.
     </BqPageTitle>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqPageTitle, BqButton, BqIcon } from "@beeq/angular/standalone";
     @Component({
@@ -297,7 +301,7 @@ Add a subtitle when people need a little more context before acting.
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqButton, BqIcon, BqPageTitle } from "@beeq/vue";
     </script>
@@ -347,7 +351,7 @@ Use the suffix slot for page-level actions when back navigation is not relevant 
   `}
 >
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-page-title>
       Dashboard users
       <div slot="suffix">
@@ -359,7 +363,7 @@ Use the suffix slot for page-level actions when back navigation is not relevant 
     </bq-page-title>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqButton, BqIcon, BqPageTitle } from "@beeq/react";
 
     <BqPageTitle>
@@ -373,7 +377,7 @@ Use the suffix slot for page-level actions when back navigation is not relevant 
     </BqPageTitle>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqPageTitle, BqButton, BqIcon } from "@beeq/angular/standalone";
     @Component({
@@ -395,7 +399,7 @@ Use the suffix slot for page-level actions when back navigation is not relevant 
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqButton, BqIcon, BqPageTitle } from "@beeq/vue";
     </script>
@@ -454,7 +458,7 @@ Use the suffix slot when the title area needs page-level actions such as edit or
   `}
 >
   <CodeGroup>
-    ```css CSS icon="css"
+    ```css styles.css icon="css" expandable
     bq-page-title {
       inline-size: 100% !important;
 
@@ -470,7 +474,7 @@ Use the suffix slot when the title area needs page-level actions such as edit or
     }
     ```
 
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-page-title>
       <bq-button appearance="link" slot="back" only-icon>
         <bq-icon color="text--primary" name="arrow-left" weight="bold" title="Navigate back to the previous page"></bq-icon>
@@ -488,8 +492,9 @@ Use the suffix slot when the title area needs page-level actions such as edit or
     </bq-page-title>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqButton, BqIcon, BqPageTitle } from "@beeq/react";
+    import "./styles.css";
 
     <BqPageTitle>
       <BqButton appearance="link" slot="back" onlyIcon>
@@ -508,7 +513,7 @@ Use the suffix slot when the title area needs page-level actions such as edit or
     </BqPageTitle>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqPageTitle, BqButton, BqIcon } from "@beeq/angular/standalone";
     @Component({
@@ -532,11 +537,26 @@ Use the suffix slot when the title area needs page-level actions such as edit or
           </div>
         </bq-page-title>
       `,
+      style: `
+        bq-page-title {
+          inline-size: 100% !important;
+
+          & [slot="suffix"] {
+            display: flex;
+            flex-grow: 1;
+            justify-content: end;
+          }
+
+          & [slot="suffix"] bq-button {
+            padding: var(--bq-spacing-xs2);
+          }
+        }
+      `,
     })
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqButton, BqIcon, BqPageTitle } from "@beeq/vue";
     </script>
@@ -558,6 +578,24 @@ Use the suffix slot when the title area needs page-level actions such as edit or
         </div>
       </BqPageTitle>
     </template>
+
+
+    <style>
+    bq-page-title {
+      inline-size: 100% !important;
+
+      & [slot="suffix"] {
+        display: flex;
+        flex-grow: 1;
+        justify-content: end;
+      }
+
+      & [slot="suffix"] bq-button {
+        padding: var(--bq-spacing-xs2);
+      }
+    }
+
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>

--- a/apps/beeq-docs/components/page-title.mdx
+++ b/apps/beeq-docs/components/page-title.mdx
@@ -141,8 +141,8 @@ Use the default composition when the title alone provides enough context.
       imports: [BqPageTitle],
       template: `
         <bq-page-title>
-              Title
-            </bq-page-title>
+          Title
+        </bq-page-title>
       `,
     })
     export class AppComponent {}
@@ -207,11 +207,11 @@ Use a back action when the page is part of a flow or nested navigation path.
       imports: [BqPageTitle, BqButton, BqIcon],
       template: `
         <bq-page-title>
-              <bq-button appearance="link" slot="back" only-icon>
-                <bq-icon color="text--primary" name="arrow-left" weight="bold" title="Navigate back to the previous page"></bq-icon>
-              </bq-button>
-              Title
-            </bq-page-title>
+          <bq-button appearance="link" slot="back" only-icon>
+            <bq-icon color="text--primary" name="arrow-left" weight="bold" title="Navigate back to the previous page"></bq-icon>
+          </bq-button>
+          Title
+        </bq-page-title>
       `,
     })
     export class AppComponent {}
@@ -286,12 +286,12 @@ Add a subtitle when people need a little more context before acting.
       imports: [BqPageTitle, BqButton, BqIcon],
       template: `
         <bq-page-title>
-              <bq-button appearance="link" slot="back" only-icon>
-                <bq-icon color="text--primary" name="arrow-left" weight="bold" title="Navigate back to the previous page"></bq-icon>
-              </bq-button>
-              Title
-              <div slot="sub-title">Sub-title</div>
-            </bq-page-title>
+          <bq-button appearance="link" slot="back" only-icon>
+            <bq-icon color="text--primary" name="arrow-left" weight="bold" title="Navigate back to the previous page"></bq-icon>
+          </bq-button>
+          Title
+          <div slot="sub-title">Sub-title</div>
+        </bq-page-title>
       `,
     })
     export class AppComponent {}
@@ -382,14 +382,14 @@ Use the suffix slot for page-level actions when back navigation is not relevant 
       imports: [BqPageTitle, BqButton, BqIcon],
       template: `
         <bq-page-title>
-              Dashboard users
-              <div slot="suffix">
-                <bq-button>
-                  <bq-icon name="plus" aria-hidden="true" slot="prefix"></bq-icon>
-                  Add user
-                </bq-button>
-              </div>
-            </bq-page-title>
+          Dashboard users
+          <div slot="suffix">
+            <bq-button>
+              <bq-icon name="plus" aria-hidden="true" slot="prefix"></bq-icon>
+              Add user
+            </bq-button>
+          </div>
+        </bq-page-title>
       `,
     })
     export class AppComponent {}
@@ -517,20 +517,20 @@ Use the suffix slot when the title area needs page-level actions such as edit or
       imports: [BqPageTitle, BqButton, BqIcon],
       template: `
         <bq-page-title>
-              <bq-button appearance="link" slot="back" only-icon>
-                <bq-icon color="text--primary" name="arrow-left" weight="bold" title="Navigate back to the previous page"></bq-icon>
-              </bq-button>
-              Title
-              <div slot="sub-title">Sub-title</div>
-              <div slot="suffix">
-                <bq-button appearance="text" size="small" only-icon>
-                  <bq-icon name="pencil-simple-bold" color="text--brand" aria-label="Edit"></bq-icon>
-                </bq-button>
-                <bq-button appearance="text" size="small" only-icon>
-                  <bq-icon name="download-simple-bold" color="text--brand" aria-label="Download"></bq-icon>
-                </bq-button>
-              </div>
-            </bq-page-title>
+          <bq-button appearance="link" slot="back" only-icon>
+            <bq-icon color="text--primary" name="arrow-left" weight="bold" title="Navigate back to the previous page"></bq-icon>
+          </bq-button>
+          Title
+          <div slot="sub-title">Sub-title</div>
+          <div slot="suffix">
+            <bq-button appearance="text" size="small" only-icon>
+              <bq-icon name="pencil-simple-bold" color="text--brand" aria-label="Edit"></bq-icon>
+            </bq-button>
+            <bq-button appearance="text" size="small" only-icon>
+              <bq-icon name="download-simple-bold" color="text--brand" aria-label="Download"></bq-icon>
+            </bq-button>
+          </div>
+        </bq-page-title>
       `,
     })
     export class AppComponent {}

--- a/apps/beeq-docs/components/page-title.mdx
+++ b/apps/beeq-docs/components/page-title.mdx
@@ -462,7 +462,7 @@ Use the suffix slot when the title area needs page-level actions such as edit or
   `}
 >
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     bq-page-title {
       inline-size: 100% !important;
 

--- a/apps/beeq-docs/components/progress.mdx
+++ b/apps/beeq-docs/components/progress.mdx
@@ -162,6 +162,7 @@ Use the default progress bar for general task tracking when the process has a me
     import { BqProgress } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqProgress],
       template: `
@@ -171,7 +172,7 @@ Use the default progress bar for general task tracking when the process has a me
         <bq-progress value="100"></bq-progress>
       `
     })
-    export class DefaultProgressComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -231,6 +232,7 @@ Use `thickness="large"` to increase the visual weight of the progress bar in mor
     import { BqProgress } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqProgress],
       template: `
@@ -238,7 +240,7 @@ Use `thickness="large"` to increase the visual weight of the progress bar in mor
         <bq-progress thickness="large" value="30"></bq-progress>
       `
     })
-    export class LargeThicknessProgressComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -283,11 +285,12 @@ Use `type="error"` to communicate that a process failed or needs attention.
     import { BqProgress } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqProgress],
       template: `<bq-progress type="error" value="30"></bq-progress>`
     })
-    export class ErrorProgressComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -346,6 +349,7 @@ Use `border-shape="square"` when you want a straighter edge treatment. The defau
     import { BqProgress } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqProgress],
       template: `
@@ -353,7 +357,7 @@ Use `border-shape="square"` when you want a straighter edge treatment. The defau
         <bq-progress border-shape="square" value="80"></bq-progress>
       `
     })
-    export class BorderShapeProgressComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -415,6 +419,7 @@ Add `label` to display a persistent numeric percentage beside the bar.
     import { BqProgress } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqProgress],
       template: `
@@ -424,7 +429,7 @@ Add `label` to display a persistent numeric percentage beside the bar.
         <bq-progress label value="100"></bq-progress>
       `
     })
-    export class LabelProgressComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -486,6 +491,7 @@ Add `enable-tooltip` to show the current percentage at the indicator. In the cur
     import { BqProgress } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqProgress],
       template: `
@@ -494,7 +500,7 @@ Add `enable-tooltip` to show the current percentage at the indicator. In the cur
         <bq-progress enable-tooltip value="75"></bq-progress>
       `
     })
-    export class TooltipProgressComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -544,11 +550,12 @@ Use `indeterminate` when the task is active but the exact completion point canno
     import { BqProgress } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqProgress],
       template: `<bq-progress indeterminate></bq-progress>`
     })
-    export class IndeterminateProgressComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/radio.mdx
+++ b/apps/beeq-docs/components/radio.mdx
@@ -150,6 +150,7 @@ Wrap `bq-radio` elements inside a `bq-radio-group`. Set a matching `value` on th
     import { BqRadio, BqRadioGroup } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqRadio, BqRadioGroup],
       template: `
@@ -161,7 +162,7 @@ Wrap `bq-radio` elements inside a `bq-radio-group`. Set a matching `value` on th
         </bq-radio-group>
       `
     })
-    export class DefaultRadioGroupComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -250,6 +251,7 @@ Set `disabled` on the group to prevent all interaction. You can also disable ind
     import { BqRadio, BqRadioGroup } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqRadio, BqRadioGroup],
       template: `
@@ -270,7 +272,7 @@ Set `disabled` on the group to prevent all interaction. You can also disable ind
         </bq-radio-group>
       `
     })
-    export class DisabledRadioGroupComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -337,6 +339,7 @@ Use `orientation="horizontal"` to arrange options side by side. Best for short l
     import { BqRadio, BqRadioGroup } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqRadio, BqRadioGroup],
       template: `
@@ -348,7 +351,7 @@ Use `orientation="horizontal"` to arrange options side by side. Best for short l
         </bq-radio-group>
       `
     })
-    export class HorizontalRadioGroupComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -406,6 +409,7 @@ Add the `fieldset` attribute to render a visible border and legend around the gr
     import { BqRadio, BqRadioGroup } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqRadio, BqRadioGroup],
       template: `
@@ -417,7 +421,7 @@ Add the `fieldset` attribute to render a visible border and legend around the gr
         </bq-radio-group>
       `
     })
-    export class FieldsetRadioGroupComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -475,6 +479,7 @@ Set `background-on-hover` on the group (or on individual `bq-radio` elements) to
     import { BqRadio, BqRadioGroup } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqRadio, BqRadioGroup],
       template: `
@@ -486,7 +491,7 @@ Set `background-on-hover` on the group (or on individual `bq-radio` elements) to
         </bq-radio-group>
       `
     })
-    export class BackgroundOnHoverRadioGroupComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/select.mdx
+++ b/apps/beeq-docs/components/select.mdx
@@ -138,7 +138,7 @@ Enhance user interaction by implementing the default select variant. Perfect for
   </bq-select>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-select placeholder="Placeholder">
       <label slot="label">Select label</label>
       <span slot="helper-text">
@@ -151,7 +151,7 @@ Enhance user interaction by implementing the default select variant. Perfect for
     </bq-select>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqIcon, BqOption, BqSelect } from "@beeq/react";
 
     <BqSelect placeholder="Placeholder">
@@ -166,7 +166,7 @@ Enhance user interaction by implementing the default select variant. Perfect for
     </BqSelect>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
@@ -190,7 +190,7 @@ Enhance user interaction by implementing the default select variant. Perfect for
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <template>
       <BqSelect placeholder="Placeholder">
         <label slot="label">Select label</label>
@@ -237,7 +237,7 @@ Use the `open` attribute to display the select dropdown by default, offering use
   </bq-select>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-select autofocus open placeholder="Placeholder">
       <label slot="label">Select label</label>
       <span slot="helper-text">
@@ -250,7 +250,7 @@ Use the `open` attribute to display the select dropdown by default, offering use
     </bq-select>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqIcon, BqOption, BqSelect } from "@beeq/react";
 
     <BqSelect autofocus open placeholder="Placeholder">
@@ -265,7 +265,7 @@ Use the `open` attribute to display the select dropdown by default, offering use
     </BqSelect>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
@@ -289,7 +289,7 @@ Use the `open` attribute to display the select dropdown by default, offering use
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <template>
       <BqSelect autofocus open placeholder="Placeholder">
         <label slot="label">Select label</label>
@@ -335,7 +335,7 @@ Set an initial `value` for the select component to preselect an option, providin
   </bq-select>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-select placeholder="Placeholder" value="2">
       <label slot="label">Select label</label>
       <span slot="helper-text">
@@ -348,7 +348,7 @@ Set an initial `value` for the select component to preselect an option, providin
     </bq-select>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqIcon, BqOption, BqSelect } from "@beeq/react";
 
     <BqSelect placeholder="Placeholder" value="2">
@@ -363,7 +363,7 @@ Set an initial `value` for the select component to preselect an option, providin
     </BqSelect>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
@@ -387,7 +387,7 @@ Set an initial `value` for the select component to preselect an option, providin
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <template>
       <BqSelect placeholder="Placeholder" value="2">
         <label slot="label">Select label</label>
@@ -484,7 +484,7 @@ The `displayValue` property (`display-value` attribute) on `bq-option` overrides
   </bq-select>
 `}>
   <CodeGroup>
-    ```css payment-option.css icon="css3"
+    ```css styles.css icon="css" expandable
     .payment-option {
       display: flex;
       flex-direction: column;
@@ -516,7 +516,7 @@ The `displayValue` property (`display-value` attribute) on `bq-option` overrides
     }
     ```
 
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-select placeholder="Payment method..." open>
       <label slot="label">Choose a payment method</label>
       <span slot="helper-text">
@@ -554,9 +554,9 @@ The `displayValue` property (`display-value` attribute) on `bq-option` overrides
     </bq-select>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqIcon, BqOption, BqSelect } from "@beeq/react";
-    import "./payment-option.css";
+    import "./styles.css";
 
     <BqSelect placeholder="Payment method..." open>
       <label slot="label">Choose a payment method</label>
@@ -595,7 +595,7 @@ The `displayValue` property (`display-value` attribute) on `bq-option` overrides
     </BqSelect>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
@@ -640,8 +640,8 @@ The `displayValue` property (`display-value` attribute) on `bq-option` overrides
           </bq-option>
         </bq-select>
       `,
-      styles: [
-        `
+      style: `
+
           .payment-option {
             display: flex;
             flex-direction: column;
@@ -671,13 +671,13 @@ The `displayValue` property (`display-value` attribute) on `bq-option` overrides
           .payment-option__owner {
             font-size: var(--bq-font-size--xs);
           }
-        `
-      ],
+        
+      `,
     })
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup>
     import { BqIcon, BqOption, BqSelect } from "@beeq/vue";
     </script>
@@ -781,7 +781,7 @@ Employ the `disabled` attribute to restrict user interaction with the select com
   </bq-select>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-select disabled placeholder="Placeholder" value="3">
       <label slot="label">Select label</label>
       <span slot="helper-text">
@@ -794,7 +794,7 @@ Employ the `disabled` attribute to restrict user interaction with the select com
     </bq-select>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqIcon, BqOption, BqSelect } from "@beeq/react";
 
     <BqSelect disabled placeholder="Placeholder" value="3">
@@ -809,7 +809,7 @@ Employ the `disabled` attribute to restrict user interaction with the select com
     </BqSelect>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
@@ -833,7 +833,7 @@ Employ the `disabled` attribute to restrict user interaction with the select com
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <template>
       <BqSelect disabled placeholder="Placeholder" value="3">
         <label slot="label">Select label</label>
@@ -907,7 +907,7 @@ Use the `multiple` property to enable multiple selections. Use `keep-open-on-sel
   </bq-select>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-select
       multiple
       keep-open-on-select
@@ -947,7 +947,7 @@ Use the `multiple` property to enable multiple selections. Use `keep-open-on-sel
     </bq-select>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqIcon, BqOption, BqSelect } from "@beeq/react";
 
     <BqSelect
@@ -989,7 +989,7 @@ Use the `multiple` property to enable multiple selections. Use `keep-open-on-sel
     </BqSelect>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
@@ -1040,7 +1040,7 @@ Use the `multiple` property to enable multiple selections. Use `keep-open-on-sel
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <template>
       <BqSelect
         multiple
@@ -1117,7 +1117,7 @@ Use the `prefix` slot to include additional visual elements or context, such as 
   </bq-select>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-select placeholder="Placeholder">
       <label slot="label">Select label</label>
       <bq-icon name="user-circle" slot="prefix"></bq-icon>
@@ -1131,7 +1131,7 @@ Use the `prefix` slot to include additional visual elements or context, such as 
     </bq-select>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqIcon, BqOption, BqSelect } from "@beeq/react";
 
     <BqSelect placeholder="Placeholder">
@@ -1147,7 +1147,7 @@ Use the `prefix` slot to include additional visual elements or context, such as 
     </BqSelect>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
@@ -1172,7 +1172,7 @@ Use the `prefix` slot to include additional visual elements or context, such as 
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <template>
       <BqSelect placeholder="Placeholder">
         <label slot="label">Select label</label>
@@ -1221,7 +1221,7 @@ Leverage the `suffix` slot to enhance the select component with extra elements. 
   </bq-select>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-select placeholder="Placeholder">
       <label slot="label">Select label</label>
       <bq-icon name="arrow-down" slot="suffix"></bq-icon>
@@ -1235,7 +1235,7 @@ Leverage the `suffix` slot to enhance the select component with extra elements. 
     </bq-select>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqIcon, BqOption, BqSelect } from "@beeq/react";
 
     <BqSelect placeholder="Placeholder">
@@ -1251,7 +1251,7 @@ Leverage the `suffix` slot to enhance the select component with extra elements. 
     </BqSelect>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
@@ -1276,7 +1276,7 @@ Leverage the `suffix` slot to enhance the select component with extra elements. 
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <template>
       <BqSelect placeholder="Placeholder">
         <label slot="label">Select label</label>
@@ -1346,7 +1346,7 @@ Use `validation-status` to signal the validation state (`error`, `warning`, or `
   </bq-select>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-select placeholder="Placeholder" validation-status="error" value="1">
       <label slot="label">Select label</label>
       <span slot="helper-text">
@@ -1381,7 +1381,7 @@ Use `validation-status` to signal the validation state (`error`, `warning`, or `
     </bq-select>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqIcon, BqOption, BqSelect } from "@beeq/react";
 
     <BqSelect placeholder="Placeholder" validationStatus="error" value="1">
@@ -1418,7 +1418,7 @@ Use `validation-status` to signal the validation state (`error`, `warning`, or `
     </BqSelect>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
@@ -1464,7 +1464,7 @@ Use `validation-status` to signal the validation state (`error`, `warning`, or `
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <template>
       <BqSelect placeholder="Placeholder" validationStatus="error" value="1">
         <label slot="label">Select label</label>
@@ -1553,7 +1553,7 @@ Choose this style when you want to include an optional label for additional cont
   </bq-select>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-select placeholder="Placeholder">
       <div slot="label">
         <label>Select label</label>
@@ -1570,7 +1570,7 @@ Choose this style when you want to include an optional label for additional cont
     </bq-select>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqIcon, BqOption, BqSelect } from "@beeq/react";
 
     <BqSelect placeholder="Placeholder">
@@ -1589,7 +1589,7 @@ Choose this style when you want to include an optional label for additional cont
     </BqSelect>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
@@ -1617,7 +1617,7 @@ Choose this style when you want to include an optional label for additional cont
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <template>
       <BqSelect placeholder="Placeholder">
         <div slot="label">
@@ -1698,7 +1698,7 @@ Enhance user understanding by incorporating a `bq-tooltip` alongside the label, 
   </bq-select>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-select placeholder="Placeholder">
       <div slot="label">
         <label>
@@ -1721,7 +1721,7 @@ Enhance user understanding by incorporating a `bq-tooltip` alongside the label, 
     </bq-select>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqIcon, BqOption, BqSelect, BqTooltip } from "@beeq/react";
 
     <BqSelect placeholder="Placeholder">
@@ -1746,7 +1746,7 @@ Enhance user understanding by incorporating a `bq-tooltip` alongside the label, 
     </BqSelect>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqOption, BqSelect, BqTooltip } from "@beeq/angular/standalone";
 
@@ -1780,7 +1780,7 @@ Enhance user understanding by incorporating a `bq-tooltip` alongside the label, 
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <template>
       <BqSelect placeholder="Placeholder">
         <div slot="label">
@@ -1855,7 +1855,7 @@ Adjust the panel placement to suit your layout. Use the `placement` attribute to
   </bq-select>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-select placeholder="Placeholder" placement="top">
       <label slot="label">
         Select label
@@ -1875,7 +1875,7 @@ Adjust the panel placement to suit your layout. Use the `placement` attribute to
     </bq-select>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqIcon, BqOption, BqSelect, BqTooltip } from "@beeq/react";
 
     <BqSelect placeholder="Placeholder" placement="top">
@@ -1897,7 +1897,7 @@ Adjust the panel placement to suit your layout. Use the `placement` attribute to
     </BqSelect>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqOption, BqSelect, BqTooltip } from "@beeq/angular/standalone";
 
@@ -1928,7 +1928,7 @@ Adjust the panel placement to suit your layout. Use the `placement` attribute to
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <template>
       <BqSelect placeholder="Placeholder" placement="top">
         <label slot="label">
@@ -1983,7 +1983,7 @@ Use this style when you prefer a minimal look and the field's purpose is conveye
   </bq-select>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-select placeholder="Placeholder">
       <bq-icon name="user-circle" slot="prefix"></bq-icon>
       <span slot="helper-text">
@@ -1996,7 +1996,7 @@ Use this style when you prefer a minimal look and the field's purpose is conveye
     </bq-select>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqIcon, BqOption, BqSelect } from "@beeq/react";
 
     <BqSelect placeholder="Placeholder">
@@ -2011,7 +2011,7 @@ Use this style when you prefer a minimal look and the field's purpose is conveye
     </BqSelect>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
@@ -2035,7 +2035,7 @@ Use this style when you prefer a minimal look and the field's purpose is conveye
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <template>
       <BqSelect placeholder="Placeholder">
         <BqIcon name="user-circle" slot="prefix" />
@@ -2074,7 +2074,7 @@ Select this variant when you don't need additional helper text, giving users a s
   </bq-select>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-select placeholder="Placeholder">
       <label slot="label">Select label</label>
       <bq-icon name="user-circle" slot="prefix"></bq-icon>
@@ -2084,7 +2084,7 @@ Select this variant when you don't need additional helper text, giving users a s
     </bq-select>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqIcon, BqOption, BqSelect } from "@beeq/react";
 
     <BqSelect placeholder="Placeholder">
@@ -2096,7 +2096,7 @@ Select this variant when you don't need additional helper text, giving users a s
     </BqSelect>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
@@ -2117,7 +2117,7 @@ Select this variant when you don't need additional helper text, giving users a s
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <template>
       <BqSelect placeholder="Placeholder">
         <label slot="label">Select label</label>
@@ -2162,7 +2162,7 @@ A readonly select shows the current value but prevents the panel from opening. U
   </bq-select>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-select placeholder="Placeholder" value="2" readonly>
       <label slot="label">Select label</label>
       <span slot="helper-text">
@@ -2175,7 +2175,7 @@ A readonly select shows the current value but prevents the panel from opening. U
     </bq-select>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqIcon, BqOption, BqSelect } from "@beeq/react";
 
     <BqSelect placeholder="Placeholder" value="2" readOnly>
@@ -2190,7 +2190,7 @@ A readonly select shows the current value but prevents the panel from opening. U
     </BqSelect>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
@@ -2214,7 +2214,7 @@ A readonly select shows the current value but prevents the panel from opening. U
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <template>
       <BqSelect placeholder="Placeholder" value="2" readonly>
         <label slot="label">Select label</label>
@@ -2262,7 +2262,7 @@ Set `disable-clear` to hide the clear button and prevent one-click deselection. 
   </bq-select>
 `}>
   <CodeGroup>
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-select placeholder="Placeholder" value="1" disable-clear>
       <label slot="label">Select label</label>
       <span slot="helper-text">
@@ -2275,7 +2275,7 @@ Set `disable-clear` to hide the clear button and prevent one-click deselection. 
     </bq-select>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqIcon, BqOption, BqSelect } from "@beeq/react";
 
     <BqSelect placeholder="Placeholder" value="1" disableClear>
@@ -2290,7 +2290,7 @@ Set `disable-clear` to hide the clear button and prevent one-click deselection. 
     </BqSelect>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
@@ -2314,7 +2314,7 @@ Set `disable-clear` to hide the clear button and prevent one-click deselection. 
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <template>
       <BqSelect placeholder="Placeholder" value="1" disableClear>
         <label slot="label">Select label</label>

--- a/apps/beeq-docs/components/select.mdx
+++ b/apps/beeq-docs/components/select.mdx
@@ -641,37 +641,35 @@ The `displayValue` property (`display-value` attribute) on `bq-option` overrides
         </bq-select>
       `,
       styles: [`
+        .payment-option {
+          display: flex;
+          flex-direction: column;
+          gap: var(--bq-spacing-xs2);
+        }
 
-          .payment-option {
-            display: flex;
-            flex-direction: column;
-            gap: var(--bq-spacing-xs2);
-          }
+        .payment-option__header {
+          display: flex;
+          align-items: center;
+          gap: var(--bq-spacing-xs);
+        }
 
-          .payment-option__header {
-            display: flex;
-            align-items: center;
-            gap: var(--bq-spacing-xs);
-          }
+        .payment-option__name {
+          font-weight: 600;
+        }
 
-          .payment-option__name {
-            font-weight: 600;
-          }
+        .payment-option__meta,
+        .payment-option__owner {
+          padding-inline-start: 28px;
+          color: var(--bq-text--secondary);
+        }
 
-          .payment-option__meta,
-          .payment-option__owner {
-            padding-inline-start: 28px;
-            color: var(--bq-text--secondary);
-          }
+        .payment-option__meta {
+          font-size: var(--bq-font-size--s);
+        }
 
-          .payment-option__meta {
-            font-size: var(--bq-font-size--s);
-          }
-
-          .payment-option__owner {
-            font-size: var(--bq-font-size--xs);
-          }
-        
+        .payment-option__owner {
+          font-size: var(--bq-font-size--xs);
+        }
       `],
     })
     export class AppComponent {}
@@ -721,35 +719,35 @@ The `displayValue` property (`display-value` attribute) on `bq-option` overrides
     </template>
 
     <style>
-    .payment-option {
-      display: flex;
-      flex-direction: column;
-      gap: var(--bq-spacing-xs2);
-    }
+      .payment-option {
+        display: flex;
+        flex-direction: column;
+        gap: var(--bq-spacing-xs2);
+      }
 
-    .payment-option__header {
-      display: flex;
-      align-items: center;
-      gap: var(--bq-spacing-xs);
-    }
+      .payment-option__header {
+        display: flex;
+        align-items: center;
+        gap: var(--bq-spacing-xs);
+      }
 
-    .payment-option__name {
-      font-weight: 600;
-    }
+      .payment-option__name {
+        font-weight: 600;
+      }
 
-    .payment-option__meta,
-    .payment-option__owner {
-      padding-inline-start: 28px;
-      color: var(--bq-text--secondary);
-    }
+      .payment-option__meta,
+      .payment-option__owner {
+        padding-inline-start: 28px;
+        color: var(--bq-text--secondary);
+      }
 
-    .payment-option__meta {
-      font-size: var(--bq-font-size--s);
-    }
+      .payment-option__meta {
+        font-size: var(--bq-font-size--s);
+      }
 
-    .payment-option__owner {
-      font-size: var(--bq-font-size--xs);
-    }
+      .payment-option__owner {
+        font-size: var(--bq-font-size--xs);
+      }
     </style>
     ```
   </CodeGroup>

--- a/apps/beeq-docs/components/select.mdx
+++ b/apps/beeq-docs/components/select.mdx
@@ -484,7 +484,7 @@ The `displayValue` property (`display-value` attribute) on `bq-option` overrides
   </bq-select>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     .payment-option {
       display: flex;
       flex-direction: column;
@@ -640,7 +640,7 @@ The `displayValue` property (`display-value` attribute) on `bq-option` overrides
           </bq-option>
         </bq-select>
       `,
-      style: `
+      styles: [`
 
           .payment-option {
             display: flex;
@@ -672,7 +672,7 @@ The `displayValue` property (`display-value` attribute) on `bq-option` overrides
             font-size: var(--bq-font-size--xs);
           }
         
-      `,
+      `],
     })
     export class AppComponent {}
     ```
@@ -2491,24 +2491,6 @@ Call `preventDefault()` on the `bqInput` event to take full control of option fi
       const select = document.querySelector('#custom-select');
       const staticOpts = Array.from(select.querySelectorAll('bq-option'));
 
-    const select = previewRoot.querySelector('#custom-select');
-
-    function highlight(text, query) {
-      const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      return text.replace(new RegExp(`(${escaped})`, 'gi'), '<b>$1</b>');
-    }
-
-    function renderOptions(items, query = '') {
-      select.querySelectorAll('bq-option').forEach((el) => el.remove());
-
-      if (items.length === 0) {
-        const opt = document.createElement('bq-option');
-        opt.setAttribute('disabled', '');
-        opt.innerHTML = `<bq-icon slot="prefix" name="x-circle"></bq-icon> No results found`;
-        select.appendChild(opt);
-        return;
-      }
-
       function removeTempOpts() {
         select.querySelectorAll('bq-option[data-temp]').forEach((opt) => opt.remove());
       }
@@ -2578,6 +2560,11 @@ Call `preventDefault()` on the `bqInput` event to take full control of option fi
         removeTempOpts();
         showAllOptions();
       });
+
+      function highlight(text, query) {
+        const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        return text.replace(new RegExp(`(${escaped})`, 'gi'), '<b>$1</b>');
+      }
     </script>
     ```
 

--- a/apps/beeq-docs/components/select.mdx
+++ b/apps/beeq-docs/components/select.mdx
@@ -2475,9 +2475,22 @@ Call `preventDefault()` on the `bqInput` event to take full control of option fi
       const select = document.querySelector('#custom-select');
       const staticOpts = Array.from(select.querySelectorAll('bq-option'));
 
-      function highlight(text, query) {
-        const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        return text.replace(new RegExp(`(${escaped})`, 'gi'), '<b>$1</b>');
+    const select = previewRoot.querySelector('#custom-select');
+
+    function highlight(text, query) {
+      const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      return text.replace(new RegExp(`(${escaped})`, 'gi'), '<b>$1</b>');
+    }
+
+    function renderOptions(items, query = '') {
+      select.querySelectorAll('bq-option').forEach((el) => el.remove());
+
+      if (items.length === 0) {
+        const opt = document.createElement('bq-option');
+        opt.setAttribute('disabled', '');
+        opt.innerHTML = `<bq-icon slot="prefix" name="x-circle"></bq-icon> No results found`;
+        select.appendChild(opt);
+        return;
       }
 
       function removeTempOpts() {

--- a/apps/beeq-docs/components/select.mdx
+++ b/apps/beeq-docs/components/select.mdx
@@ -484,7 +484,7 @@ The `displayValue` property (`display-value` attribute) on `bq-option` overrides
   </bq-select>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     .payment-option {
       display: flex;
       flex-direction: column;

--- a/apps/beeq-docs/components/select.mdx
+++ b/apps/beeq-docs/components/select.mdx
@@ -171,6 +171,7 @@ Enhance user interaction by implementing the default select variant. Perfect for
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqOption, BqSelect],
       template: `
@@ -186,7 +187,7 @@ Enhance user interaction by implementing the default select variant. Perfect for
         </bq-select>
       `
     })
-    export class DefaultSelectComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -269,6 +270,7 @@ Use the `open` attribute to display the select dropdown by default, offering use
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqOption, BqSelect],
       template: `
@@ -284,7 +286,7 @@ Use the `open` attribute to display the select dropdown by default, offering use
         </bq-select>
       `
     })
-    export class OpenSelectComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -366,6 +368,7 @@ Set an initial `value` for the select component to preselect an option, providin
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqOption, BqSelect],
       template: `
@@ -381,7 +384,7 @@ Set an initial `value` for the select component to preselect an option, providin
         </bq-select>
       `
     })
-    export class InitialValueSelectComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -597,6 +600,7 @@ The `displayValue` property (`display-value` attribute) on `bq-option` overrides
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqOption, BqSelect],
       template: `
@@ -670,7 +674,7 @@ The `displayValue` property (`display-value` attribute) on `bq-option` overrides
         `
       ],
     })
-    export class DisplayValueSelectComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -810,6 +814,7 @@ Employ the `disabled` attribute to restrict user interaction with the select com
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqOption, BqSelect],
       template: `
@@ -825,7 +830,7 @@ Employ the `disabled` attribute to restrict user interaction with the select com
         </bq-select>
       `
     })
-    export class DisabledSelectComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -989,6 +994,7 @@ Use the `multiple` property to enable multiple selections. Use `keep-open-on-sel
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqOption, BqSelect],
       template: `
@@ -1031,7 +1037,7 @@ Use the `multiple` property to enable multiple selections. Use `keep-open-on-sel
         </bq-select>
       `
     })
-    export class MultipleSelectComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -1146,6 +1152,7 @@ Use the `prefix` slot to include additional visual elements or context, such as 
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqOption, BqSelect],
       template: `
@@ -1162,7 +1169,7 @@ Use the `prefix` slot to include additional visual elements or context, such as 
         </bq-select>
       `
     })
-    export class PrefixSelectComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -1249,6 +1256,7 @@ Leverage the `suffix` slot to enhance the select component with extra elements. 
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqOption, BqSelect],
       template: `
@@ -1265,7 +1273,7 @@ Leverage the `suffix` slot to enhance the select component with extra elements. 
         </bq-select>
       `
     })
-    export class SuffixSelectComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -1415,6 +1423,7 @@ Use `validation-status` to signal the validation state (`error`, `warning`, or `
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqOption, BqSelect],
       template: `
@@ -1452,7 +1461,7 @@ Use `validation-status` to signal the validation state (`error`, `warning`, or `
         </bq-select>
       `
     })
-    export class ValidationSelectComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -1585,6 +1594,7 @@ Choose this style when you want to include an optional label for additional cont
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqOption, BqSelect],
       template: `
@@ -1604,7 +1614,7 @@ Choose this style when you want to include an optional label for additional cont
         </bq-select>
       `
     })
-    export class LabelOptionalSelectComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -1741,6 +1751,7 @@ Enhance user understanding by incorporating a `bq-tooltip` alongside the label, 
     import { BqIcon, BqOption, BqSelect, BqTooltip } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqOption, BqSelect, BqTooltip],
       template: `
@@ -1766,7 +1777,7 @@ Enhance user understanding by incorporating a `bq-tooltip` alongside the label, 
         </bq-select>
       `
     })
-    export class LabelTooltipSelectComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -1891,6 +1902,7 @@ Adjust the panel placement to suit your layout. Use the `placement` attribute to
     import { BqIcon, BqOption, BqSelect, BqTooltip } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqOption, BqSelect, BqTooltip],
       template: `
@@ -1913,7 +1925,7 @@ Adjust the panel placement to suit your layout. Use the `placement` attribute to
         </bq-select>
       `
     })
-    export class PanelPlacementSelectComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -2004,6 +2016,7 @@ Use this style when you prefer a minimal look and the field's purpose is conveye
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqOption, BqSelect],
       template: `
@@ -2019,7 +2032,7 @@ Use this style when you prefer a minimal look and the field's purpose is conveye
         </bq-select>
       `
     })
-    export class NoLabelSelectComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -2088,6 +2101,7 @@ Select this variant when you don't need additional helper text, giving users a s
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqOption, BqSelect],
       template: `
@@ -2100,7 +2114,7 @@ Select this variant when you don't need additional helper text, giving users a s
         </bq-select>
       `
     })
-    export class NoHelperTextSelectComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -2181,6 +2195,7 @@ A readonly select shows the current value but prevents the panel from opening. U
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqOption, BqSelect],
       template: `
@@ -2196,7 +2211,7 @@ A readonly select shows the current value but prevents the panel from opening. U
         </bq-select>
       `
     })
-    export class ReadonlySelectComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -2280,6 +2295,7 @@ Set `disable-clear` to hide the clear button and prevent one-click deselection. 
     import { BqIcon, BqOption, BqSelect } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqOption, BqSelect],
       template: `
@@ -2295,7 +2311,7 @@ Set `disable-clear` to hide the clear button and prevent one-click deselection. 
         </bq-select>
       `
     })
-    export class DisableClearSelectComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -2677,6 +2693,7 @@ Call `preventDefault()` on the `bqInput` event to take full control of option fi
     ];
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqOption, BqSelect, BqSpinner],
       template: `
@@ -2709,7 +2726,7 @@ Call `preventDefault()` on the `bqInput` event to take full control of option fi
         </bq-select>
       `
     })
-    export class CustomFilteringSelectComponent {
+    export class AppComponent {
       visibleOptions = [...ALL_OPTIONS];
       isLoading = false;
 

--- a/apps/beeq-docs/components/side-menu.mdx
+++ b/apps/beeq-docs/components/side-menu.mdx
@@ -147,7 +147,7 @@ The default side menu is a versatile container for organizing and displaying nav
   </bq-side-menu>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     .app-logo {
       display: flex;
       align-items: center;
@@ -1289,7 +1289,7 @@ Use the footer slot for supplementary actions, links, or information at the bott
   </bq-side-menu>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     app-logo {
       display: flex;
       align-items: center;
@@ -1658,7 +1658,7 @@ Wire your app control to the side menu state so the button can expand and collap
   </script>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     .app-menu[collapse] [slot="logo"] {
       padding-inline: var(--bq-spacing-xs);
     }

--- a/apps/beeq-docs/components/side-menu.mdx
+++ b/apps/beeq-docs/components/side-menu.mdx
@@ -269,7 +269,7 @@ The default side menu is a versatile container for organizing and displaying nav
           </bq-side-menu-item>
         </bq-side-menu>
       `,
-      styles: `
+      styles: [`
         .app-logo {
           display: flex;
           align-items: center;
@@ -287,7 +287,7 @@ The default side menu is a versatile container for organizing and displaying nav
           font-size: var(--bq-font-size--xl);
           white-space: nowrap;
         }
-      `
+      `]
     })
     export class DefaultSideMenuComponent {}
     ```
@@ -1447,7 +1447,7 @@ Use the footer slot for supplementary actions, links, or information at the bott
           </div>
         </bq-side-menu>
       `,
-      styles: `
+      styles: [`
         .app-logo {
           display: flex;
           align-items: center;
@@ -1465,7 +1465,7 @@ Use the footer slot for supplementary actions, links, or information at the bott
           font-size: var(--bq-font-size--xl);
           white-space: nowrap;
         }
-      `
+      `]
     })
     export class DefaultSideMenuComponent {}
     ```
@@ -1658,7 +1658,7 @@ Wire your app control to the side menu state so the button can expand and collap
   </script>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     .app-menu[collapse] [slot="logo"] {
       padding-inline: var(--bq-spacing-xs);
     }
@@ -1876,7 +1876,7 @@ Wire your app control to the side menu state so the button can expand and collap
           </div>
         </main>
       `,
-      styles: `
+      styles: [`
         .app-menu[collapse] [slot="logo"] {
           padding-inline: var(--bq-spacing-xs);
         }
@@ -1924,7 +1924,7 @@ Wire your app control to the side menu state so the button can expand and collap
           border: 2px dashed var(--bq-color-primary);
           background-color: var(--bq-ui--alt);
         }
-      `
+      `]
     })
     export class CollapsibleSideMenuComponent {
       isCollapsed = true;

--- a/apps/beeq-docs/components/side-menu.mdx
+++ b/apps/beeq-docs/components/side-menu.mdx
@@ -329,23 +329,23 @@ The default side menu is a versatile container for organizing and displaying nav
     </template>
 
     <style>
-    .app-logo {
-      display: flex;
-      align-items: center;
-      gap: var(--bq-spacing-s);
-      padding-inline: var(--bq-spacing-m);
-      padding-block-start: var(--bq-spacing-m);
-    }
+      .app-logo {
+        display: flex;
+        align-items: center;
+        gap: var(--bq-spacing-s);
+        padding-inline: var(--bq-spacing-m);
+        padding-block-start: var(--bq-spacing-m);
+      }
 
-    .app-logo svg {
-      height: 2.5rem;
-      width: 2.5rem;
-    }
+      .app-logo svg {
+        height: 2.5rem;
+        width: 2.5rem;
+      }
 
-    .app-logo h1 {
-      font-size: var(--bq-font-size--xl);
-      white-space: nowrap;
-    }
+      .app-logo h1 {
+        font-size: var(--bq-font-size--xl);
+        white-space: nowrap;
+      }
     </style>
     ```
   </CodeGroup>
@@ -1519,22 +1519,22 @@ Use the footer slot for supplementary actions, links, or information at the bott
     </template>
 
     <style>
-    .app-logo {
-      display: flex;
-      align-items: center;
-      gap: var(--bq-spacing-s);
-      padding: var(--bq-spacing-m);
-    }
+      .app-logo {
+        display: flex;
+        align-items: center;
+        gap: var(--bq-spacing-s);
+        padding: var(--bq-spacing-m);
+      }
 
-    .app-logo svg {
-      height: 2.5rem;
-      width: 2.5rem;
-    }
+      .app-logo svg {
+        height: 2.5rem;
+        width: 2.5rem;
+      }
 
-    .app-logo h1 {
-      font-size: var(--bq-font-size--xl);
-      white-space: nowrap;
-    }
+      .app-logo h1 {
+        font-size: var(--bq-font-size--xl);
+        white-space: nowrap;
+      }
     </style>
     ```
   </CodeGroup>

--- a/apps/beeq-docs/components/spinner.mdx
+++ b/apps/beeq-docs/components/spinner.mdx
@@ -142,11 +142,12 @@ Use the default spinner when the surrounding UI already makes the loading contex
     import { BqSpinner } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqSpinner],
       template: `<bq-spinner></bq-spinner>`
     })
-    export class DefaultSpinnerComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -190,11 +191,12 @@ Use the small spinner when space is limited and the loading state belongs to a c
     import { BqSpinner } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqSpinner],
       template: `<bq-spinner size="small"></bq-spinner>`
     })
-    export class SmallSpinnerComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -232,11 +234,12 @@ Use `size="large"` for prominent loading states such as page-level waits, major 
     import { BqSpinner } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqSpinner],
       template: `<bq-spinner size="large"></bq-spinner>`
     })
-    export class LargeSpinnerComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -291,6 +294,7 @@ Use `text-position` to control where the loading message appears relative to the
     import { BqSpinner } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqSpinner],
       template: `
@@ -300,7 +304,7 @@ Use `text-position` to control where the loading message appears relative to the
         <bq-spinner text-position="left">Processing...</bq-spinner>
       `
     })
-    export class LabelledSpinnerComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -347,6 +351,7 @@ Use the `icon` slot when you need a different spinner icon treatment. Make sure 
     import { BqIcon, BqSpinner } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqSpinner],
       template: `
@@ -355,7 +360,7 @@ Use the `icon` slot when you need a different spinner icon treatment. Make sure 
         </bq-spinner>
       `
     })
-    export class CustomIconSpinnerComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/status.mdx
+++ b/apps/beeq-docs/components/status.mdx
@@ -104,11 +104,18 @@ Use the default neutral status when the message should stay present without stro
     <BqStatus>Neutral status</BqStatus>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqStatus } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-
-    <bq-status>Neutral status</bq-status>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqStatus } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqStatus],
+      template: `
+        <bq-status>Neutral status</bq-status>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -147,11 +154,18 @@ Use `type="alert"` when the message needs immediate attention.
     <BqStatus type="alert">Alert status</BqStatus>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqStatus } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-
-    <bq-status type="alert">Alert status</bq-status>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqStatus } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqStatus],
+      template: `
+        <bq-status type="alert">Alert status</bq-status>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -186,11 +200,18 @@ Use `type="danger"` when the state signals risk, failure, or a blocked condition
     <BqStatus type="danger">Danger status</BqStatus>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqStatus } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-
-    <bq-status type="danger">Danger status</bq-status>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqStatus } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqStatus],
+      template: `
+        <bq-status type="danger">Danger status</bq-status>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -225,11 +246,18 @@ Use `type="info"` when the status provides neutral or supporting context.
     <BqStatus type="info">Information status</BqStatus>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqStatus } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-
-    <bq-status type="info">Information status</bq-status>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqStatus } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqStatus],
+      template: `
+        <bq-status type="info">Information status</bq-status>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -264,11 +292,18 @@ Use `type="success"` when the state confirms a positive outcome.
     <BqStatus type="success">Success status</BqStatus>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqStatus } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-
-    <bq-status type="success">Success status</bq-status>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqStatus } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqStatus],
+      template: `
+        <bq-status type="success">Success status</bq-status>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/status.mdx
+++ b/apps/beeq-docs/components/status.mdx
@@ -107,6 +107,7 @@ Use the default neutral status when the message should stay present without stro
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqStatus } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -157,6 +158,7 @@ Use `type="alert"` when the message needs immediate attention.
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqStatus } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -203,6 +205,7 @@ Use `type="danger"` when the state signals risk, failure, or a blocked condition
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqStatus } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -249,6 +252,7 @@ Use `type="info"` when the status provides neutral or supporting context.
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqStatus } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -295,6 +299,7 @@ Use `type="success"` when the state confirms a positive outcome.
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqStatus } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,

--- a/apps/beeq-docs/components/steps.mdx
+++ b/apps/beeq-docs/components/steps.mdx
@@ -812,7 +812,7 @@ Use `orientation="vertical"` when the process should unfold from top to bottom o
           flex-direction: column;
           flex-grow: 1;
         }
-      `
+      `],
     })
     export class VerticalStepsComponent {}
     ```

--- a/apps/beeq-docs/components/steps.mdx
+++ b/apps/beeq-docs/components/steps.mdx
@@ -723,7 +723,7 @@ Use `orientation="vertical"` when the process should unfold from top to bottom o
   </div>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     body {
       display: flex;
       padding: var(--bq-spacing-m);

--- a/apps/beeq-docs/components/steps.mdx
+++ b/apps/beeq-docs/components/steps.mdx
@@ -723,7 +723,7 @@ Use `orientation="vertical"` when the process should unfold from top to bottom o
   </div>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     body {
       display: flex;
       padding: var(--bq-spacing-m);
@@ -801,7 +801,7 @@ Use `orientation="vertical"` when the process should unfold from top to bottom o
           </bq-steps>
         </div>
       `,
-      style: `
+      styles: [`
         body {
           display: flex;
           padding: var(--bq-spacing-m);

--- a/apps/beeq-docs/components/switch.mdx
+++ b/apps/beeq-docs/components/switch.mdx
@@ -94,17 +94,17 @@ The default switch provides a basic on/off toggle functionality, allowing users 
   <bq-switch>Toggle me!</bq-switch>
 `}>
   <CodeGroup>
-    ```html HTML
+    ```html HTML icon="html5"
     <bq-switch>Toggle me!</bq-switch>
     ```
-    ```tsx React
+    ```tsx React icon="react"
     import { BqSwitch } from "@beeq/react";
 
     export default () => (
       <BqSwitch>Toggle me!</BqSwitch>
     );
     ```
-    ```ts Angular
+    ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqSwitch } from "@beeq/angular/standalone";
 
@@ -116,7 +116,7 @@ The default switch provides a basic on/off toggle functionality, allowing users 
     })
     export class AppComponent {}
     ```
-    ```vue Vue
+    ```vue Vue icon="vuejs"
     <script setup lang="ts">
     import { BqSwitch } from "@beeq/vue";
     </script>
@@ -140,17 +140,17 @@ Use the `checked` attribute to set the initial state of the toggle as ON. This i
   <bq-switch checked>Toggle me!</bq-switch>
 `}>
   <CodeGroup>
-    ```html HTML
+    ```html HTML icon="html5"
     <bq-switch checked>Toggle me!</bq-switch>
     ```
-    ```tsx React
+    ```tsx React icon="react"
     import { BqSwitch } from "@beeq/react";
 
     export default () => (
       <BqSwitch checked>Toggle me!</BqSwitch>
     );
     ```
-    ```ts Angular
+    ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqSwitch } from "@beeq/angular/standalone";
 
@@ -162,7 +162,7 @@ Use the `checked` attribute to set the initial state of the toggle as ON. This i
     })
     export class AppComponent {}
     ```
-    ```vue Vue
+    ```vue Vue icon="vuejs"
     <script setup lang="ts">
     import { BqSwitch } from "@beeq/vue";
     </script>
@@ -184,17 +184,17 @@ The disabled switch prevents user interaction, making it visually clear that the
   <bq-switch disabled>Toggle me!</bq-switch>
 `}>
   <CodeGroup>
-    ```html HTML
+    ```html HTML icon="html5"
     <bq-switch disabled>Toggle me!</bq-switch>
     ```
-    ```tsx React
+    ```tsx React icon="react"
     import { BqSwitch } from "@beeq/react";
 
     export default () => (
       <BqSwitch disabled>Toggle me!</BqSwitch>
     );
     ```
-    ```ts Angular
+    ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqSwitch } from "@beeq/angular/standalone";
 
@@ -206,7 +206,7 @@ The disabled switch prevents user interaction, making it visually clear that the
     })
     export class AppComponent {}
     ```
-    ```vue Vue
+    ```vue Vue icon="vuejs"
     <script setup lang="ts">
     import { BqSwitch } from "@beeq/vue";
     </script>
@@ -226,17 +226,17 @@ Enhance user understanding by incorporating an inner label that provides context
   <bq-switch inner-label="icon">Toggle me!</bq-switch>
 `}>
   <CodeGroup>
-    ```html HTML
+    ```html HTML icon="html5"
     <bq-switch inner-label="icon">Toggle me!</bq-switch>
     ```
-    ```tsx React
+    ```tsx React icon="react"
     import { BqSwitch } from "@beeq/react";
 
     export default () => (
       <BqSwitch innerLabel="icon">Toggle me!</BqSwitch>
     );
     ```
-    ```ts Angular
+    ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqSwitch } from "@beeq/angular/standalone";
 
@@ -248,7 +248,7 @@ Enhance user understanding by incorporating an inner label that provides context
     })
     export class AppComponent {}
     ```
-    ```vue Vue
+    ```vue Vue icon="vuejs"
     <script setup lang="ts">
     import { BqSwitch } from "@beeq/vue";
     </script>
@@ -268,17 +268,17 @@ The reverse order switch alters the visual arrangement, placing the toggle on th
   <bq-switch reverse-order>Toggle me!</bq-switch>
 `}>
   <CodeGroup>
-    ```html HTML
+    ```html HTML icon="html5"
     <bq-switch reverse-order>Toggle me!</bq-switch>
     ```
-    ```tsx React
+    ```tsx React icon="react"
     import { BqSwitch } from "@beeq/react";
 
     export default () => (
       <BqSwitch reverseOrder>Toggle me!</BqSwitch>
     );
     ```
-    ```ts Angular
+    ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqSwitch } from "@beeq/angular/standalone";
 
@@ -290,7 +290,7 @@ The reverse order switch alters the visual arrangement, placing the toggle on th
     })
     export class AppComponent {}
     ```
-    ```vue Vue
+    ```vue Vue icon="vuejs"
     <script setup lang="ts">
     import { BqSwitch } from "@beeq/vue";
     </script>
@@ -360,7 +360,7 @@ Use `full-width` with `reverse-order` and `justify-content="space-between"` to b
   </bq-switch>
 `}>
   <CodeGroup>
-    ```html HTML
+    ```html HTML icon="html5"
     <bq-switch
       background-on-hover
       full-width
@@ -405,7 +405,7 @@ Use `full-width` with `reverse-order` and `justify-content="space-between"` to b
       Show app notifications
     </bq-switch>
     ```
-    ```tsx React
+    ```tsx React icon="react"
     import { BqSwitch } from "@beeq/react";
 
     export default () => (
@@ -456,7 +456,7 @@ Use `full-width` with `reverse-order` and `justify-content="space-between"` to b
       </>
     );
     ```
-    ```ts Angular
+    ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqSwitch } from "@beeq/angular/standalone";
 
@@ -512,7 +512,7 @@ Use `full-width` with `reverse-order` and `justify-content="space-between"` to b
     })
     export class AppComponent {}
     ```
-    ```vue Vue
+    ```vue Vue icon="vuejs"
     <script setup lang="ts">
     import { BqSwitch } from "@beeq/vue";
     </script>

--- a/apps/beeq-docs/components/table.mdx
+++ b/apps/beeq-docs/components/table.mdx
@@ -225,7 +225,9 @@ The default table applies base typography, header and cell padding, and row sepa
     import { Component } from "@angular/core";
 
     @Component({
+      selector: "app-root",
       standalone: true,
+      imports: [],
       template: `
         <table class="bq-table">
           <thead>
@@ -255,7 +257,7 @@ The default table applies base typography, header and cell padding, and row sepa
         </table>
       `,
     })
-    export class DefaultTableComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -395,7 +397,9 @@ Add the `selected` class to a `<tr>` to highlight the active record. Use this wh
     import { Component } from "@angular/core";
 
     @Component({
+      selector: "app-root",
       standalone: true,
+      imports: [],
       template: `
         <table class="bq-table">
           <thead>
@@ -425,7 +429,7 @@ Add the `selected` class to a `<tr>` to highlight the active record. Use this wh
         </table>
       `,
     })
-    export class SelectedRowTableComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -563,7 +567,9 @@ Add the `compact` class to the `<table>` to reduce cell and header padding. This
     import { Component } from "@angular/core";
 
     @Component({
+      selector: "app-root",
       standalone: true,
+      imports: [],
       template: `
         <table class="bq-table compact">
           <thead>
@@ -593,7 +599,7 @@ Add the `compact` class to the `<table>` to reduce cell and header padding. This
         </table>
       `,
     })
-    export class CompactTableComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -731,7 +737,9 @@ Add the `bordered` class to draw explicit borders around each cell and the table
     import { Component } from "@angular/core";
 
     @Component({
+      selector: "app-root",
       standalone: true,
+      imports: [],
       template: `
         <table class="bq-table bordered">
           <thead>
@@ -761,7 +769,7 @@ Add the `bordered` class to draw explicit borders around each cell and the table
         </table>
       `,
     })
-    export class BorderedTableComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/tag.mdx
+++ b/apps/beeq-docs/components/tag.mdx
@@ -124,6 +124,7 @@ Use the standard tag when you want a simple and clean representation.
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqTag } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -176,6 +177,7 @@ Adjust the `size` attribute to customize the tag's dimensions and support a clea
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqTag } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -229,6 +231,7 @@ Apply the `clickable` attribute for interactive tags that can trigger actions or
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqTag } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -280,6 +283,7 @@ Apply `disabled` alongside `clickable` when a tag action is temporarily unavaila
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqTag } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -340,6 +344,7 @@ Use filled colored tags when you want a stronger visual distinction for categori
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqTag } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -404,6 +409,7 @@ Use `variant="outline"` when you want a subtler visual distinction without a fil
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqTag } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -481,6 +487,7 @@ Enable `removable` when users need to clear selected items, applied filters, or 
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqTag } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -559,6 +566,7 @@ Use `variant="outline"` with `removable` when you want the same close behavior w
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqTag } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -682,6 +690,7 @@ Use the `prefix` slot to add an icon when extra context helps, while keeping the
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqTag, BqIcon } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,
@@ -841,6 +850,7 @@ Use the outline variant with a prefix icon when you want context with a lighter 
     ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqTag, BqIcon } from "@beeq/angular/standalone";
+
     @Component({
       selector: "app-root",
       standalone: true,

--- a/apps/beeq-docs/components/tag.mdx
+++ b/apps/beeq-docs/components/tag.mdx
@@ -121,11 +121,18 @@ Use the standard tag when you want a simple and clean representation.
     <BqTag>Tag</BqTag>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqTag } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-
-    <bq-tag>Tag</bq-tag>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqTag } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqTag],
+      template: `
+        <bq-tag>Tag</bq-tag>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -166,10 +173,20 @@ Adjust the `size` attribute to customize the tag's dimensions and support a clea
     </>
     ```
 
-    ```html Angular icon="angular"
-    <bq-tag size="xsmall">Extra small</bq-tag>
-    <bq-tag size="small">Small</bq-tag>
-    <bq-tag size="medium">Medium</bq-tag>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqTag } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqTag],
+      template: `
+            <bq-tag size="xsmall">Extra small</bq-tag>
+            <bq-tag size="small">Small</bq-tag>
+            <bq-tag size="medium">Medium</bq-tag>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -209,9 +226,19 @@ Apply the `clickable` attribute for interactive tags that can trigger actions or
     </>
     ```
 
-    ```html Angular icon="angular"
-    <bq-tag clickable>Tag</bq-tag>
-    <bq-tag clickable selected>Tag</bq-tag>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqTag } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqTag],
+      template: `
+            <bq-tag clickable>Tag</bq-tag>
+            <bq-tag clickable selected>Tag</bq-tag>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -250,9 +277,19 @@ Apply `disabled` alongside `clickable` when a tag action is temporarily unavaila
     </>
     ```
 
-    ```html Angular icon="angular"
-    <bq-tag clickable>Enabled</bq-tag>
-    <bq-tag clickable disabled>Disabled</bq-tag>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqTag } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqTag],
+      template: `
+            <bq-tag clickable>Enabled</bq-tag>
+            <bq-tag clickable disabled>Disabled</bq-tag>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -300,12 +337,22 @@ Use filled colored tags when you want a stronger visual distinction for categori
     <BqTag color="gray">Gray</BqTag>
     ```
 
-    ```html Angular icon="angular"
-    <bq-tag color="success">Success</bq-tag>
-    <bq-tag color="info">Info</bq-tag>
-    <bq-tag color="error">Error</bq-tag>
-    <bq-tag color="warning">Warning</bq-tag>
-    <bq-tag color="gray">Gray</bq-tag>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqTag } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqTag],
+      template: `
+            <bq-tag color="success">Success</bq-tag>
+            <bq-tag color="info">Info</bq-tag>
+            <bq-tag color="error">Error</bq-tag>
+            <bq-tag color="warning">Warning</bq-tag>
+            <bq-tag color="gray">Gray</bq-tag>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -354,12 +401,22 @@ Use `variant="outline"` when you want a subtler visual distinction without a fil
     <BqTag color="gray" variant="outline">Gray</BqTag>
     ```
 
-    ```html Angular icon="angular"
-    <bq-tag color="success" variant="outline">Success</bq-tag>
-    <bq-tag color="info" variant="outline">Info</bq-tag>
-    <bq-tag color="error" variant="outline">Error</bq-tag>
-    <bq-tag color="warning" variant="outline">Warning</bq-tag>
-    <bq-tag color="gray" variant="outline">Gray</bq-tag>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqTag } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqTag],
+      template: `
+            <bq-tag color="success" variant="outline">Success</bq-tag>
+            <bq-tag color="info" variant="outline">Info</bq-tag>
+            <bq-tag color="error" variant="outline">Error</bq-tag>
+            <bq-tag color="warning" variant="outline">Warning</bq-tag>
+            <bq-tag color="gray" variant="outline">Gray</bq-tag>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -392,10 +449,7 @@ Enable `removable` when users need to clear selected items, applied filters, or 
 
   <script>
     (() => {
-      const preview = document.currentScript?.parentElement;
-      if (!preview) return;
-
-      preview.querySelectorAll('bq-tag[removable]').forEach((tag) => {
+      previewRoot.querySelectorAll('bq-tag[removable]').forEach((tag) => {
         tag.addEventListener('bqClose', () => {
           window.setTimeout(() => tag.show(), 1500);
         });
@@ -424,16 +478,23 @@ Enable `removable` when users need to clear selected items, applied filters, or 
     <BqTag removable color="gray">Gray</BqTag>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqTag } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-
-    <bq-tag removable>Default</bq-tag>
-    <bq-tag removable color="success">Success</bq-tag>
-    <bq-tag removable color="info">Info</bq-tag>
-    <bq-tag removable color="error">Error</bq-tag>
-    <bq-tag removable color="warning">Warning</bq-tag>
-    <bq-tag removable color="gray">Gray</bq-tag>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqTag } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqTag],
+      template: `
+        <bq-tag removable>Default</bq-tag>
+            <bq-tag removable color="success">Success</bq-tag>
+            <bq-tag removable color="info">Info</bq-tag>
+            <bq-tag removable color="error">Error</bq-tag>
+            <bq-tag removable color="warning">Warning</bq-tag>
+            <bq-tag removable color="gray">Gray</bq-tag>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -466,10 +527,7 @@ Use `variant="outline"` with `removable` when you want the same close behavior w
   <bq-tag removable color="gray" variant="outline">Gray</bq-tag>
   <script>
     (() => {
-      const preview = document.currentScript?.parentElement;
-      if (!preview) return;
-
-      preview.querySelectorAll('bq-tag[removable]').forEach((tag) => {
+      previewRoot.querySelectorAll('bq-tag[removable]').forEach((tag) => {
         tag.addEventListener('bqClose', () => {
           window.setTimeout(() => tag.show(), 1500);
         });
@@ -498,16 +556,23 @@ Use `variant="outline"` with `removable` when you want the same close behavior w
     <BqTag removable color="gray" variant="outline">Gray</BqTag>
     ```
 
-    ```html Angular icon="angular"
-    <!-- Standalone: import { BqTag } from "@beeq/angular/standalone" -->
-    <!-- Modules: components are available after importing BeeQModule -->
-
-    <bq-tag removable variant="outline">Default</bq-tag>
-    <bq-tag removable color="success" variant="outline">Success</bq-tag>
-    <bq-tag removable color="info" variant="outline">Info</bq-tag>
-    <bq-tag removable color="error" variant="outline">Error</bq-tag>
-    <bq-tag removable color="warning" variant="outline">Warning</bq-tag>
-    <bq-tag removable color="gray" variant="outline">Gray</bq-tag>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqTag } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqTag],
+      template: `
+        <bq-tag removable variant="outline">Default</bq-tag>
+            <bq-tag removable color="success" variant="outline">Success</bq-tag>
+            <bq-tag removable color="info" variant="outline">Info</bq-tag>
+            <bq-tag removable color="error" variant="outline">Error</bq-tag>
+            <bq-tag removable color="warning" variant="outline">Warning</bq-tag>
+            <bq-tag removable color="gray" variant="outline">Gray</bq-tag>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -614,31 +679,41 @@ Use the `prefix` slot to add an icon when extra context helps, while keeping the
     </BqTag>
     ```
 
-    ```html Angular icon="angular"
-    <bq-tag>
-      <bq-icon name="alarm" slot="prefix"></bq-icon>
-      Default
-    </bq-tag>
-    <bq-tag color="success">
-      <bq-icon name="check-circle" slot="prefix"></bq-icon>
-      Success
-    </bq-tag>
-    <bq-tag color="info">
-      <bq-icon name="info" slot="prefix"></bq-icon>
-      Info
-    </bq-tag>
-    <bq-tag color="error">
-      <bq-icon name="warning-diamond" slot="prefix"></bq-icon>
-      Error
-    </bq-tag>
-    <bq-tag color="warning">
-      <bq-icon name="warning" slot="prefix"></bq-icon>
-      Warning
-    </bq-tag>
-    <bq-tag color="gray">
-      <bq-icon name="video-camera-slash" slot="prefix"></bq-icon>
-      Gray
-    </bq-tag>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqTag, BqIcon } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqTag, BqIcon],
+      template: `
+            <bq-tag>
+              <bq-icon name="alarm" slot="prefix"></bq-icon>
+              Default
+            </bq-tag>
+            <bq-tag color="success">
+              <bq-icon name="check-circle" slot="prefix"></bq-icon>
+              Success
+            </bq-tag>
+            <bq-tag color="info">
+              <bq-icon name="info" slot="prefix"></bq-icon>
+              Info
+            </bq-tag>
+            <bq-tag color="error">
+              <bq-icon name="warning-diamond" slot="prefix"></bq-icon>
+              Error
+            </bq-tag>
+            <bq-tag color="warning">
+              <bq-icon name="warning" slot="prefix"></bq-icon>
+              Warning
+            </bq-tag>
+            <bq-tag color="gray">
+              <bq-icon name="video-camera-slash" slot="prefix"></bq-icon>
+              Gray
+            </bq-tag>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -763,31 +838,41 @@ Use the outline variant with a prefix icon when you want context with a lighter 
     </BqTag>
     ```
 
-    ```html Angular icon="angular"
-    <bq-tag variant="outline">
-      <bq-icon name="alarm" slot="prefix"></bq-icon>
-      Default
-    </bq-tag>
-    <bq-tag color="success" variant="outline">
-      <bq-icon name="check-circle" slot="prefix"></bq-icon>
-      Success
-    </bq-tag>
-    <bq-tag color="info" variant="outline">
-      <bq-icon name="info" slot="prefix"></bq-icon>
-      Info
-    </bq-tag>
-    <bq-tag color="error" variant="outline">
-      <bq-icon name="warning-diamond" slot="prefix"></bq-icon>
-      Error
-    </bq-tag>
-    <bq-tag color="warning" variant="outline">
-      <bq-icon name="warning" slot="prefix"></bq-icon>
-      Warning
-    </bq-tag>
-    <bq-tag color="gray" variant="outline">
-      <bq-icon name="video-camera-slash" slot="prefix"></bq-icon>
-      Gray
-    </bq-tag>
+    ```ts Angular icon="angular"
+    import { Component } from "@angular/core";
+    import { BqTag, BqIcon } from "@beeq/angular/standalone";
+    @Component({
+      selector: "app-root",
+      standalone: true,
+      imports: [BqTag, BqIcon],
+      template: `
+            <bq-tag variant="outline">
+              <bq-icon name="alarm" slot="prefix"></bq-icon>
+              Default
+            </bq-tag>
+            <bq-tag color="success" variant="outline">
+              <bq-icon name="check-circle" slot="prefix"></bq-icon>
+              Success
+            </bq-tag>
+            <bq-tag color="info" variant="outline">
+              <bq-icon name="info" slot="prefix"></bq-icon>
+              Info
+            </bq-tag>
+            <bq-tag color="error" variant="outline">
+              <bq-icon name="warning-diamond" slot="prefix"></bq-icon>
+              Error
+            </bq-tag>
+            <bq-tag color="warning" variant="outline">
+              <bq-icon name="warning" slot="prefix"></bq-icon>
+              Warning
+            </bq-tag>
+            <bq-tag color="gray" variant="outline">
+              <bq-icon name="video-camera-slash" slot="prefix"></bq-icon>
+              Gray
+            </bq-tag>
+      `,
+    })
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/tag.mdx
+++ b/apps/beeq-docs/components/tag.mdx
@@ -181,9 +181,9 @@ Adjust the `size` attribute to customize the tag's dimensions and support a clea
       standalone: true,
       imports: [BqTag],
       template: `
-            <bq-tag size="xsmall">Extra small</bq-tag>
-            <bq-tag size="small">Small</bq-tag>
-            <bq-tag size="medium">Medium</bq-tag>
+        <bq-tag size="xsmall">Extra small</bq-tag>
+        <bq-tag size="small">Small</bq-tag>
+        <bq-tag size="medium">Medium</bq-tag>
       `,
     })
     export class AppComponent {}
@@ -234,8 +234,8 @@ Apply the `clickable` attribute for interactive tags that can trigger actions or
       standalone: true,
       imports: [BqTag],
       template: `
-            <bq-tag clickable>Tag</bq-tag>
-            <bq-tag clickable selected>Tag</bq-tag>
+        <bq-tag clickable>Tag</bq-tag>
+        <bq-tag clickable selected>Tag</bq-tag>
       `,
     })
     export class AppComponent {}
@@ -285,8 +285,8 @@ Apply `disabled` alongside `clickable` when a tag action is temporarily unavaila
       standalone: true,
       imports: [BqTag],
       template: `
-            <bq-tag clickable>Enabled</bq-tag>
-            <bq-tag clickable disabled>Disabled</bq-tag>
+        <bq-tag clickable>Enabled</bq-tag>
+        <bq-tag clickable disabled>Disabled</bq-tag>
       `,
     })
     export class AppComponent {}
@@ -345,11 +345,11 @@ Use filled colored tags when you want a stronger visual distinction for categori
       standalone: true,
       imports: [BqTag],
       template: `
-            <bq-tag color="success">Success</bq-tag>
-            <bq-tag color="info">Info</bq-tag>
-            <bq-tag color="error">Error</bq-tag>
-            <bq-tag color="warning">Warning</bq-tag>
-            <bq-tag color="gray">Gray</bq-tag>
+        <bq-tag color="success">Success</bq-tag>
+        <bq-tag color="info">Info</bq-tag>
+        <bq-tag color="error">Error</bq-tag>
+        <bq-tag color="warning">Warning</bq-tag>
+        <bq-tag color="gray">Gray</bq-tag>
       `,
     })
     export class AppComponent {}
@@ -409,11 +409,11 @@ Use `variant="outline"` when you want a subtler visual distinction without a fil
       standalone: true,
       imports: [BqTag],
       template: `
-            <bq-tag color="success" variant="outline">Success</bq-tag>
-            <bq-tag color="info" variant="outline">Info</bq-tag>
-            <bq-tag color="error" variant="outline">Error</bq-tag>
-            <bq-tag color="warning" variant="outline">Warning</bq-tag>
-            <bq-tag color="gray" variant="outline">Gray</bq-tag>
+        <bq-tag color="success" variant="outline">Success</bq-tag>
+        <bq-tag color="info" variant="outline">Info</bq-tag>
+        <bq-tag color="error" variant="outline">Error</bq-tag>
+        <bq-tag color="warning" variant="outline">Warning</bq-tag>
+        <bq-tag color="gray" variant="outline">Gray</bq-tag>
       `,
     })
     export class AppComponent {}
@@ -487,11 +487,11 @@ Enable `removable` when users need to clear selected items, applied filters, or 
       imports: [BqTag],
       template: `
         <bq-tag removable>Default</bq-tag>
-            <bq-tag removable color="success">Success</bq-tag>
-            <bq-tag removable color="info">Info</bq-tag>
-            <bq-tag removable color="error">Error</bq-tag>
-            <bq-tag removable color="warning">Warning</bq-tag>
-            <bq-tag removable color="gray">Gray</bq-tag>
+        <bq-tag removable color="success">Success</bq-tag>
+        <bq-tag removable color="info">Info</bq-tag>
+        <bq-tag removable color="error">Error</bq-tag>
+        <bq-tag removable color="warning">Warning</bq-tag>
+        <bq-tag removable color="gray">Gray</bq-tag>
       `,
     })
     export class AppComponent {}
@@ -565,11 +565,11 @@ Use `variant="outline"` with `removable` when you want the same close behavior w
       imports: [BqTag],
       template: `
         <bq-tag removable variant="outline">Default</bq-tag>
-            <bq-tag removable color="success" variant="outline">Success</bq-tag>
-            <bq-tag removable color="info" variant="outline">Info</bq-tag>
-            <bq-tag removable color="error" variant="outline">Error</bq-tag>
-            <bq-tag removable color="warning" variant="outline">Warning</bq-tag>
-            <bq-tag removable color="gray" variant="outline">Gray</bq-tag>
+        <bq-tag removable color="success" variant="outline">Success</bq-tag>
+        <bq-tag removable color="info" variant="outline">Info</bq-tag>
+        <bq-tag removable color="error" variant="outline">Error</bq-tag>
+        <bq-tag removable color="warning" variant="outline">Warning</bq-tag>
+        <bq-tag removable color="gray" variant="outline">Gray</bq-tag>
       `,
     })
     export class AppComponent {}
@@ -687,30 +687,30 @@ Use the `prefix` slot to add an icon when extra context helps, while keeping the
       standalone: true,
       imports: [BqTag, BqIcon],
       template: `
-            <bq-tag>
-              <bq-icon name="alarm" slot="prefix"></bq-icon>
-              Default
-            </bq-tag>
-            <bq-tag color="success">
-              <bq-icon name="check-circle" slot="prefix"></bq-icon>
-              Success
-            </bq-tag>
-            <bq-tag color="info">
-              <bq-icon name="info" slot="prefix"></bq-icon>
-              Info
-            </bq-tag>
-            <bq-tag color="error">
-              <bq-icon name="warning-diamond" slot="prefix"></bq-icon>
-              Error
-            </bq-tag>
-            <bq-tag color="warning">
-              <bq-icon name="warning" slot="prefix"></bq-icon>
-              Warning
-            </bq-tag>
-            <bq-tag color="gray">
-              <bq-icon name="video-camera-slash" slot="prefix"></bq-icon>
-              Gray
-            </bq-tag>
+        <bq-tag>
+          <bq-icon name="alarm" slot="prefix"></bq-icon>
+          Default
+        </bq-tag>
+        <bq-tag color="success">
+          <bq-icon name="check-circle" slot="prefix"></bq-icon>
+          Success
+        </bq-tag>
+        <bq-tag color="info">
+          <bq-icon name="info" slot="prefix"></bq-icon>
+          Info
+        </bq-tag>
+        <bq-tag color="error">
+          <bq-icon name="warning-diamond" slot="prefix"></bq-icon>
+          Error
+        </bq-tag>
+        <bq-tag color="warning">
+          <bq-icon name="warning" slot="prefix"></bq-icon>
+          Warning
+        </bq-tag>
+        <bq-tag color="gray">
+          <bq-icon name="video-camera-slash" slot="prefix"></bq-icon>
+          Gray
+        </bq-tag>
       `,
     })
     export class AppComponent {}
@@ -846,30 +846,30 @@ Use the outline variant with a prefix icon when you want context with a lighter 
       standalone: true,
       imports: [BqTag, BqIcon],
       template: `
-            <bq-tag variant="outline">
-              <bq-icon name="alarm" slot="prefix"></bq-icon>
-              Default
-            </bq-tag>
-            <bq-tag color="success" variant="outline">
-              <bq-icon name="check-circle" slot="prefix"></bq-icon>
-              Success
-            </bq-tag>
-            <bq-tag color="info" variant="outline">
-              <bq-icon name="info" slot="prefix"></bq-icon>
-              Info
-            </bq-tag>
-            <bq-tag color="error" variant="outline">
-              <bq-icon name="warning-diamond" slot="prefix"></bq-icon>
-              Error
-            </bq-tag>
-            <bq-tag color="warning" variant="outline">
-              <bq-icon name="warning" slot="prefix"></bq-icon>
-              Warning
-            </bq-tag>
-            <bq-tag color="gray" variant="outline">
-              <bq-icon name="video-camera-slash" slot="prefix"></bq-icon>
-              Gray
-            </bq-tag>
+        <bq-tag variant="outline">
+          <bq-icon name="alarm" slot="prefix"></bq-icon>
+          Default
+        </bq-tag>
+        <bq-tag color="success" variant="outline">
+          <bq-icon name="check-circle" slot="prefix"></bq-icon>
+          Success
+        </bq-tag>
+        <bq-tag color="info" variant="outline">
+          <bq-icon name="info" slot="prefix"></bq-icon>
+          Info
+        </bq-tag>
+        <bq-tag color="error" variant="outline">
+          <bq-icon name="warning-diamond" slot="prefix"></bq-icon>
+          Error
+        </bq-tag>
+        <bq-tag color="warning" variant="outline">
+          <bq-icon name="warning" slot="prefix"></bq-icon>
+          Warning
+        </bq-tag>
+        <bq-tag color="gray" variant="outline">
+          <bq-icon name="video-camera-slash" slot="prefix"></bq-icon>
+          Gray
+        </bq-tag>
       `,
     })
     export class AppComponent {}

--- a/apps/beeq-docs/components/textarea.mdx
+++ b/apps/beeq-docs/components/textarea.mdx
@@ -109,7 +109,7 @@ Use the default textarea when you need a standard multi-line text input. Provide
   </bq-textarea>
 `}>
   <CodeGroup>
-    ```html HTML
+    ```html HTML icon="html5"
     <bq-textarea placeholder="Placeholder...">
       <label slot="label">Label</label>
       <span slot="helper-text">
@@ -118,7 +118,7 @@ Use the default textarea when you need a standard multi-line text input. Provide
       </span>
     </bq-textarea>
     ```
-    ```tsx React
+    ```tsx React icon="react"
     import { BqIcon, BqTextarea } from "@beeq/react";
 
     export default () => (
@@ -131,7 +131,7 @@ Use the default textarea when you need a standard multi-line text input. Provide
       </BqTextarea>
     );
     ```
-    ```ts Angular
+    ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqIcon, BqTextarea } from "@beeq/angular/standalone";
 
@@ -151,7 +151,7 @@ Use the default textarea when you need a standard multi-line text input. Provide
     })
     export class AppComponent {}
     ```
-    ```vue Vue
+    ```vue Vue icon="vuejs"
     <script setup lang="ts">
     import { BqIcon, BqTextarea } from "@beeq/vue";
     </script>
@@ -194,7 +194,7 @@ Pre-populate your textarea with an initial `value` attribute to streamline user 
   </bq-textarea>
 `}>
   <CodeGroup>
-    ```html HTML
+    ```html HTML icon="html5"
     <bq-textarea
       placeholder="Placeholder..."
       value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
@@ -206,7 +206,7 @@ Pre-populate your textarea with an initial `value` attribute to streamline user 
       </span>
     </bq-textarea>
     ```
-    ```tsx React
+    ```tsx React icon="react"
     import { BqIcon, BqTextarea } from "@beeq/react";
 
     export default () => (
@@ -222,7 +222,7 @@ Pre-populate your textarea with an initial `value` attribute to streamline user 
       </BqTextarea>
     );
     ```
-    ```ts Angular
+    ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqIcon, BqTextarea } from "@beeq/angular/standalone";
 
@@ -234,7 +234,7 @@ Pre-populate your textarea with an initial `value` attribute to streamline user 
         <bq-textarea
           placeholder="Placeholder..."
           value="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora, nulla. Ab non odio facere enim, voluptatum voluptates quod molestias suscipit fugiat et expedita accusamus quidem nostrum maxime illo recusandae ratione?"
-        >
+          >
           <label slot="label">Label</label>
           <span slot="helper-text">
             <bq-icon name="star"></bq-icon>
@@ -245,7 +245,7 @@ Pre-populate your textarea with an initial `value` attribute to streamline user 
     })
     export class AppComponent {}
     ```
-    ```vue Vue
+    ```vue Vue icon="vuejs"
     <script setup lang="ts">
     import { BqIcon, BqTextarea } from "@beeq/vue";
     </script>
@@ -294,7 +294,7 @@ Set `disabled` when the field is not currently available for interaction. Use it
   </bq-textarea>
 `}>
   <CodeGroup>
-    ```html HTML
+    ```html HTML icon="html5"
     <bq-textarea
       disabled
       placeholder="Placeholder..."
@@ -307,7 +307,7 @@ Set `disabled` when the field is not currently available for interaction. Use it
       </span>
     </bq-textarea>
     ```
-    ```tsx React
+    ```tsx React icon="react"
     import { BqIcon, BqTextarea } from "@beeq/react";
 
     export default () => (
@@ -324,7 +324,7 @@ Set `disabled` when the field is not currently available for interaction. Use it
       </BqTextarea>
     );
     ```
-    ```ts Angular
+    ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqIcon, BqTextarea } from "@beeq/angular/standalone";
 
@@ -348,7 +348,7 @@ Set `disabled` when the field is not currently available for interaction. Use it
     })
     export class AppComponent {}
     ```
-    ```vue Vue
+    ```vue Vue icon="vuejs"
     <script setup lang="ts">
     import { BqIcon, BqTextarea } from "@beeq/vue";
     </script>
@@ -406,7 +406,7 @@ Add `disable-resize` to prevent users from resizing the textarea. This is useful
   </div>
 `}>
   <CodeGroup>
-    ```html HTML
+    ```html HTML icon="html5"
     <div class="textarea--resize-group">
       <bq-textarea placeholder="Resize is enabled">
         <label slot="label">Label</label>
@@ -424,7 +424,7 @@ Add `disable-resize` to prevent users from resizing the textarea. This is useful
       </bq-textarea>
     </div>
     ```
-    ```tsx React
+    ```tsx React icon="react"
     import { BqIcon, BqTextarea } from "@beeq/react";
 
     export default () => (
@@ -446,7 +446,7 @@ Add `disable-resize` to prevent users from resizing the textarea. This is useful
       </>
     );
     ```
-    ```ts Angular
+    ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqIcon, BqTextarea } from "@beeq/angular/standalone";
 
@@ -475,7 +475,7 @@ Add `disable-resize` to prevent users from resizing the textarea. This is useful
     })
     export class AppComponent {}
     ```
-    ```vue Vue
+    ```vue Vue icon="vuejs"
     <script setup lang="ts">
     import { BqIcon, BqTextarea } from "@beeq/vue";
     </script>
@@ -532,7 +532,7 @@ Set `maxlength` to limit the number of characters users can enter. A character c
   </bq-textarea>
 `}>
   <CodeGroup>
-    ```html HTML
+    ```html HTML icon="html5"
     <bq-textarea
       maxlength="100"
       placeholder="Placeholder..."
@@ -545,7 +545,7 @@ Set `maxlength` to limit the number of characters users can enter. A character c
       </span>
     </bq-textarea>
     ```
-    ```tsx React
+    ```tsx React icon="react"
     import { BqIcon, BqTextarea } from "@beeq/react";
 
     export default () => (
@@ -562,7 +562,7 @@ Set `maxlength` to limit the number of characters users can enter. A character c
       </BqTextarea>
     );
     ```
-    ```ts Angular
+    ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqIcon, BqTextarea } from "@beeq/angular/standalone";
 
@@ -586,7 +586,7 @@ Set `maxlength` to limit the number of characters users can enter. A character c
     })
     export class AppComponent {}
     ```
-    ```vue Vue
+    ```vue Vue icon="vuejs"
     <script setup lang="ts">
     import { BqIcon, BqTextarea } from "@beeq/vue";
     </script>
@@ -634,7 +634,7 @@ Set `readonly` to display the value without allowing edits. Unlike `disabled`, a
   </bq-textarea>
 `}>
   <CodeGroup>
-    ```html HTML
+    ```html HTML icon="html5"
     <bq-textarea
       placeholder="Placeholder..."
       readonly
@@ -647,7 +647,7 @@ Set `readonly` to display the value without allowing edits. Unlike `disabled`, a
       </span>
     </bq-textarea>
     ```
-    ```tsx React
+    ```tsx React icon="react"
     import { BqIcon, BqTextarea } from "@beeq/react";
 
     export default () => (
@@ -664,7 +664,7 @@ Set `readonly` to display the value without allowing edits. Unlike `disabled`, a
       </BqTextarea>
     );
     ```
-    ```ts Angular
+    ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqIcon, BqTextarea } from "@beeq/angular/standalone";
 
@@ -688,7 +688,7 @@ Set `readonly` to display the value without allowing edits. Unlike `disabled`, a
     })
     export class AppComponent {}
     ```
-    ```vue Vue
+    ```vue Vue icon="vuejs"
     <script setup lang="ts">
     import { BqIcon, BqTextarea } from "@beeq/vue";
     </script>
@@ -768,7 +768,7 @@ Set `validation-status` to `error`, `warning`, or `success` to communicate the s
   </div>
 `}>
   <CodeGroup>
-    ```html HTML
+    ```html HTML icon="html5"
     <div class="textarea--validation-group">
       <bq-textarea
         maxlength="100"
@@ -808,7 +808,7 @@ Set `validation-status` to `error`, `warning`, or `success` to communicate the s
       </bq-textarea>
     </div>
     ```
-    ```tsx React
+    ```tsx React icon="react"
     import { BqIcon, BqTextarea } from "@beeq/react";
 
     export default () => (
@@ -852,7 +852,7 @@ Set `validation-status` to `error`, `warning`, or `success` to communicate the s
       </>
     );
     ```
-    ```ts Angular
+    ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqIcon, BqTextarea } from "@beeq/angular/standalone";
 
@@ -903,7 +903,7 @@ Set `validation-status` to `error`, `warning`, or `success` to communicate the s
     })
     export class AppComponent {}
     ```
-    ```vue Vue
+    ```vue Vue icon="vuejs"
     <script setup lang="ts">
     import { BqIcon, BqTextarea } from "@beeq/vue";
     </script>

--- a/apps/beeq-docs/components/toast.mdx
+++ b/apps/beeq-docs/components/toast.mdx
@@ -148,6 +148,7 @@ Use the built-in `type` values to communicate the nature of the message quickly.
     import { BqToast } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqToast],
       template: `
@@ -158,7 +159,7 @@ Use the built-in `type` values to communicate the nature of the message quickly.
         <bq-toast open type="loading">Uploading file...</bq-toast>
       `
     })
-    export class ToastTypesComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -217,6 +218,7 @@ Use `type="custom"` when you need a branded or domain-specific status cue. Repla
     import { BqIcon, BqToast } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqToast],
       template: `
@@ -226,7 +228,7 @@ Use `type="custom"` when you need a branded or domain-specific status cue. Repla
         </bq-toast>
       `
     })
-    export class CustomIconToastComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -395,6 +397,7 @@ Use a dedicated toast container when you want the stacking behavior to be explic
     const TOAST_TYPES = ['info', 'success', 'alert', 'error', 'loading'];
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqButton, BqToast],
       template: `
@@ -408,7 +411,7 @@ Use a dedicated toast container when you want the stacking behavior to be explic
         </div>
       `,
     })
-    export class ToastStackExample {
+    export class AppComponent {
       toasts: ToastItem[] = [];
       private readonly timerIds = new Set<ReturnType<typeof setTimeout>>();
       private readonly destroyRef = inject(DestroyRef);

--- a/apps/beeq-docs/components/toast.mdx
+++ b/apps/beeq-docs/components/toast.mdx
@@ -313,8 +313,8 @@ Use a dedicated toast container when you want the stacking behavior to be explic
     ```js JavaScript icon="js" expandable
     const TOAST_TYPE = ['info', 'success', 'alert', 'error', 'loading'];
 
-    const button = document.querySelector('bq-button');
-    const toastContainer = document.querySelector('[data-toast-container]');
+    const button = previewRoot.querySelector('bq-button');
+    const toastContainer = previewRoot.querySelector('[data-toast-container]');
 
     const getRandomType = () => TOAST_TYPE[Math.floor(Math.random() * TOAST_TYPE.length)];
     const createToast = (type, message) => {

--- a/apps/beeq-docs/components/tooltip.mdx
+++ b/apps/beeq-docs/components/tooltip.mdx
@@ -96,6 +96,7 @@ By default the tooltip appears **above** the trigger on hover. Tooltip content g
     import { BqButton, BqTooltip } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqButton, BqTooltip],
       template: `
@@ -105,7 +106,7 @@ By default the tooltip appears **above** the trigger on hover. Tooltip content g
         </bq-tooltip>
       `
     })
-    export class DefaultTooltipComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -207,6 +208,7 @@ Use `placement` to control which side of the trigger the tooltip appears on. The
     import { BqButton, BqTooltip } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqButton, BqTooltip],
       template: `
@@ -231,7 +233,7 @@ Use `placement` to control which side of the trigger the tooltip appears on. The
         </bq-tooltip>
       `
     })
-    export class PlacementTooltipComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -305,6 +307,7 @@ Set `display-on="click"` when the trigger element is not naturally focusable (e.
     import { BqButton, BqTooltip } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqButton, BqTooltip],
       template: `
@@ -314,7 +317,7 @@ Set `display-on="click"` when the trigger element is not naturally focusable (e.
         </bq-tooltip>
       `
     })
-    export class DisplayOnClickTooltipComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -373,6 +376,7 @@ Use `always-visible` to keep the tooltip permanently displayed regardless of use
     import { BqButton, BqTooltip } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqButton, BqTooltip],
       template: `
@@ -382,7 +386,7 @@ Use `always-visible` to keep the tooltip permanently displayed regardless of use
         </bq-tooltip>
       `
     })
-    export class AlwaysVisibleTooltipComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -479,6 +483,7 @@ Unlike `always-visible`, a controlled tooltip can still be dismissed by the user
     import { BqButton, BqTooltip } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqButton, BqTooltip],
       template: `
@@ -488,7 +493,7 @@ Unlike `always-visible`, a controlled tooltip can still be dismissed by the user
         </bq-tooltip>
       `
     })
-    export class ControlledTooltipComponent {
+    export class AppComponent {
       isTooltipVisible = false;
     }
     ```
@@ -583,6 +588,7 @@ The `show()` and `hide()` async methods give you imperative control over the too
   import { BqButton, BqTooltip } from "@beeq/angular/standalone";
 
   @Component({
+    selector: "app-root",
     standalone: true,
     imports: [BqButton, BqTooltip],
     template: `
@@ -595,7 +601,7 @@ The `show()` and `hide()` async methods give you imperative control over the too
       <bq-button (bqClick)="myTooltip.hide()">Hide tooltip</bq-button>
     `
   })
-  export class ProgrammaticTooltipComponent {}
+  export class AppComponent {}
   ```
 
   ```vue Vue icon="vuejs"
@@ -739,6 +745,7 @@ All five tooltip events support `preventDefault()`. Calling it inside a handler 
     import { BqButton, BqSwitch, BqTooltip } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqButton, BqSwitch, BqTooltip],
       template: `
@@ -749,7 +756,7 @@ All five tooltip events support `preventDefault()`. Calling it inside a handler 
         <bq-switch (bqChange)="locked = $event.detail.checked">Lock tooltip</bq-switch>
       `
     })
-    export class PreventDefaultTooltipComponent {
+    export class AppComponent {
       locked = false;
 
       onHoverIn(event: CustomEvent): void {
@@ -848,6 +855,7 @@ Add `hide-arrow` to remove the directional pointer. Use this when the tooltip is
     import { BqButton, BqTooltip } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqButton, BqTooltip],
       template: `
@@ -864,7 +872,7 @@ Add `hide-arrow` to remove the directional pointer. Use this when the tooltip is
         </bq-tooltip>
       `
     })
-    export class HideArrowTooltipComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -926,6 +934,7 @@ Set `same-width` to match the tooltip panel width to the trigger element. Useful
     import { BqButton, BqTooltip } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqButton, BqTooltip],
       template: `
@@ -935,7 +944,7 @@ Set `same-width` to match the tooltip panel width to the trigger element. Useful
         </bq-tooltip>
       `
     })
-    export class SameWidthTooltipComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -1019,6 +1028,7 @@ The `distance` prop controls the gap in pixels between the trigger and the toolt
     import { BqButton, BqTooltip } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqButton, BqTooltip],
       template: `
@@ -1038,7 +1048,7 @@ The `distance` prop controls the gap in pixels between the trigger and the toolt
         </bq-tooltip>
       `
     })
-    export class DistanceTooltipComponent {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/components/tooltip.mdx
+++ b/apps/beeq-docs/components/tooltip.mdx
@@ -515,6 +515,32 @@ Unlike `always-visible`, a controlled tooltip can still be dismissed by the user
 
 The `show()` and `hide()` async methods give you imperative control over the tooltip from outside the component — useful when another UI element or an application event should trigger the tooltip rather than the trigger element's own interaction.
 
+<CodeLivePreview code={`
+  <style>
+    :host {
+      min-height: 15rem !important;
+    }
+  </style>
+
+  <bq-tooltip id="my-tooltip">
+    Programmatically controlled
+    <bq-button slot="trigger">Trigger (hover also works)</bq-button>
+  </bq-tooltip>
+
+  <bq-button id="show-btn">Show tooltip</bq-button>
+  <bq-button id="hide-btn">Hide tooltip</bq-button>
+
+  <script>
+    (() => {
+      const tooltip = previewRoot.querySelector('#my-tooltip');
+      const showBtn = previewRoot.querySelector('#show-btn');
+      const hideBtn = previewRoot.querySelector('#hide-btn');
+
+      showBtn?.addEventListener('bqClick', () => tooltip?.show());
+      hideBtn?.addEventListener('bqClick', () => tooltip?.hide());
+    })();
+  </script>
+`}>
 <CodeGroup>
   ```html HTML icon="html5"
   <bq-tooltip id="my-tooltip">
@@ -590,6 +616,7 @@ The `show()` and `hide()` async methods give you imperative control over the too
   </template>
   ```
 </CodeGroup>
+</CodeLivePreview>
 
 ### Cancelling default behavior
 

--- a/apps/beeq-docs/guides/frameworks/html-web-components.mdx
+++ b/apps/beeq-docs/guides/frameworks/html-web-components.mdx
@@ -85,7 +85,7 @@ BEEQ components are standard custom elements (`<bq-button>`, `<bq-input>`, and s
     Import global styles once, register custom elements at startup, and load your entry script from HTML:
 
     <CodeGroup>
-      ```css src/style.css icon="css"
+      ```css src/style.css icon="css3"
       @import "@beeq/core/dist/beeq/beeq.css";
       ```
 

--- a/apps/beeq-docs/guides/frameworks/html-web-components.mdx
+++ b/apps/beeq-docs/guides/frameworks/html-web-components.mdx
@@ -43,7 +43,7 @@ BEEQ components are standard custom elements (`<bq-button>`, `<bq-input>`, and s
 
     Link the BEEQ stylesheet and ESM bundle from a CDN. Components register automatically when the module loads.
 
-    ```html index.html icon=html5
+    ```html index.html icon="html5"
     <!doctype html>
     <html lang="en">
       <head>
@@ -69,15 +69,15 @@ BEEQ components are standard custom elements (`<bq-button>`, `<bq-input>`, and s
     Install `@beeq/core` with your package manager, then call `defineCustomElements()` at app startup:
 
     <CodeGroup>
-      ```bash npm icon=npm
+      ```bash npm icon="npm"
       npm install @beeq/core
       ```
 
-      ```bash pnpm icon=data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+CjxzdmcgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCBtZWV0IiB2aWV3Qm94PSI3Ni41ODk4NzI0NDg5Nzk1OCA0NCAxNjQuMDA3NzU1MTAyMDQwNjggMTY0IiB3aWR0aD0iMTYwLjAxIiBoZWlnaHQ9IjE2MCI+PGRlZnM+PHBhdGggZD0iTTIzNy42IDk1TDE4Ny42IDk1TDE4Ny42IDQ1TDIzNy42IDQ1TDIzNy42IDk1WiIgaWQ9ImI0NXZkVEQ4aHMiPjwvcGF0aD48cGF0aCBkPSJNMTgyLjU5IDk1TDEzMi41OSA5NUwxMzIuNTkgNDVMMTgyLjU5IDQ1TDE4Mi41OSA5NVoiIGlkPSJhNDBXdHhJbDhkIj48L3BhdGg+PHBhdGggZD0iTTEyNy41OSA5NUw3Ny41OSA5NUw3Ny41OSA0NUwxMjcuNTkgNDVMMTI3LjU5IDk1WiIgaWQ9ImgyQ045QUVFcGUiPjwvcGF0aD48cGF0aCBkPSJNMjM3LjYgMTUwTDE4Ny42IDE1MEwxODcuNiAxMDBMMjM3LjYgMTAwTDIzNy42IDE1MFoiIGlkPSJkcXY1MTMzRzgiPjwvcGF0aD48cGF0aCBkPSJNMTgyLjU5IDE1MEwxMzIuNTkgMTUwTDEzMi41OSAxMDBMMTgyLjU5IDEwMEwxODIuNTkgMTUwWiIgaWQ9ImIxTHY3OXlwdm0iPjwvcGF0aD48cGF0aCBkPSJNMTgyLjU5IDIwNUwxMzIuNTkgMjA1TDEzMi41OSAxNTVMMTgyLjU5IDE1NUwxODIuNTkgMjA1WiIgaWQ9Imh5MUlaV3dMWCI+PC9wYXRoPjxwYXRoIGQ9Ik0yMzcuNiAyMDVMMTg3LjYgMjA1TDE4Ny42IDE1NUwyMzcuNiAxNTVMMjM3LjYgMjA1WiIgaWQ9ImFrUWZqeFFlcyI+PC9wYXRoPjxwYXRoIGQ9Ik0xMjcuNTkgMjA1TDc3LjU5IDIwNUw3Ny41OSAxNTVMMTI3LjU5IDE1NUwxMjcuNTkgMjA1WiIgaWQ9ImJkU3J3RTVwayI+PC9wYXRoPjwvZGVmcz48Zz48Zz48dXNlIHhsaW5rOmhyZWY9IiNiNDV2ZFREOGhzIiBvcGFjaXR5PSIxIiBmaWxsPSIjZjlhZDAwIiBmaWxsLW9wYWNpdHk9IjEiPjwvdXNlPjwvZz48Zz48dXNlIHhsaW5rOmhyZWY9IiNhNDBXdHhJbDhkIiBvcGFjaXR5PSIxIiBmaWxsPSIjZjlhZDAwIiBmaWxsLW9wYWNpdHk9IjEiPjwvdXNlPjwvZz48Zz48dXNlIHhsaW5rOmhyZWY9IiNoMkNOOUFFRXBlIiBvcGFjaXR5PSIxIiBmaWxsPSIjZjlhZDAwIiBmaWxsLW9wYWNpdHk9IjEiPjwvdXNlPjwvZz48Zz48dXNlIHhsaW5rOmhyZWY9IiNkcXY1MTMzRzgiIG9wYWNpdHk9IjEiIGZpbGw9IiNmOWFkMDAiIGZpbGwtb3BhY2l0eT0iMSI+PC91c2U+PC9nPjxnPjx1c2UgeGxpbms6aHJlZj0iI2IxTHY3OXlwdm0iIG9wYWNpdHk9IjEiIGZpbGw9IiNmZmZmZmYiIGZpbGwtb3BhY2l0eT0iMSI+PC91c2U+PC9nPjxnPjx1c2UgeGxpbms6aHJlZj0iI2h5MUlaV3dMWCIgb3BhY2l0eT0iMSIgZmlsbD0iI2ZmZmZmZiIgZmlsbC1vcGFjaXR5PSIxIj48L3VzZT48L2c+PGc+PHVzZSB4bGluazpocmVmPSIjYWtRZmp4UWVzIiBvcGFjaXR5PSIxIiBmaWxsPSIjZmZmZmZmIiBmaWxsLW9wYWNpdHk9IjEiPjwvdXNlPjwvZz48Zz48dXNlIHhsaW5rOmhyZWY9IiNiZFNyd0U1cGsiIG9wYWNpdHk9IjEiIGZpbGw9IiNmZmZmZmYiIGZpbGwtb3BhY2l0eT0iMSI+PC91c2U+PC9nPjwvZz48L3N2Zz4=
+      ```bash pnpm icon="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+CjxzdmcgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCBtZWV0IiB2aWV3Qm94PSI3Ni41ODk4NzI0NDg5Nzk1OCA0NCAxNjQuMDA3NzU1MTAyMDQwNjggMTY0IiB3aWR0aD0iMTYwLjAxIiBoZWlnaHQ9IjE2MCI+PGRlZnM+PHBhdGggZD0iTTIzNy42IDk1TDE4Ny42IDk1TDE4Ny42IDQ1TDIzNy42IDQ1TDIzNy42IDk1WiIgaWQ9ImI0NXZkVEQ4aHMiPjwvcGF0aD48cGF0aCBkPSJNMTgyLjU5IDk1TDEzMi41OSA5NUwxMzIuNTkgNDVMMTgyLjU5IDQ1TDE4Mi41OSA5NVoiIGlkPSJhNDBXdHhJbDhkIj48L3BhdGg+PHBhdGggZD0iTTEyNy41OSA5NUw3Ny41OSA5NUw3Ny41OSA0NUwxMjcuNTkgNDVMMTI3LjU5IDk1WiIgaWQ9ImgyQ045QUVFcGUiPjwvcGF0aD48cGF0aCBkPSJNMjM3LjYgMTUwTDE4Ny42IDE1MEwxODcuNiAxMDBMMjM3LjYgMTAwTDIzNy42IDE1MFoiIGlkPSJkcXY1MTMzRzgiPjwvcGF0aD48cGF0aCBkPSJNMTgyLjU5IDE1MEwxMzIuNTkgMTUwTDEzMi41OSAxMDBMMTgyLjU5IDEwMEwxODIuNTkgMTUwWiIgaWQ9ImIxTHY3OXlwdm0iPjwvcGF0aD48cGF0aCBkPSJNMTgyLjU5IDIwNUwxMzIuNTkgMjA1TDEzMi41OSAxNTVMMTgyLjU5IDE1NUwxODIuNTkgMjA1WiIgaWQ9Imh5MUlaV3dMWCI+PC9wYXRoPjxwYXRoIGQ9Ik0yMzcuNiAyMDVMMTg3LjYgMjA1TDE4Ny42IDE1NUwyMzcuNiAxNTVMMjM3LjYgMjA1WiIgaWQ9ImFrUWZqeFFlcyI+PC9wYXRoPjxwYXRoIGQ9Ik0xMjcuNTkgMjA1TDc3LjU5IDIwNUw3Ny41OSAxNTVMMTI3LjU5IDE1NUwxMjcuNTkgMjA1WiIgaWQ9ImJkU3J3RTVwayI+PC9wYXRoPjwvZGVmcz48Zz48Zz48dXNlIHhsaW5rOmhyZWY9IiNiNDV2ZFREOGhzIiBvcGFjaXR5PSIxIiBmaWxsPSIjZjlhZDAwIiBmaWxsLW9wYWNpdHk9IjEiPjwvdXNlPjwvZz48Zz48dXNlIHhsaW5rOmhyZWY9IiNhNDBXdHhJbDhkIiBvcGFjaXR5PSIxIiBmaWxsPSIjZjlhZDAwIiBmaWxsLW9wYWNpdHk9IjEiPjwvdXNlPjwvZz48Zz48dXNlIHhsaW5rOmhyZWY9IiNoMkNOOUFFRXBlIiBvcGFjaXR5PSIxIiBmaWxsPSIjZjlhZDAwIiBmaWxsLW9wYWNpdHk9IjEiPjwvdXNlPjwvZz48Zz48dXNlIHhsaW5rOmhyZWY9IiNkcXY1MTMzRzgiIG9wYWNpdHk9IjEiIGZpbGw9IiNmOWFkMDAiIGZpbGwtb3BhY2l0eT0iMSI+PC91c2U+PC9nPjxnPjx1c2UgeGxpbms6aHJlZj0iI2IxTHY3OXlwdm0iIG9wYWNpdHk9IjEiIGZpbGw9IiNmZmZmZmYiIGZpbGwtb3BhY2l0eT0iMSI+PC91c2U+PC9nPjxnPjx1c2UgeGxpbms6aHJlZj0iI2h5MUlaV3dMWCIgb3BhY2l0eT0iMSIgZmlsbD0iI2ZmZmZmZiIgZmlsbC1vcGFjaXR5PSIxIj48L3VzZT48L2c+PGc+PHVzZSB4bGluazpocmVmPSIjYWtRZmp4UWVzIiBvcGFjaXR5PSIxIiBmaWxsPSIjZmZmZmZmIiBmaWxsLW9wYWNpdHk9IjEiPjwvdXNlPjwvZz48Zz48dXNlIHhsaW5rOmhyZWY9IiNiZFNyd0U1cGsiIG9wYWNpdHk9IjEiIGZpbGw9IiNmZmZmZmYiIGZpbGwtb3BhY2l0eT0iMSI+PC91c2U+PC9nPjwvZz48L3N2Zz4="
       pnpm add @beeq/core
       ```
 
-      ```bash yarn icon=yarn
+      ```bash yarn icon="yarn"
       yarn add @beeq/core
       ```
     </CodeGroup>
@@ -85,18 +85,18 @@ BEEQ components are standard custom elements (`<bq-button>`, `<bq-input>`, and s
     Import global styles once, register custom elements at startup, and load your entry script from HTML:
 
     <CodeGroup>
-      ```css src/style.css icon=css
+      ```css src/style.css icon="css"
       @import "@beeq/core/dist/beeq/beeq.css";
       ```
 
-      ```ts src/main.ts icon=ts
+      ```ts src/main.ts icon="ts"
       import { defineCustomElements } from "@beeq/core/dist/loader";
       import "./style.css";
 
       defineCustomElements();
       ```
 
-      ```html index.html icon=html5
+      ```html index.html icon="html5"
       <!doctype html>
       <html lang="en">
         <head>
@@ -134,7 +134,7 @@ BEEQ components are standard custom elements (`<bq-button>`, `<bq-input>`, and s
 
     Add the `data-beeq` attribute to the `<script type="module">` tag pointing at the directory or a CDN URL that contains the SVG files. BEEQ reads this automatically.
 
-    ```html index.html icon=html5 highlight={12}
+    ```html index.html icon="html5" highlight={12}
     <!doctype html>
     <html lang="en">
       <head>
@@ -164,21 +164,21 @@ BEEQ components are standard custom elements (`<bq-button>`, `<bq-input>`, and s
     Install the static copy plugin, copy SVGs into your build output, and call `setBasePath()` before rendering components that use icons:
 
     <CodeGroup>
-      ```bash npm icon=npm
+      ```bash npm icon="npm"
       npm install -D vite-plugin-static-copy
       ```
 
-      ```bash pnpm icon=data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+CjxzdmcgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCBtZWV0IiB2aWV3Qm94PSI3Ni41ODk4NzI0NDg5Nzk1OCA0NCAxNjQuMDA3NzU1MTAyMDQwNjggMTY0IiB3aWR0aD0iMTYwLjAxIiBoZWlnaHQ9IjE2MCI+PGRlZnM+PHBhdGggZD0iTTIzNy42IDk1TDE4Ny42IDk1TDE4Ny42IDQ1TDIzNy42IDQ1TDIzNy42IDk1WiIgaWQ9ImI0NXZkVEQ4aHMiPjwvcGF0aD48cGF0aCBkPSJNMTgyLjU5IDk1TDEzMi41OSA5NUwxMzIuNTkgNDVMMTgyLjU5IDQ1TDE4Mi41OSA5NVoiIGlkPSJhNDBXdHhJbDhkIj48L3BhdGg+PHBhdGggZD0iTTEyNy41OSA5NUw3Ny41OSA5NUw3Ny41OSA0NUwxMjcuNTkgNDVMMTI3LjU5IDk1WiIgaWQ9ImgyQ045QUVFcGUiPjwvcGF0aD48cGF0aCBkPSJNMjM3LjYgMTUwTDE4Ny42IDE1MEwxODcuNiAxMDBMMjM3LjYgMTAwTDIzNy42IDE1MFoiIGlkPSJkcXY1MTMzRzgiPjwvcGF0aD48cGF0aCBkPSJNMTgyLjU5IDE1MEwxMzIuNTkgMTUwTDEzMi41OSAxMDBMMTgyLjU5IDEwMEwxODIuNTkgMTUwWiIgaWQ9ImIxTHY3OXlwdm0iPjwvcGF0aD48cGF0aCBkPSJNMTgyLjU5IDIwNUwxMzIuNTkgMjA1TDEzMi41OSAxNTVMMTgyLjU5IDE1NUwxODIuNTkgMjA1WiIgaWQ9Imh5MUlaV3dMWCI+PC9wYXRoPjxwYXRoIGQ9Ik0yMzcuNiAyMDVMMTg3LjYgMjA1TDE4Ny42IDE1NUwyMzcuNiAxNTVMMjM3LjYgMjA1WiIgaWQ9ImFrUWZqeFFlcyI+PC9wYXRoPjxwYXRoIGQ9Ik0xMjcuNTkgMjA1TDc3LjU5IDIwNUw3Ny41OSAxNTVMMTI3LjU5IDE1NUwxMjcuNTkgMjA1WiIgaWQ9ImJkU3J3RTVwayI+PC9wYXRoPjwvZGVmcz48Zz48Zz48dXNlIHhsaW5rOmhyZWY9IiNiNDV2ZFREOGhzIiBvcGFjaXR5PSIxIiBmaWxsPSIjZjlhZDAwIiBmaWxsLW9wYWNpdHk9IjEiPjwvdXNlPjwvZz48Zz48dXNlIHhsaW5rOmhyZWY9IiNhNDBXdHhJbDhkIiBvcGFjaXR5PSIxIiBmaWxsPSIjZjlhZDAwIiBmaWxsLW9wYWNpdHk9IjEiPjwvdXNlPjwvZz48Zz48dXNlIHhsaW5rOmhyZWY9IiNoMkNOOUFFRXBlIiBvcGFjaXR5PSIxIiBmaWxsPSIjZjlhZDAwIiBmaWxsLW9wYWNpdHk9IjEiPjwvdXNlPjwvZz48Zz48dXNlIHhsaW5rOmhyZWY9IiNkcXY1MTMzRzgiIG9wYWNpdHk9IjEiIGZpbGw9IiNmOWFkMDAiIGZpbGwtb3BhY2l0eT0iMSI+PC91c2U+PC9nPjxnPjx1c2UgeGxpbms6aHJlZj0iI2IxTHY3OXlwdm0iIG9wYWNpdHk9IjEiIGZpbGw9IiNmZmZmZmYiIGZpbGwtb3BhY2l0eT0iMSI+PC91c2U+PC9nPjxnPjx1c2UgeGxpbms6aHJlZj0iI2h5MUlaV3dMWCIgb3BhY2l0eT0iMSIgZmlsbD0iI2ZmZmZmZiIgZmlsbC1vcGFjaXR5PSIxIj48L3VzZT48L2c+PGc+PHVzZSB4bGluazpocmVmPSIjYWtRZmp4UWVzIiBvcGFjaXR5PSIxIiBmaWxsPSIjZmZmZmZmIiBmaWxsLW9wYWNpdHk9IjEiPjwvdXNlPjwvZz48Zz48dXNlIHhsaW5rOmhyZWY9IiNiZFNyd0U1cGsiIG9wYWNpdHk9IjEiIGZpbGw9IiNmZmZmZmYiIGZpbGwtb3BhY2l0eT0iMSI+PC91c2U+PC9nPjwvZz48L3N2Zz4=
+      ```bash pnpm icon="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+CjxzdmcgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCBtZWV0IiB2aWV3Qm94PSI3Ni41ODk4NzI0NDg5Nzk1OCA0NCAxNjQuMDA3NzU1MTAyMDQwNjggMTY0IiB3aWR0aD0iMTYwLjAxIiBoZWlnaHQ9IjE2MCI+PGRlZnM+PHBhdGggZD0iTTIzNy42IDk1TDE4Ny42IDk1TDE4Ny42IDQ1TDIzNy42IDQ1TDIzNy42IDk1WiIgaWQ9ImI0NXZkVEQ4aHMiPjwvcGF0aD48cGF0aCBkPSJNMTgyLjU5IDk1TDEzMi41OSA5NUwxMzIuNTkgNDVMMTgyLjU5IDQ1TDE4Mi41OSA5NVoiIGlkPSJhNDBXdHhJbDhkIj48L3BhdGg+PHBhdGggZD0iTTEyNy41OSA5NUw3Ny41OSA5NUw3Ny41OSA0NUwxMjcuNTkgNDVMMTI3LjU5IDk1WiIgaWQ9ImgyQ045QUVFcGUiPjwvcGF0aD48cGF0aCBkPSJNMjM3LjYgMTUwTDE4Ny42IDE1MEwxODcuNiAxMDBMMjM3LjYgMTAwTDIzNy42IDE1MFoiIGlkPSJkcXY1MTMzRzgiPjwvcGF0aD48cGF0aCBkPSJNMTgyLjU5IDE1MEwxMzIuNTkgMTUwTDEzMi41OSAxMDBMMTgyLjU5IDEwMEwxODIuNTkgMTUwWiIgaWQ9ImIxTHY3OXlwdm0iPjwvcGF0aD48cGF0aCBkPSJNMTgyLjU5IDIwNUwxMzIuNTkgMjA1TDEzMi41OSAxNTVMMTgyLjU5IDE1NUwxODIuNTkgMjA1WiIgaWQ9Imh5MUlaV3dMWCI+PC9wYXRoPjxwYXRoIGQ9Ik0yMzcuNiAyMDVMMTg3LjYgMjA1TDE4Ny42IDE1NUwyMzcuNiAxNTVMMjM3LjYgMjA1WiIgaWQ9ImFrUWZqeFFlcyI+PC9wYXRoPjxwYXRoIGQ9Ik0xMjcuNTkgMjA1TDc3LjU5IDIwNUw3Ny41OSAxNTVMMTI3LjU5IDE1NUwxMjcuNTkgMjA1WiIgaWQ9ImJkU3J3RTVwayI+PC9wYXRoPjwvZGVmcz48Zz48Zz48dXNlIHhsaW5rOmhyZWY9IiNiNDV2ZFREOGhzIiBvcGFjaXR5PSIxIiBmaWxsPSIjZjlhZDAwIiBmaWxsLW9wYWNpdHk9IjEiPjwvdXNlPjwvZz48Zz48dXNlIHhsaW5rOmhyZWY9IiNhNDBXdHhJbDhkIiBvcGFjaXR5PSIxIiBmaWxsPSIjZjlhZDAwIiBmaWxsLW9wYWNpdHk9IjEiPjwvdXNlPjwvZz48Zz48dXNlIHhsaW5rOmhyZWY9IiNoMkNOOUFFRXBlIiBvcGFjaXR5PSIxIiBmaWxsPSIjZjlhZDAwIiBmaWxsLW9wYWNpdHk9IjEiPjwvdXNlPjwvZz48Zz48dXNlIHhsaW5rOmhyZWY9IiNkcXY1MTMzRzgiIG9wYWNpdHk9IjEiIGZpbGw9IiNmOWFkMDAiIGZpbGwtb3BhY2l0eT0iMSI+PC91c2U+PC9nPjxnPjx1c2UgeGxpbms6aHJlZj0iI2IxTHY3OXlwdm0iIG9wYWNpdHk9IjEiIGZpbGw9IiNmZmZmZmYiIGZpbGwtb3BhY2l0eT0iMSI+PC91c2U+PC9nPjxnPjx1c2UgeGxpbms6aHJlZj0iI2h5MUlaV3dMWCIgb3BhY2l0eT0iMSIgZmlsbD0iI2ZmZmZmZiIgZmlsbC1vcGFjaXR5PSIxIj48L3VzZT48L2c+PGc+PHVzZSB4bGluazpocmVmPSIjYWtRZmp4UWVzIiBvcGFjaXR5PSIxIiBmaWxsPSIjZmZmZmZmIiBmaWxsLW9wYWNpdHk9IjEiPjwvdXNlPjwvZz48Zz48dXNlIHhsaW5rOmhyZWY9IiNiZFNyd0U1cGsiIG9wYWNpdHk9IjEiIGZpbGw9IiNmZmZmZmYiIGZpbGwtb3BhY2l0eT0iMSI+PC91c2U+PC9nPjwvZz48L3N2Zz4="
       pnpm add -D vite-plugin-static-copy
       ```
 
-      ```bash yarn icon=yarn
+      ```bash yarn icon="yarn"
       yarn add -D vite-plugin-static-copy
       ```
     </CodeGroup>
 
     <CodeGroup>
-      ```ts vite.config.ts icon=ts
+      ```ts vite.config.ts icon="ts"
       import { defineConfig } from "vite";
       import { viteStaticCopy } from "vite-plugin-static-copy";
 
@@ -196,7 +196,7 @@ BEEQ components are standard custom elements (`<bq-button>`, `<bq-input>`, and s
       });
       ```
 
-      ```ts src/main.ts icon=ts highlight={2,6}
+      ```ts src/main.ts icon="ts" highlight={2,6}
       import { defineCustomElements } from "@beeq/core/dist/loader";
       import { setBasePath } from "@beeq/core";
       import "./style.css";

--- a/apps/beeq-docs/guides/frameworks/html-web-components.mdx
+++ b/apps/beeq-docs/guides/frameworks/html-web-components.mdx
@@ -85,7 +85,7 @@ BEEQ components are standard custom elements (`<bq-button>`, `<bq-input>`, and s
     Import global styles once, register custom elements at startup, and load your entry script from HTML:
 
     <CodeGroup>
-      ```css src/style.css icon="css3"
+      ```css src/style.css icon="css"
       @import "@beeq/core/dist/beeq/beeq.css";
       ```
 

--- a/apps/beeq-docs/guides/frameworks/vue.mdx
+++ b/apps/beeq-docs/guides/frameworks/vue.mdx
@@ -175,7 +175,7 @@ You can add BEEQ to an existing Vue project in a few steps:
   <Step title="Render your first component" titleSize="h3">
     Once styles and icons are configured, import and use BEEQ components in your Vue app:
 
-    ```vue icon="vuejs"
+    ```vue
     <script setup lang="ts">
     import { BqButton, BqIcon } from "@beeq/vue";
     </script>

--- a/apps/beeq-docs/guides/styles.mdx
+++ b/apps/beeq-docs/guides/styles.mdx
@@ -49,7 +49,7 @@ Style them using the `::part()` pseudo-element from your own stylesheet:
   </bq-button>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3"
+    ```css styles.css icon="css"
     .custom-button::part(label) {
       font-size: var(--bq-font-size--xl);
       font-weight: var(--bq-font-weight--semibold);
@@ -118,17 +118,17 @@ Style them using the `::part()` pseudo-element from your own stylesheet:
     </template>
 
     <style>
-    .custom-button::part(label) {
-      font-size: var(--bq-font-size--xl);
-      font-weight: var(--bq-font-weight--semibold);
-    }
+      .custom-button::part(label) {
+        font-size: var(--bq-font-size--xl);
+        font-weight: var(--bq-font-weight--semibold);
+      }
 
-    .custom-button::part(button) {
-      background-color: var(--bq-magenta-600);
-      border-radius: var(--bq-radius--full);
-      padding-block: var(--bq-spacing-xl);
-      padding-inline: var(--bq-spacing-xxl);
-    }
+      .custom-button::part(button) {
+        background-color: var(--bq-magenta-600);
+        border-radius: var(--bq-radius--full);
+        padding-block: var(--bq-spacing-xl);
+        padding-inline: var(--bq-spacing-xxl);
+      }
     </style>
     ```
   </CodeGroup>
@@ -165,7 +165,7 @@ BEEQ relies on CSS custom properties to maintain a consistent visual system acro
   </bq-button>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3"
+    ```css styles.css icon="css"
     :root {
       --bq-brand: var(--bq-orange-600);
     }
@@ -218,9 +218,9 @@ BEEQ relies on CSS custom properties to maintain a consistent visual system acro
     </template>
 
     <style>
-    :root {
-      --bq-brand: var(--bq-orange-600);
-    }
+      :root {
+        --bq-brand: var(--bq-orange-600);
+      }
     </style>
     ```
   </CodeGroup>
@@ -248,7 +248,7 @@ In the example below, the second button overrides one brand token locally while 
   </bq-button>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3"
+    ```css styles.css icon="css"
     .primary-magenta {
       --bq-ui--brand: var(--bq-magenta-600);
     }
@@ -319,9 +319,9 @@ In the example below, the second button overrides one brand token locally while 
     </template>
 
     <style>
-    .primary-magenta {
-      --bq-ui--brand: var(--bq-magenta-600);
-    }
+      .primary-magenta {
+        --bq-ui--brand: var(--bq-magenta-600);
+      }
     </style>
     ```
   </CodeGroup>
@@ -371,7 +371,7 @@ Combine component CSS variables and `::part()` selectors when token overrides al
   </bq-button>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3"
+    ```css styles.css icon="css"
     .larger-button {
       --bq-button--small-height: 42px;
       --bq-button--small-paddingY: 10px;
@@ -490,27 +490,27 @@ Combine component CSS variables and `::part()` selectors when token overrides al
     </template>
 
     <style>
-    .larger-button {
-      --bq-button--small-height: 42px;
-      --bq-button--small-paddingY: 10px;
-      --bq-button--small-paddingX: var(--bq-spacing-l);
-      --bq-button--medium-height: 53px;
-      --bq-button--medium-paddingY: 14px;
-      --bq-button--medium-paddingX: var(--bq-spacing-xl);
-      --bq-button--large-height: 60px;
-      --bq-button--large-paddingY: 18px;
-      --bq-button--large-paddingX: var(--bq-spacing-xxl);
-      --bq-ui--brand: #192b37;
-      --bq-focus: #192b37;
-    }
+      .larger-button {
+        --bq-button--small-height: 42px;
+        --bq-button--small-paddingY: 10px;
+        --bq-button--small-paddingX: var(--bq-spacing-l);
+        --bq-button--medium-height: 53px;
+        --bq-button--medium-paddingY: 14px;
+        --bq-button--medium-paddingX: var(--bq-spacing-xl);
+        --bq-button--large-height: 60px;
+        --bq-button--large-paddingY: 18px;
+        --bq-button--large-paddingX: var(--bq-spacing-xxl);
+        --bq-ui--brand: #192b37;
+        --bq-focus: #192b37;
+      }
 
-    .larger-button::part(button) {
-      border-radius: var(--bq-radius--full);
-    }
+      .larger-button::part(button) {
+        border-radius: var(--bq-radius--full);
+      }
 
-    .larger-button::part(label) {
-      font-size: var(--bq-font-size--l);
-    }
+      .larger-button::part(label) {
+        font-size: var(--bq-font-size--l);
+      }
     </style>
     ```
   </CodeGroup>

--- a/apps/beeq-docs/guides/styles.mdx
+++ b/apps/beeq-docs/guides/styles.mdx
@@ -49,7 +49,7 @@ Style them using the `::part()` pseudo-element from your own stylesheet:
   </bq-button>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css"
+    ```css styles.css icon="css3"
     .custom-button::part(label) {
       font-size: var(--bq-font-size--xl);
       font-weight: var(--bq-font-weight--semibold);
@@ -91,7 +91,7 @@ Style them using the `::part()` pseudo-element from your own stylesheet:
           Custom button
         </bq-button>
       `,
-      style: `
+      styles: [`
         .custom-button::part(label) {
           font-size: var(--bq-font-size--xl);
           font-weight: var(--bq-font-weight--semibold);
@@ -103,7 +103,7 @@ Style them using the `::part()` pseudo-element from your own stylesheet:
           padding-block: var(--bq-spacing-xl);
           padding-inline: var(--bq-spacing-xxl);
         }
-      `
+      `],
     })
     export class ExampleComponent {}
     ```
@@ -165,7 +165,7 @@ BEEQ relies on CSS custom properties to maintain a consistent visual system acro
   </bq-button>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css"
+    ```css styles.css icon="css3"
     :root {
       --bq-brand: var(--bq-orange-600);
     }
@@ -199,11 +199,11 @@ BEEQ relies on CSS custom properties to maintain a consistent visual system acro
           Primary button
         </bq-button>
       `,
-      style: `
+      styles: [`
         :root {
           --bq-brand: var(--bq-orange-600);
         }
-      `
+      `],
     })
     export class ExampleComponent {}
     ```
@@ -248,7 +248,7 @@ In the example below, the second button overrides one brand token locally while 
   </bq-button>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css"
+    ```css styles.css icon="css3"
     .primary-magenta {
       --bq-ui--brand: var(--bq-magenta-600);
     }
@@ -297,11 +297,11 @@ In the example below, the second button overrides one brand token locally while 
           Primary custom
         </bq-button>
       `,
-      style: `
+      styles: [`
         .primary-magenta {
           --bq-ui--brand: var(--bq-magenta-600);
         }
-      `
+      `],
     })
     export class ExampleComponent {}
     ```
@@ -371,7 +371,7 @@ Combine component CSS variables and `::part()` selectors when token overrides al
   </bq-button>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css"
+    ```css styles.css icon="css3"
     .larger-button {
       --bq-button--small-height: 42px;
       --bq-button--small-paddingY: 10px;
@@ -451,7 +451,7 @@ Combine component CSS variables and `::part()` selectors when token overrides al
           Button
         </bq-button>
       `,
-      style: `
+      styles: [`
         .larger-button {
           --bq-button--small-height: 42px;
           --bq-button--small-paddingY: 10px;
@@ -473,7 +473,7 @@ Combine component CSS variables and `::part()` selectors when token overrides al
         .larger-button::part(label) {
           font-size: var(--bq-font-size--l);
         }
-      `
+      `],
     })
     export class ExampleComponent {}
     ```

--- a/apps/beeq-docs/guides/styles.mdx
+++ b/apps/beeq-docs/guides/styles.mdx
@@ -49,7 +49,7 @@ Style them using the `::part()` pseudo-element from your own stylesheet:
   </bq-button>
 `}>
   <CodeGroup>
-    ```css styles.css icon=css
+    ```css styles.css icon="css"
     .custom-button::part(label) {
       font-size: var(--bq-font-size--xl);
       font-weight: var(--bq-font-weight--semibold);
@@ -63,13 +63,13 @@ Style them using the `::part()` pseudo-element from your own stylesheet:
     }
     ```
 
-    ```html HTML icon=html5
+    ```html HTML icon="html5"
     <bq-button class="custom-button">
       Custom button
     </bq-button>
     ```
 
-    ```tsx React icon=react
+    ```tsx React icon="react"
     import { BqButton } from "@beeq/react";
     import "./styles.css";
 
@@ -78,7 +78,7 @@ Style them using the `::part()` pseudo-element from your own stylesheet:
     }
     ```
 
-    ```ts Angular icon=angular
+    ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqButton } from "@beeq/angular/standalone";
 
@@ -108,7 +108,7 @@ Style them using the `::part()` pseudo-element from your own stylesheet:
     export class ExampleComponent {}
     ```
 
-    ```vue Vue icon=vuejs
+    ```vue Vue icon="vuejs"
     <script setup lang="ts">
     import { BqButton } from "@beeq/vue";
     </script>
@@ -165,19 +165,19 @@ BEEQ relies on CSS custom properties to maintain a consistent visual system acro
   </bq-button>
 `}>
   <CodeGroup>
-    ```css styles.css icon=css
+    ```css styles.css icon="css"
     :root {
       --bq-brand: var(--bq-orange-600);
     }
     ```
 
-    ```html HTML icon=html5
+    ```html HTML icon="html5"
     <bq-button appearance="primary">
       Primary button
     </bq-button>
     ```
 
-    ```tsx React icon=react
+    ```tsx React icon="react"
     import { BqButton } from "@beeq/react";
     import "./styles.css";
 
@@ -186,7 +186,7 @@ BEEQ relies on CSS custom properties to maintain a consistent visual system acro
     }
     ```
 
-    ```ts Angular icon=angular
+    ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqButton } from "@beeq/angular/standalone";
 
@@ -208,7 +208,7 @@ BEEQ relies on CSS custom properties to maintain a consistent visual system acro
     export class ExampleComponent {}
     ```
 
-    ```vue Vue icon=vuejs
+    ```vue Vue icon="vuejs"
     <script setup lang="ts">
     import { BqButton } from "@beeq/vue";
     </script>
@@ -248,13 +248,13 @@ In the example below, the second button overrides one brand token locally while 
   </bq-button>
 `}>
   <CodeGroup>
-    ```css styles.css icon=css
+    ```css styles.css icon="css"
     .primary-magenta {
       --bq-ui--brand: var(--bq-magenta-600);
     }
     ```
 
-    ```html HTML icon=html5
+    ```html HTML icon="html5"
     <bq-button appearance="primary">
       Primary button
     </bq-button>
@@ -264,7 +264,7 @@ In the example below, the second button overrides one brand token locally while 
     </bq-button>
     ```
 
-    ```tsx React icon=react
+    ```tsx React icon="react"
     import { BqButton } from "@beeq/react";
     import "./styles.css";
 
@@ -280,7 +280,7 @@ In the example below, the second button overrides one brand token locally while 
     }
     ```
 
-    ```ts Angular icon=angular
+    ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqButton } from "@beeq/angular/standalone";
 
@@ -306,7 +306,7 @@ In the example below, the second button overrides one brand token locally while 
     export class ExampleComponent {}
     ```
 
-    ```vue Vue icon=vuejs
+    ```vue Vue icon="vuejs"
     <script setup lang="ts">
     import { BqButton } from "@beeq/vue";
     </script>
@@ -371,7 +371,7 @@ Combine component CSS variables and `::part()` selectors when token overrides al
   </bq-button>
 `}>
   <CodeGroup>
-    ```css styles.css icon=css
+    ```css styles.css icon="css"
     .larger-button {
       --bq-button--small-height: 42px;
       --bq-button--small-paddingY: 10px;
@@ -395,7 +395,7 @@ Combine component CSS variables and `::part()` selectors when token overrides al
     }
     ```
 
-    ```html HTML icon=html5
+    ```html HTML icon="html5"
     <bq-button class="larger-button" size="small">
       Button
     </bq-button>
@@ -409,7 +409,7 @@ Combine component CSS variables and `::part()` selectors when token overrides al
     </bq-button>
     ```
 
-    ```tsx React icon=react
+    ```tsx React icon="react"
     import { BqButton } from "@beeq/react";
     import "./styles.css";
 
@@ -430,7 +430,7 @@ Combine component CSS variables and `::part()` selectors when token overrides al
     }
     ```
 
-    ```ts Angular icon=angular
+    ```ts Angular icon="angular"
     import { Component } from "@angular/core";
     import { BqButton } from "@beeq/angular/standalone";
 
@@ -478,7 +478,7 @@ Combine component CSS variables and `::part()` selectors when token overrides al
     export class ExampleComponent {}
     ```
 
-    ```vue Vue icon=vuejs
+    ```vue Vue icon="vuejs"
     <script setup lang="ts">
     import { BqButton } from "@beeq/vue";
     </script>

--- a/apps/beeq-docs/theming/component-css-variables.mdx
+++ b/apps/beeq-docs/theming/component-css-variables.mdx
@@ -128,6 +128,7 @@ Applies the custom styles to every `bq-badge` in the application.
     // Import the CSS override in your global stylesheet
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqBadge],
       template: `
@@ -136,7 +137,7 @@ Applies the custom styles to every `bq-badge` in the application.
         <bq-badge>99+</bq-badge>
       `,
     })
-    export class BadgeGlobalOverrideExample {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"
@@ -215,6 +216,7 @@ Only the `bq-badge` elements with the matching CSS class will have the overridde
     // Import the CSS override in your global stylesheet
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqBadge],
       template: `
@@ -224,7 +226,7 @@ Only the `bq-badge` elements with the matching CSS class will have the overridde
         <bq-badge class="success">completed</bq-badge>
       `,
     })
-    export class BadgeTargetedOverrideExample {}
+    export class AppComponent {}
     ```
 
     ```vue Vue icon="vuejs"

--- a/apps/beeq-docs/theming/component-css-variables.mdx
+++ b/apps/beeq-docs/theming/component-css-variables.mdx
@@ -95,7 +95,7 @@ Applies the custom styles to every `bq-badge` in the application.
     <bq-badge>99+</bq-badge>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     bq-badge {
       --bq-badge--background-color: var(--bq-green-400);
       --bq-badge--box-shadow: var(--bq-box-shadow--l);
@@ -137,7 +137,7 @@ Applies the custom styles to every `bq-badge` in the application.
         <bq-badge size="medium"></bq-badge>
         <bq-badge>99+</bq-badge>
       `,
-      style: `
+      styles: [`
         bq-badge {
           --bq-badge--background-color: var(--bq-green-400);
           --bq-badge--box-shadow: var(--bq-box-shadow--l);
@@ -146,7 +146,7 @@ Applies the custom styles to every `bq-badge` in the application.
           --bq-badge--border-width: 1px;
           --bq-badge--border-radius: 4px;
         }
-      `,
+      `],
     })
     export class AppComponent {}
     ```
@@ -205,7 +205,7 @@ Only the `bq-badge` elements with the matching CSS class will have the overridde
   <bq-badge class="success">completed</bq-badge>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     bq-badge.success {
       --bq-badge--background-color: var(--bq-green-400);
       --bq-badge--box-shadow: var(--bq-box-shadow--l);
@@ -250,7 +250,7 @@ Only the `bq-badge` elements with the matching CSS class will have the overridde
         <bq-badge>99+</bq-badge>
         <bq-badge class="success">completed</bq-badge>
       `,
-      style: `
+      styles: [`
         bq-badge.success {
           --bq-badge--background-color: var(--bq-green-400);
           --bq-badge--box-shadow: var(--bq-box-shadow--l);
@@ -259,7 +259,7 @@ Only the `bq-badge` elements with the matching CSS class will have the overridde
           --bq-badge--border-width: 1px;
           --bq-badge--border-radius: 4px;
         }
-      `,
+      `],
     })
     export class AppComponent {}
     ```

--- a/apps/beeq-docs/theming/component-css-variables.mdx
+++ b/apps/beeq-docs/theming/component-css-variables.mdx
@@ -95,7 +95,7 @@ Applies the custom styles to every `bq-badge` in the application.
     <bq-badge>99+</bq-badge>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     bq-badge {
       --bq-badge--background-color: var(--bq-green-400);
       --bq-badge--box-shadow: var(--bq-box-shadow--l);
@@ -162,15 +162,14 @@ Applies the custom styles to every `bq-badge` in the application.
 
 
     <style>
-    bq-badge {
-      --bq-badge--background-color: var(--bq-green-400);
-      --bq-badge--box-shadow: var(--bq-box-shadow--l);
-      --bq-badge--border-color: var(--bq-green-600);
-      --bq-badge--border-style: solid;
-      --bq-badge--border-width: 1px;
-      --bq-badge--border-radius: 4px;
-    }
-
+      bq-badge {
+        --bq-badge--background-color: var(--bq-green-400);
+        --bq-badge--box-shadow: var(--bq-box-shadow--l);
+        --bq-badge--border-color: var(--bq-green-600);
+        --bq-badge--border-style: solid;
+        --bq-badge--border-width: 1px;
+        --bq-badge--border-radius: 4px;
+      }
     </style>
     ```
   </CodeGroup>
@@ -202,7 +201,7 @@ Only the `bq-badge` elements with the matching CSS class will have the overridde
   <bq-badge class="success">completed</bq-badge>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     bq-badge.success {
       --bq-badge--background-color: var(--bq-green-400);
       --bq-badge--box-shadow: var(--bq-box-shadow--l);
@@ -273,15 +272,14 @@ Only the `bq-badge` elements with the matching CSS class will have the overridde
 
 
     <style>
-    bq-badge.success {
-      --bq-badge--background-color: var(--bq-green-400);
-      --bq-badge--box-shadow: var(--bq-box-shadow--l);
-      --bq-badge--border-color: var(--bq-green-600);
-      --bq-badge--border-style: solid;
-      --bq-badge--border-width: 1px;
-      --bq-badge--border-radius: 4px;
-    }
-
+      bq-badge.success {
+        --bq-badge--background-color: var(--bq-green-400);
+        --bq-badge--box-shadow: var(--bq-box-shadow--l);
+        --bq-badge--border-color: var(--bq-green-600);
+        --bq-badge--border-style: solid;
+        --bq-badge--border-width: 1px;
+        --bq-badge--border-radius: 4px;
+      }
     </style>
     ```
   </CodeGroup>

--- a/apps/beeq-docs/theming/component-css-variables.mdx
+++ b/apps/beeq-docs/theming/component-css-variables.mdx
@@ -126,8 +126,6 @@ Applies the custom styles to every `bq-badge` in the application.
     import { Component } from "@angular/core";
     import { BqBadge } from "@beeq/angular/standalone";
 
-    // Import the CSS override in your global stylesheet
-
     @Component({
       selector: "app-root",
       standalone: true,
@@ -154,7 +152,6 @@ Applies the custom styles to every `bq-badge` in the application.
     ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqBadge } from "@beeq/vue";
-    // Import the CSS override in your global stylesheet
     </script>
 
     <template>
@@ -238,8 +235,6 @@ Only the `bq-badge` elements with the matching CSS class will have the overridde
     import { Component } from "@angular/core";
     import { BqBadge } from "@beeq/angular/standalone";
 
-    // Import the CSS override in your global stylesheet
-
     @Component({
       selector: "app-root",
       standalone: true,
@@ -267,7 +262,6 @@ Only the `bq-badge` elements with the matching CSS class will have the overridde
     ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqBadge } from "@beeq/vue";
-    // Import the CSS override in your global stylesheet
     </script>
 
     <template>

--- a/apps/beeq-docs/theming/component-css-variables.mdx
+++ b/apps/beeq-docs/theming/component-css-variables.mdx
@@ -95,7 +95,7 @@ Applies the custom styles to every `bq-badge` in the application.
     <bq-badge>99+</bq-badge>
 `}>
   <CodeGroup>
-    ```css CSS icon="css"
+    ```css styles.css icon="css" expandable
     bq-badge {
       --bq-badge--background-color: var(--bq-green-400);
       --bq-badge--box-shadow: var(--bq-box-shadow--l);
@@ -106,14 +106,15 @@ Applies the custom styles to every `bq-badge` in the application.
     }
     ```
 
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-badge size="small"></bq-badge>
     <bq-badge size="medium"></bq-badge>
     <bq-badge>99+</bq-badge>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqBadge } from "@beeq/react";
+    import "./styles.css";
     // Import the CSS override in your global stylesheet
 
     <BqBadge size="small" />
@@ -121,7 +122,7 @@ Applies the custom styles to every `bq-badge` in the application.
     <BqBadge>99+</BqBadge>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqBadge } from "@beeq/angular/standalone";
 
@@ -136,11 +137,21 @@ Applies the custom styles to every `bq-badge` in the application.
         <bq-badge size="medium"></bq-badge>
         <bq-badge>99+</bq-badge>
       `,
+      style: `
+        bq-badge {
+          --bq-badge--background-color: var(--bq-green-400);
+          --bq-badge--box-shadow: var(--bq-box-shadow--l);
+          --bq-badge--border-color: var(--bq-green-600);
+          --bq-badge--border-style: solid;
+          --bq-badge--border-width: 1px;
+          --bq-badge--border-radius: 4px;
+        }
+      `,
     })
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqBadge } from "@beeq/vue";
     // Import the CSS override in your global stylesheet
@@ -151,6 +162,19 @@ Applies the custom styles to every `bq-badge` in the application.
       <BqBadge size="medium" />
       <BqBadge>99+</BqBadge>
     </template>
+
+
+    <style>
+    bq-badge {
+      --bq-badge--background-color: var(--bq-green-400);
+      --bq-badge--box-shadow: var(--bq-box-shadow--l);
+      --bq-badge--border-color: var(--bq-green-600);
+      --bq-badge--border-style: solid;
+      --bq-badge--border-width: 1px;
+      --bq-badge--border-radius: 4px;
+    }
+
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>
@@ -181,7 +205,7 @@ Only the `bq-badge` elements with the matching CSS class will have the overridde
   <bq-badge class="success">completed</bq-badge>
 `}>
   <CodeGroup>
-    ```css CSS icon="css"
+    ```css styles.css icon="css" expandable
     bq-badge.success {
       --bq-badge--background-color: var(--bq-green-400);
       --bq-badge--box-shadow: var(--bq-box-shadow--l);
@@ -192,15 +216,16 @@ Only the `bq-badge` elements with the matching CSS class will have the overridde
     }
     ```
 
-    ```html HTML icon="html5"
+    ```html HTML icon="html5" expandable
     <bq-badge size="small"></bq-badge>
     <bq-badge size="medium"></bq-badge>
     <bq-badge>99+</bq-badge>
     <bq-badge class="success">completed</bq-badge>
     ```
 
-    ```jsx React icon="react"
+    ```jsx React icon="react" expandable
     import { BqBadge } from "@beeq/react";
+    import "./styles.css";
     // Import the CSS override in your global stylesheet
 
     <BqBadge size="small" />
@@ -209,7 +234,7 @@ Only the `bq-badge` elements with the matching CSS class will have the overridde
     <BqBadge className="success">completed</BqBadge>
     ```
 
-    ```ts Angular icon="angular"
+    ```ts Angular icon="angular" expandable
     import { Component } from "@angular/core";
     import { BqBadge } from "@beeq/angular/standalone";
 
@@ -225,11 +250,21 @@ Only the `bq-badge` elements with the matching CSS class will have the overridde
         <bq-badge>99+</bq-badge>
         <bq-badge class="success">completed</bq-badge>
       `,
+      style: `
+        bq-badge.success {
+          --bq-badge--background-color: var(--bq-green-400);
+          --bq-badge--box-shadow: var(--bq-box-shadow--l);
+          --bq-badge--border-color: var(--bq-green-600);
+          --bq-badge--border-style: solid;
+          --bq-badge--border-width: 1px;
+          --bq-badge--border-radius: 4px;
+        }
+      `,
     })
     export class AppComponent {}
     ```
 
-    ```vue Vue icon="vuejs"
+    ```vue Vue icon="vuejs" expandable
     <script setup lang="ts">
     import { BqBadge } from "@beeq/vue";
     // Import the CSS override in your global stylesheet
@@ -241,6 +276,19 @@ Only the `bq-badge` elements with the matching CSS class will have the overridde
       <BqBadge>99+</BqBadge>
       <BqBadge class="success">completed</BqBadge>
     </template>
+
+
+    <style>
+    bq-badge.success {
+      --bq-badge--background-color: var(--bq-green-400);
+      --bq-badge--box-shadow: var(--bq-box-shadow--l);
+      --bq-badge--border-color: var(--bq-green-600);
+      --bq-badge--border-style: solid;
+      --bq-badge--border-width: 1px;
+      --bq-badge--border-radius: 4px;
+    }
+
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>

--- a/apps/beeq-docs/theming/custom-theme.mdx
+++ b/apps/beeq-docs/theming/custom-theme.mdx
@@ -877,6 +877,7 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
     // document.documentElement.setAttribute('bq-theme', 'techflow');
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqTabGroup, BqTab, BqIcon, BqButton, BqInput],
       template: `
@@ -938,7 +939,7 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
         }
       `,
     })
-    export class TechFlowDemoComponent {
+    export class AppComponent {
       private readonly document = inject(DOCUMENT);
       readonly activeTab = signal('home');
       readonly isDark = signal(true);

--- a/apps/beeq-docs/theming/custom-theme.mdx
+++ b/apps/beeq-docs/theming/custom-theme.mdx
@@ -540,7 +540,7 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
   </script>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     /* -------------------------------------------------------------------------- */
     /* BASE THEME VARIABLES                                                       */
     /* -------------------------------------------------------------------------- */
@@ -939,7 +939,7 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
           <h1>Settings tab!</h1>
         }
       `,
-      style: `
+      styles: [`
             /* -------------------------------------------------------------------------- */
             /* BASE THEME VARIABLES                                                       */
             /* -------------------------------------------------------------------------- */
@@ -1094,7 +1094,7 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
               --bq-state--hover:    rgba(255, 255, 255, 0.10);
               --bq-state--active:   rgba(255, 255, 255, 0.15);
             }
-      `,
+      `],
     })
     export class AppComponent {
       private readonly document = inject(DOCUMENT);

--- a/apps/beeq-docs/theming/custom-theme.mdx
+++ b/apps/beeq-docs/theming/custom-theme.mdx
@@ -540,7 +540,7 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
   </script>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
+    ```css styles.css icon="css" expandable
     /* -------------------------------------------------------------------------- */
     /* BASE THEME VARIABLES                                                       */
     /* -------------------------------------------------------------------------- */
@@ -940,160 +940,160 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
         }
       `,
       styles: [`
-            /* -------------------------------------------------------------------------- */
-            /* BASE THEME VARIABLES                                                       */
-            /* -------------------------------------------------------------------------- */
-            [bq-theme="techflow"],
-            .techflow {
-              --bq-font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-              --bq-brand-light: #a8f0e6;
-              --bq-brand:       #00836e;
-              --bq-brand-dark:  #005a4f;
-              --bq-accent-light: #e8d5f2;
-              --bq-accent:       #9d4edd;
-              --bq-accent-dark:  #5a189a;
-              --bq-success-light: #a1e4cb;
-              --bq-success:       #05b981;
-              --bq-success-dark:  #047857;
-              --bq-danger-light:  #fecaca;
-              --bq-danger:        #ef4444;
-              --bq-danger-dark:   #991b1b;
-              --bq-warning-light: #fef3c7;
-              --bq-warning:       #f59e0b;
-              --bq-warning-dark:  #92400e;
-              --bq-info-light:    #bfdbfe;
-              --bq-info:          #3b82f6;
-              --bq-info-dark:     #1e3a8a;
-              --bq-focus:         #00836e;
-              --bq-white:         #ffffff;
-              --bq-black:         #000000;
-              --bq-neutral-50:    #f9fafb;
-              --bq-neutral-100:   #f3f4f6;
-              --bq-neutral-200:   #e5e7eb;
-              --bq-neutral-300:   #d1d5db;
-              --bq-neutral-400:   #9ca3af;
-              --bq-neutral-500:   #6b7280;
-              --bq-neutral-600:   #4b5563;
-              --bq-neutral-700:   #374151;
-              --bq-neutral-800:   #1f2937;
-              --bq-neutral-900:   #111827;
-              --bq-neutral-950:   #0f172a;
-              --bq-neutral-1000:  #030712;
-            }
+        /* -------------------------------------------------------------------------- */
+        /* BASE THEME VARIABLES                                                       */
+        /* -------------------------------------------------------------------------- */
+        [bq-theme="techflow"],
+        .techflow {
+          --bq-font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+          --bq-brand-light: #a8f0e6;
+          --bq-brand:       #00836e;
+          --bq-brand-dark:  #005a4f;
+          --bq-accent-light: #e8d5f2;
+          --bq-accent:       #9d4edd;
+          --bq-accent-dark:  #5a189a;
+          --bq-success-light: #a1e4cb;
+          --bq-success:       #05b981;
+          --bq-success-dark:  #047857;
+          --bq-danger-light:  #fecaca;
+          --bq-danger:        #ef4444;
+          --bq-danger-dark:   #991b1b;
+          --bq-warning-light: #fef3c7;
+          --bq-warning:       #f59e0b;
+          --bq-warning-dark:  #92400e;
+          --bq-info-light:    #bfdbfe;
+          --bq-info:          #3b82f6;
+          --bq-info-dark:     #1e3a8a;
+          --bq-focus:         #00836e;
+          --bq-white:         #ffffff;
+          --bq-black:         #000000;
+          --bq-neutral-50:    #f9fafb;
+          --bq-neutral-100:   #f3f4f6;
+          --bq-neutral-200:   #e5e7eb;
+          --bq-neutral-300:   #d1d5db;
+          --bq-neutral-400:   #9ca3af;
+          --bq-neutral-500:   #6b7280;
+          --bq-neutral-600:   #4b5563;
+          --bq-neutral-700:   #374151;
+          --bq-neutral-800:   #1f2937;
+          --bq-neutral-900:   #111827;
+          --bq-neutral-950:   #0f172a;
+          --bq-neutral-1000:  #030712;
+        }
 
-            /* -------------------------------------------------------------------------- */
-            /* LIGHT MODE                                                                 */
-            /* -------------------------------------------------------------------------- */
-            [bq-theme="techflow"]:not([bq-mode]),
-            [bq-theme="techflow"][bq-mode="light"],
-            .techflow:not([bq-mode]),
-            .techflow.light {
-              --bq-background--primary:   #ffffff;
-              --bq-background--secondary: #f9fafb;
-              --bq-background--tertiary:  #f3f4f6;
-              --bq-background--alt:       #e5e7eb;
-              --bq-background--inverse:   #111827;
-              --bq-background--brand:     #a8f0e6;
-              --bq-background--overlay:   rgba(0, 0, 0, 0.5);
-              --bq-icon--primary:   #1f2937;
-              --bq-icon--secondary: #6b7280;
-              --bq-icon--inverse:   #f9fafb;
-              --bq-icon--brand:     #00836e;
-              --bq-icon--alt:       #ffffff;
-              --bq-icon--info:      #1d4ed8;
-              --bq-icon--success:   #047857;
-              --bq-icon--warning:   #92400e;
-              --bq-icon--danger:    #b91c1c;
-              --bq-stroke--primary:   #e5e7eb;
-              --bq-stroke--secondary: #d1d5db;
-              --bq-stroke--tertiary:  #9ca3af;
-              --bq-stroke--inverse:   #ffffff;
-              --bq-stroke--brand:     #00836e;
-              --bq-stroke--alt:       #f3f4f6;
-              --bq-stroke--success:   #047857;
-              --bq-stroke--warning:   #92400e;
-              --bq-stroke--danger:    #b91c1c;
-              --bq-text--primary:   #111827;
-              --bq-text--secondary: #6b7280;
-              --bq-text--inverse:   #f9fafb;
-              --bq-text--brand:     #00836e;
-              --bq-text--alt:       #ffffff;
-              --bq-text--info:      #1d4ed8;
-              --bq-text--success:   #047857;
-              --bq-text--warning:   #92400e;
-              --bq-text--danger:    #b91c1c;
-              --bq-ui--primary:     #ffffff;
-              --bq-ui--secondary:   #f3f4f6;
-              --bq-ui--tertiary:    #e5e7eb;
-              --bq-ui--inverse:     #111827;
-              --bq-ui--brand:       #00836e;
-              --bq-ui--brand-alt:   #a8f0e6;
-              --bq-ui--alt:         #f9fafb;
-              --bq-ui--success:     #047857;
-              --bq-ui--success-alt: #a1e4cb;
-              --bq-ui--warning:     #92400e;
-              --bq-ui--warning-alt: #fef3c7;
-              --bq-ui--danger:      #b91c1c;
-              --bq-ui--danger-alt:  #fecaca;
-              --bq-state--hover:    rgba(0, 0, 0, 0.08);
-              --bq-state--active:   rgba(0, 0, 0, 0.12);
-            }
+        /* -------------------------------------------------------------------------- */
+        /* LIGHT MODE                                                                 */
+        /* -------------------------------------------------------------------------- */
+        [bq-theme="techflow"]:not([bq-mode]),
+        [bq-theme="techflow"][bq-mode="light"],
+        .techflow:not([bq-mode]),
+        .techflow.light {
+          --bq-background--primary:   #ffffff;
+          --bq-background--secondary: #f9fafb;
+          --bq-background--tertiary:  #f3f4f6;
+          --bq-background--alt:       #e5e7eb;
+          --bq-background--inverse:   #111827;
+          --bq-background--brand:     #a8f0e6;
+          --bq-background--overlay:   rgba(0, 0, 0, 0.5);
+          --bq-icon--primary:   #1f2937;
+          --bq-icon--secondary: #6b7280;
+          --bq-icon--inverse:   #f9fafb;
+          --bq-icon--brand:     #00836e;
+          --bq-icon--alt:       #ffffff;
+          --bq-icon--info:      #1d4ed8;
+          --bq-icon--success:   #047857;
+          --bq-icon--warning:   #92400e;
+          --bq-icon--danger:    #b91c1c;
+          --bq-stroke--primary:   #e5e7eb;
+          --bq-stroke--secondary: #d1d5db;
+          --bq-stroke--tertiary:  #9ca3af;
+          --bq-stroke--inverse:   #ffffff;
+          --bq-stroke--brand:     #00836e;
+          --bq-stroke--alt:       #f3f4f6;
+          --bq-stroke--success:   #047857;
+          --bq-stroke--warning:   #92400e;
+          --bq-stroke--danger:    #b91c1c;
+          --bq-text--primary:   #111827;
+          --bq-text--secondary: #6b7280;
+          --bq-text--inverse:   #f9fafb;
+          --bq-text--brand:     #00836e;
+          --bq-text--alt:       #ffffff;
+          --bq-text--info:      #1d4ed8;
+          --bq-text--success:   #047857;
+          --bq-text--warning:   #92400e;
+          --bq-text--danger:    #b91c1c;
+          --bq-ui--primary:     #ffffff;
+          --bq-ui--secondary:   #f3f4f6;
+          --bq-ui--tertiary:    #e5e7eb;
+          --bq-ui--inverse:     #111827;
+          --bq-ui--brand:       #00836e;
+          --bq-ui--brand-alt:   #a8f0e6;
+          --bq-ui--alt:         #f9fafb;
+          --bq-ui--success:     #047857;
+          --bq-ui--success-alt: #a1e4cb;
+          --bq-ui--warning:     #92400e;
+          --bq-ui--warning-alt: #fef3c7;
+          --bq-ui--danger:      #b91c1c;
+          --bq-ui--danger-alt:  #fecaca;
+          --bq-state--hover:    rgba(0, 0, 0, 0.08);
+          --bq-state--active:   rgba(0, 0, 0, 0.12);
+        }
 
-            /* -------------------------------------------------------------------------- */
-            /* DARK MODE                                                                  */
-            /* -------------------------------------------------------------------------- */
-            [bq-theme="techflow"][bq-mode="dark"],
-            .techflow.dark {
-              --bq-background--primary:   #030712;
-              --bq-background--secondary: #0f172a;
-              --bq-background--tertiary:  #1f2937;
-              --bq-background--alt:       #374151;
-              --bq-background--inverse:   #f9fafb;
-              --bq-background--brand:     #009b88;
-              --bq-background--overlay:   rgba(0, 0, 0, 0.7);
-              --bq-icon--primary:   #f3f4f6;
-              --bq-icon--secondary: #9ca3af;
-              --bq-icon--inverse:   #1f2937;
-              --bq-icon--brand:     #00d9c4;
-              --bq-icon--alt:       #ffffff;
-              --bq-icon--info:      #60a5fa;
-              --bq-icon--success:   #34d399;
-              --bq-icon--warning:   #fbbf24;
-              --bq-icon--danger:    #f87171;
-              --bq-stroke--primary:   #374151;
-              --bq-stroke--secondary: #4b5563;
-              --bq-stroke--tertiary:  #9ca3af;
-              --bq-stroke--inverse:   #0f172a;
-              --bq-stroke--brand:     #00d9c4;
-              --bq-stroke--alt:       #1f2937;
-              --bq-stroke--success:   #34d399;
-              --bq-stroke--warning:   #fbbf24;
-              --bq-stroke--danger:    #f87171;
-              --bq-text--primary:   #f9fafb;
-              --bq-text--secondary: #9ca3af;
-              --bq-text--inverse:   #1f2937;
-              --bq-text--brand:     #00d9c4;
-              --bq-text--alt:       #ffffff;
-              --bq-text--info:      #60a5fa;
-              --bq-text--success:   #34d399;
-              --bq-text--warning:   #fbbf24;
-              --bq-text--danger:    #f87171;
-              --bq-ui--primary:     #1f2937;
-              --bq-ui--secondary:   #374151;
-              --bq-ui--tertiary:    #4b5563;
-              --bq-ui--inverse:     #f9fafb;
-              --bq-ui--brand:       #00d9c4;
-              --bq-ui--brand-alt:   #009b88;
-              --bq-ui--alt:         #0f172a;
-              --bq-ui--success:     #34d399;
-              --bq-ui--success-alt: #10b981;
-              --bq-ui--warning:     #fbbf24;
-              --bq-ui--warning-alt: #f59e0b;
-              --bq-ui--danger:      #f87171;
-              --bq-ui--danger-alt:  #ef4444;
-              --bq-state--hover:    rgba(255, 255, 255, 0.10);
-              --bq-state--active:   rgba(255, 255, 255, 0.15);
-            }
+        /* -------------------------------------------------------------------------- */
+        /* DARK MODE                                                                  */
+        /* -------------------------------------------------------------------------- */
+        [bq-theme="techflow"][bq-mode="dark"],
+        .techflow.dark {
+          --bq-background--primary:   #030712;
+          --bq-background--secondary: #0f172a;
+          --bq-background--tertiary:  #1f2937;
+          --bq-background--alt:       #374151;
+          --bq-background--inverse:   #f9fafb;
+          --bq-background--brand:     #009b88;
+          --bq-background--overlay:   rgba(0, 0, 0, 0.7);
+          --bq-icon--primary:   #f3f4f6;
+          --bq-icon--secondary: #9ca3af;
+          --bq-icon--inverse:   #1f2937;
+          --bq-icon--brand:     #00d9c4;
+          --bq-icon--alt:       #ffffff;
+          --bq-icon--info:      #60a5fa;
+          --bq-icon--success:   #34d399;
+          --bq-icon--warning:   #fbbf24;
+          --bq-icon--danger:    #f87171;
+          --bq-stroke--primary:   #374151;
+          --bq-stroke--secondary: #4b5563;
+          --bq-stroke--tertiary:  #9ca3af;
+          --bq-stroke--inverse:   #0f172a;
+          --bq-stroke--brand:     #00d9c4;
+          --bq-stroke--alt:       #1f2937;
+          --bq-stroke--success:   #34d399;
+          --bq-stroke--warning:   #fbbf24;
+          --bq-stroke--danger:    #f87171;
+          --bq-text--primary:   #f9fafb;
+          --bq-text--secondary: #9ca3af;
+          --bq-text--inverse:   #1f2937;
+          --bq-text--brand:     #00d9c4;
+          --bq-text--alt:       #ffffff;
+          --bq-text--info:      #60a5fa;
+          --bq-text--success:   #34d399;
+          --bq-text--warning:   #fbbf24;
+          --bq-text--danger:    #f87171;
+          --bq-ui--primary:     #1f2937;
+          --bq-ui--secondary:   #374151;
+          --bq-ui--tertiary:    #4b5563;
+          --bq-ui--inverse:     #f9fafb;
+          --bq-ui--brand:       #00d9c4;
+          --bq-ui--brand-alt:   #009b88;
+          --bq-ui--alt:         #0f172a;
+          --bq-ui--success:     #34d399;
+          --bq-ui--success-alt: #10b981;
+          --bq-ui--warning:     #fbbf24;
+          --bq-ui--warning-alt: #f59e0b;
+          --bq-ui--danger:      #f87171;
+          --bq-ui--danger-alt:  #ef4444;
+          --bq-state--hover:    rgba(255, 255, 255, 0.10);
+          --bq-state--active:   rgba(255, 255, 255, 0.15);
+        }
       `],
     })
     export class AppComponent {
@@ -1195,160 +1195,160 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
     </template>
 
     <style>
-    /* -------------------------------------------------------------------------- */
-    /* BASE THEME VARIABLES                                                       */
-    /* -------------------------------------------------------------------------- */
-    [bq-theme="techflow"],
-    .techflow {
-      --bq-font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      --bq-brand-light: #a8f0e6;
-      --bq-brand:       #00836e;
-      --bq-brand-dark:  #005a4f;
-      --bq-accent-light: #e8d5f2;
-      --bq-accent:       #9d4edd;
-      --bq-accent-dark:  #5a189a;
-      --bq-success-light: #a1e4cb;
-      --bq-success:       #05b981;
-      --bq-success-dark:  #047857;
-      --bq-danger-light:  #fecaca;
-      --bq-danger:        #ef4444;
-      --bq-danger-dark:   #991b1b;
-      --bq-warning-light: #fef3c7;
-      --bq-warning:       #f59e0b;
-      --bq-warning-dark:  #92400e;
-      --bq-info-light:    #bfdbfe;
-      --bq-info:          #3b82f6;
-      --bq-info-dark:     #1e3a8a;
-      --bq-focus:         #00836e;
-      --bq-white:         #ffffff;
-      --bq-black:         #000000;
-      --bq-neutral-50:    #f9fafb;
-      --bq-neutral-100:   #f3f4f6;
-      --bq-neutral-200:   #e5e7eb;
-      --bq-neutral-300:   #d1d5db;
-      --bq-neutral-400:   #9ca3af;
-      --bq-neutral-500:   #6b7280;
-      --bq-neutral-600:   #4b5563;
-      --bq-neutral-700:   #374151;
-      --bq-neutral-800:   #1f2937;
-      --bq-neutral-900:   #111827;
-      --bq-neutral-950:   #0f172a;
-      --bq-neutral-1000:  #030712;
-    }
+      /* -------------------------------------------------------------------------- */
+      /* BASE THEME VARIABLES                                                       */
+      /* -------------------------------------------------------------------------- */
+      [bq-theme="techflow"],
+      .techflow {
+        --bq-font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        --bq-brand-light: #a8f0e6;
+        --bq-brand:       #00836e;
+        --bq-brand-dark:  #005a4f;
+        --bq-accent-light: #e8d5f2;
+        --bq-accent:       #9d4edd;
+        --bq-accent-dark:  #5a189a;
+        --bq-success-light: #a1e4cb;
+        --bq-success:       #05b981;
+        --bq-success-dark:  #047857;
+        --bq-danger-light:  #fecaca;
+        --bq-danger:        #ef4444;
+        --bq-danger-dark:   #991b1b;
+        --bq-warning-light: #fef3c7;
+        --bq-warning:       #f59e0b;
+        --bq-warning-dark:  #92400e;
+        --bq-info-light:    #bfdbfe;
+        --bq-info:          #3b82f6;
+        --bq-info-dark:     #1e3a8a;
+        --bq-focus:         #00836e;
+        --bq-white:         #ffffff;
+        --bq-black:         #000000;
+        --bq-neutral-50:    #f9fafb;
+        --bq-neutral-100:   #f3f4f6;
+        --bq-neutral-200:   #e5e7eb;
+        --bq-neutral-300:   #d1d5db;
+        --bq-neutral-400:   #9ca3af;
+        --bq-neutral-500:   #6b7280;
+        --bq-neutral-600:   #4b5563;
+        --bq-neutral-700:   #374151;
+        --bq-neutral-800:   #1f2937;
+        --bq-neutral-900:   #111827;
+        --bq-neutral-950:   #0f172a;
+        --bq-neutral-1000:  #030712;
+      }
 
-    /* -------------------------------------------------------------------------- */
-    /* LIGHT MODE                                                                 */
-    /* -------------------------------------------------------------------------- */
-    [bq-theme="techflow"]:not([bq-mode]),
-    [bq-theme="techflow"][bq-mode="light"],
-    .techflow:not([bq-mode]),
-    .techflow.light {
-      --bq-background--primary:   #ffffff;
-      --bq-background--secondary: #f9fafb;
-      --bq-background--tertiary:  #f3f4f6;
-      --bq-background--alt:       #e5e7eb;
-      --bq-background--inverse:   #111827;
-      --bq-background--brand:     #a8f0e6;
-      --bq-background--overlay:   rgba(0, 0, 0, 0.5);
-      --bq-icon--primary:   #1f2937;
-      --bq-icon--secondary: #6b7280;
-      --bq-icon--inverse:   #f9fafb;
-      --bq-icon--brand:     #00836e;
-      --bq-icon--alt:       #ffffff;
-      --bq-icon--info:      #1d4ed8;
-      --bq-icon--success:   #047857;
-      --bq-icon--warning:   #92400e;
-      --bq-icon--danger:    #b91c1c;
-      --bq-stroke--primary:   #e5e7eb;
-      --bq-stroke--secondary: #d1d5db;
-      --bq-stroke--tertiary:  #9ca3af;
-      --bq-stroke--inverse:   #ffffff;
-      --bq-stroke--brand:     #00836e;
-      --bq-stroke--alt:       #f3f4f6;
-      --bq-stroke--success:   #047857;
-      --bq-stroke--warning:   #92400e;
-      --bq-stroke--danger:    #b91c1c;
-      --bq-text--primary:   #111827;
-      --bq-text--secondary: #6b7280;
-      --bq-text--inverse:   #f9fafb;
-      --bq-text--brand:     #00836e;
-      --bq-text--alt:       #ffffff;
-      --bq-text--info:      #1d4ed8;
-      --bq-text--success:   #047857;
-      --bq-text--warning:   #92400e;
-      --bq-text--danger:    #b91c1c;
-      --bq-ui--primary:     #ffffff;
-      --bq-ui--secondary:   #f3f4f6;
-      --bq-ui--tertiary:    #e5e7eb;
-      --bq-ui--inverse:     #111827;
-      --bq-ui--brand:       #00836e;
-      --bq-ui--brand-alt:   #a8f0e6;
-      --bq-ui--alt:         #f9fafb;
-      --bq-ui--success:     #047857;
-      --bq-ui--success-alt: #a1e4cb;
-      --bq-ui--warning:     #92400e;
-      --bq-ui--warning-alt: #fef3c7;
-      --bq-ui--danger:      #b91c1c;
-      --bq-ui--danger-alt:  #fecaca;
-      --bq-state--hover:    rgba(0, 0, 0, 0.08);
-      --bq-state--active:   rgba(0, 0, 0, 0.12);
-    }
+      /* -------------------------------------------------------------------------- */
+      /* LIGHT MODE                                                                 */
+      /* -------------------------------------------------------------------------- */
+      [bq-theme="techflow"]:not([bq-mode]),
+      [bq-theme="techflow"][bq-mode="light"],
+      .techflow:not([bq-mode]),
+      .techflow.light {
+        --bq-background--primary:   #ffffff;
+        --bq-background--secondary: #f9fafb;
+        --bq-background--tertiary:  #f3f4f6;
+        --bq-background--alt:       #e5e7eb;
+        --bq-background--inverse:   #111827;
+        --bq-background--brand:     #a8f0e6;
+        --bq-background--overlay:   rgba(0, 0, 0, 0.5);
+        --bq-icon--primary:   #1f2937;
+        --bq-icon--secondary: #6b7280;
+        --bq-icon--inverse:   #f9fafb;
+        --bq-icon--brand:     #00836e;
+        --bq-icon--alt:       #ffffff;
+        --bq-icon--info:      #1d4ed8;
+        --bq-icon--success:   #047857;
+        --bq-icon--warning:   #92400e;
+        --bq-icon--danger:    #b91c1c;
+        --bq-stroke--primary:   #e5e7eb;
+        --bq-stroke--secondary: #d1d5db;
+        --bq-stroke--tertiary:  #9ca3af;
+        --bq-stroke--inverse:   #ffffff;
+        --bq-stroke--brand:     #00836e;
+        --bq-stroke--alt:       #f3f4f6;
+        --bq-stroke--success:   #047857;
+        --bq-stroke--warning:   #92400e;
+        --bq-stroke--danger:    #b91c1c;
+        --bq-text--primary:   #111827;
+        --bq-text--secondary: #6b7280;
+        --bq-text--inverse:   #f9fafb;
+        --bq-text--brand:     #00836e;
+        --bq-text--alt:       #ffffff;
+        --bq-text--info:      #1d4ed8;
+        --bq-text--success:   #047857;
+        --bq-text--warning:   #92400e;
+        --bq-text--danger:    #b91c1c;
+        --bq-ui--primary:     #ffffff;
+        --bq-ui--secondary:   #f3f4f6;
+        --bq-ui--tertiary:    #e5e7eb;
+        --bq-ui--inverse:     #111827;
+        --bq-ui--brand:       #00836e;
+        --bq-ui--brand-alt:   #a8f0e6;
+        --bq-ui--alt:         #f9fafb;
+        --bq-ui--success:     #047857;
+        --bq-ui--success-alt: #a1e4cb;
+        --bq-ui--warning:     #92400e;
+        --bq-ui--warning-alt: #fef3c7;
+        --bq-ui--danger:      #b91c1c;
+        --bq-ui--danger-alt:  #fecaca;
+        --bq-state--hover:    rgba(0, 0, 0, 0.08);
+        --bq-state--active:   rgba(0, 0, 0, 0.12);
+      }
 
-    /* -------------------------------------------------------------------------- */
-    /* DARK MODE                                                                  */
-    /* -------------------------------------------------------------------------- */
-    [bq-theme="techflow"][bq-mode="dark"],
-    .techflow.dark {
-      --bq-background--primary:   #030712;
-      --bq-background--secondary: #0f172a;
-      --bq-background--tertiary:  #1f2937;
-      --bq-background--alt:       #374151;
-      --bq-background--inverse:   #f9fafb;
-      --bq-background--brand:     #009b88;
-      --bq-background--overlay:   rgba(0, 0, 0, 0.7);
-      --bq-icon--primary:   #f3f4f6;
-      --bq-icon--secondary: #9ca3af;
-      --bq-icon--inverse:   #1f2937;
-      --bq-icon--brand:     #00d9c4;
-      --bq-icon--alt:       #ffffff;
-      --bq-icon--info:      #60a5fa;
-      --bq-icon--success:   #34d399;
-      --bq-icon--warning:   #fbbf24;
-      --bq-icon--danger:    #f87171;
-      --bq-stroke--primary:   #374151;
-      --bq-stroke--secondary: #4b5563;
-      --bq-stroke--tertiary:  #9ca3af;
-      --bq-stroke--inverse:   #0f172a;
-      --bq-stroke--brand:     #00d9c4;
-      --bq-stroke--alt:       #1f2937;
-      --bq-stroke--success:   #34d399;
-      --bq-stroke--warning:   #fbbf24;
-      --bq-stroke--danger:    #f87171;
-      --bq-text--primary:   #f9fafb;
-      --bq-text--secondary: #9ca3af;
-      --bq-text--inverse:   #1f2937;
-      --bq-text--brand:     #00d9c4;
-      --bq-text--alt:       #ffffff;
-      --bq-text--info:      #60a5fa;
-      --bq-text--success:   #34d399;
-      --bq-text--warning:   #fbbf24;
-      --bq-text--danger:    #f87171;
-      --bq-ui--primary:     #1f2937;
-      --bq-ui--secondary:   #374151;
-      --bq-ui--tertiary:    #4b5563;
-      --bq-ui--inverse:     #f9fafb;
-      --bq-ui--brand:       #00d9c4;
-      --bq-ui--brand-alt:   #009b88;
-      --bq-ui--alt:         #0f172a;
-      --bq-ui--success:     #34d399;
-      --bq-ui--success-alt: #10b981;
-      --bq-ui--warning:     #fbbf24;
-      --bq-ui--warning-alt: #f59e0b;
-      --bq-ui--danger:      #f87171;
-      --bq-ui--danger-alt:  #ef4444;
-      --bq-state--hover:    rgba(255, 255, 255, 0.10);
-      --bq-state--active:   rgba(255, 255, 255, 0.15);
-    }
+      /* -------------------------------------------------------------------------- */
+      /* DARK MODE                                                                  */
+      /* -------------------------------------------------------------------------- */
+      [bq-theme="techflow"][bq-mode="dark"],
+      .techflow.dark {
+        --bq-background--primary:   #030712;
+        --bq-background--secondary: #0f172a;
+        --bq-background--tertiary:  #1f2937;
+        --bq-background--alt:       #374151;
+        --bq-background--inverse:   #f9fafb;
+        --bq-background--brand:     #009b88;
+        --bq-background--overlay:   rgba(0, 0, 0, 0.7);
+        --bq-icon--primary:   #f3f4f6;
+        --bq-icon--secondary: #9ca3af;
+        --bq-icon--inverse:   #1f2937;
+        --bq-icon--brand:     #00d9c4;
+        --bq-icon--alt:       #ffffff;
+        --bq-icon--info:      #60a5fa;
+        --bq-icon--success:   #34d399;
+        --bq-icon--warning:   #fbbf24;
+        --bq-icon--danger:    #f87171;
+        --bq-stroke--primary:   #374151;
+        --bq-stroke--secondary: #4b5563;
+        --bq-stroke--tertiary:  #9ca3af;
+        --bq-stroke--inverse:   #0f172a;
+        --bq-stroke--brand:     #00d9c4;
+        --bq-stroke--alt:       #1f2937;
+        --bq-stroke--success:   #34d399;
+        --bq-stroke--warning:   #fbbf24;
+        --bq-stroke--danger:    #f87171;
+        --bq-text--primary:   #f9fafb;
+        --bq-text--secondary: #9ca3af;
+        --bq-text--inverse:   #1f2937;
+        --bq-text--brand:     #00d9c4;
+        --bq-text--alt:       #ffffff;
+        --bq-text--info:      #60a5fa;
+        --bq-text--success:   #34d399;
+        --bq-text--warning:   #fbbf24;
+        --bq-text--danger:    #f87171;
+        --bq-ui--primary:     #1f2937;
+        --bq-ui--secondary:   #374151;
+        --bq-ui--tertiary:    #4b5563;
+        --bq-ui--inverse:     #f9fafb;
+        --bq-ui--brand:       #00d9c4;
+        --bq-ui--brand-alt:   #009b88;
+        --bq-ui--alt:         #0f172a;
+        --bq-ui--success:     #34d399;
+        --bq-ui--success-alt: #10b981;
+        --bq-ui--warning:     #fbbf24;
+        --bq-ui--warning-alt: #f59e0b;
+        --bq-ui--danger:      #f87171;
+        --bq-ui--danger-alt:  #ef4444;
+        --bq-state--hover:    rgba(255, 255, 255, 0.10);
+        --bq-state--active:   rgba(255, 255, 255, 0.15);
+      }
     </style>
     ```
   </CodeGroup>

--- a/apps/beeq-docs/theming/custom-theme.mdx
+++ b/apps/beeq-docs/theming/custom-theme.mdx
@@ -540,7 +540,7 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
   </script>
 `}>
   <CodeGroup>
-    ```css CSS icon="css" expandable
+    ```css styles.css icon="css" expandable
     /* -------------------------------------------------------------------------- */
     /* BASE THEME VARIABLES                                                       */
     /* -------------------------------------------------------------------------- */
@@ -785,8 +785,9 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
     ```tsx React icon="react" expandable
     import { useState, useEffect } from "react";
     import { BqTabGroup, BqTab, BqIcon, BqButton, BqInput } from "@beeq/react";
+    import "./styles.css";
 
-    // In main.tsx, apply the TechFlow theme (import styles.css separately):
+    // In main.tsx, apply the TechFlow theme:
     // document.documentElement.setAttribute('bq-theme', 'techflow');
 
     export function TechFlowDemo() {
@@ -873,7 +874,7 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
     import { DOCUMENT } from "@angular/common";
     import { BqTabGroup, BqTab, BqIcon, BqButton, BqInput } from "@beeq/angular/standalone";
 
-    // Apply the TechFlow theme in main.ts (import styles.css separately):
+    // Apply the TechFlow theme in main.ts:
     // document.documentElement.setAttribute('bq-theme', 'techflow');
 
     @Component({
@@ -938,6 +939,162 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
           <h1>Settings tab!</h1>
         }
       `,
+      style: `
+            /* -------------------------------------------------------------------------- */
+            /* BASE THEME VARIABLES                                                       */
+            /* -------------------------------------------------------------------------- */
+            [bq-theme="techflow"],
+            .techflow {
+              --bq-font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+              --bq-brand-light: #a8f0e6;
+              --bq-brand:       #00836e;
+              --bq-brand-dark:  #005a4f;
+              --bq-accent-light: #e8d5f2;
+              --bq-accent:       #9d4edd;
+              --bq-accent-dark:  #5a189a;
+              --bq-success-light: #a1e4cb;
+              --bq-success:       #05b981;
+              --bq-success-dark:  #047857;
+              --bq-danger-light:  #fecaca;
+              --bq-danger:        #ef4444;
+              --bq-danger-dark:   #991b1b;
+              --bq-warning-light: #fef3c7;
+              --bq-warning:       #f59e0b;
+              --bq-warning-dark:  #92400e;
+              --bq-info-light:    #bfdbfe;
+              --bq-info:          #3b82f6;
+              --bq-info-dark:     #1e3a8a;
+              --bq-focus:         #00836e;
+              --bq-white:         #ffffff;
+              --bq-black:         #000000;
+              --bq-neutral-50:    #f9fafb;
+              --bq-neutral-100:   #f3f4f6;
+              --bq-neutral-200:   #e5e7eb;
+              --bq-neutral-300:   #d1d5db;
+              --bq-neutral-400:   #9ca3af;
+              --bq-neutral-500:   #6b7280;
+              --bq-neutral-600:   #4b5563;
+              --bq-neutral-700:   #374151;
+              --bq-neutral-800:   #1f2937;
+              --bq-neutral-900:   #111827;
+              --bq-neutral-950:   #0f172a;
+              --bq-neutral-1000:  #030712;
+            }
+
+            /* -------------------------------------------------------------------------- */
+            /* LIGHT MODE                                                                 */
+            /* -------------------------------------------------------------------------- */
+            [bq-theme="techflow"]:not([bq-mode]),
+            [bq-theme="techflow"][bq-mode="light"],
+            .techflow:not([bq-mode]),
+            .techflow.light {
+              --bq-background--primary:   #ffffff;
+              --bq-background--secondary: #f9fafb;
+              --bq-background--tertiary:  #f3f4f6;
+              --bq-background--alt:       #e5e7eb;
+              --bq-background--inverse:   #111827;
+              --bq-background--brand:     #a8f0e6;
+              --bq-background--overlay:   rgba(0, 0, 0, 0.5);
+              --bq-icon--primary:   #1f2937;
+              --bq-icon--secondary: #6b7280;
+              --bq-icon--inverse:   #f9fafb;
+              --bq-icon--brand:     #00836e;
+              --bq-icon--alt:       #ffffff;
+              --bq-icon--info:      #1d4ed8;
+              --bq-icon--success:   #047857;
+              --bq-icon--warning:   #92400e;
+              --bq-icon--danger:    #b91c1c;
+              --bq-stroke--primary:   #e5e7eb;
+              --bq-stroke--secondary: #d1d5db;
+              --bq-stroke--tertiary:  #9ca3af;
+              --bq-stroke--inverse:   #ffffff;
+              --bq-stroke--brand:     #00836e;
+              --bq-stroke--alt:       #f3f4f6;
+              --bq-stroke--success:   #047857;
+              --bq-stroke--warning:   #92400e;
+              --bq-stroke--danger:    #b91c1c;
+              --bq-text--primary:   #111827;
+              --bq-text--secondary: #6b7280;
+              --bq-text--inverse:   #f9fafb;
+              --bq-text--brand:     #00836e;
+              --bq-text--alt:       #ffffff;
+              --bq-text--info:      #1d4ed8;
+              --bq-text--success:   #047857;
+              --bq-text--warning:   #92400e;
+              --bq-text--danger:    #b91c1c;
+              --bq-ui--primary:     #ffffff;
+              --bq-ui--secondary:   #f3f4f6;
+              --bq-ui--tertiary:    #e5e7eb;
+              --bq-ui--inverse:     #111827;
+              --bq-ui--brand:       #00836e;
+              --bq-ui--brand-alt:   #a8f0e6;
+              --bq-ui--alt:         #f9fafb;
+              --bq-ui--success:     #047857;
+              --bq-ui--success-alt: #a1e4cb;
+              --bq-ui--warning:     #92400e;
+              --bq-ui--warning-alt: #fef3c7;
+              --bq-ui--danger:      #b91c1c;
+              --bq-ui--danger-alt:  #fecaca;
+              --bq-state--hover:    rgba(0, 0, 0, 0.08);
+              --bq-state--active:   rgba(0, 0, 0, 0.12);
+            }
+
+            /* -------------------------------------------------------------------------- */
+            /* DARK MODE                                                                  */
+            /* -------------------------------------------------------------------------- */
+            [bq-theme="techflow"][bq-mode="dark"],
+            .techflow.dark {
+              --bq-background--primary:   #030712;
+              --bq-background--secondary: #0f172a;
+              --bq-background--tertiary:  #1f2937;
+              --bq-background--alt:       #374151;
+              --bq-background--inverse:   #f9fafb;
+              --bq-background--brand:     #009b88;
+              --bq-background--overlay:   rgba(0, 0, 0, 0.7);
+              --bq-icon--primary:   #f3f4f6;
+              --bq-icon--secondary: #9ca3af;
+              --bq-icon--inverse:   #1f2937;
+              --bq-icon--brand:     #00d9c4;
+              --bq-icon--alt:       #ffffff;
+              --bq-icon--info:      #60a5fa;
+              --bq-icon--success:   #34d399;
+              --bq-icon--warning:   #fbbf24;
+              --bq-icon--danger:    #f87171;
+              --bq-stroke--primary:   #374151;
+              --bq-stroke--secondary: #4b5563;
+              --bq-stroke--tertiary:  #9ca3af;
+              --bq-stroke--inverse:   #0f172a;
+              --bq-stroke--brand:     #00d9c4;
+              --bq-stroke--alt:       #1f2937;
+              --bq-stroke--success:   #34d399;
+              --bq-stroke--warning:   #fbbf24;
+              --bq-stroke--danger:    #f87171;
+              --bq-text--primary:   #f9fafb;
+              --bq-text--secondary: #9ca3af;
+              --bq-text--inverse:   #1f2937;
+              --bq-text--brand:     #00d9c4;
+              --bq-text--alt:       #ffffff;
+              --bq-text--info:      #60a5fa;
+              --bq-text--success:   #34d399;
+              --bq-text--warning:   #fbbf24;
+              --bq-text--danger:    #f87171;
+              --bq-ui--primary:     #1f2937;
+              --bq-ui--secondary:   #374151;
+              --bq-ui--tertiary:    #4b5563;
+              --bq-ui--inverse:     #f9fafb;
+              --bq-ui--brand:       #00d9c4;
+              --bq-ui--brand-alt:   #009b88;
+              --bq-ui--alt:         #0f172a;
+              --bq-ui--success:     #34d399;
+              --bq-ui--success-alt: #10b981;
+              --bq-ui--warning:     #fbbf24;
+              --bq-ui--warning-alt: #f59e0b;
+              --bq-ui--danger:      #f87171;
+              --bq-ui--danger-alt:  #ef4444;
+              --bq-state--hover:    rgba(255, 255, 255, 0.10);
+              --bq-state--active:   rgba(255, 255, 255, 0.15);
+            }
+      `,
     })
     export class AppComponent {
       private readonly document = inject(DOCUMENT);
@@ -965,7 +1122,7 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
       import { ref, watchEffect } from "vue";
       import { BqTabGroup, BqTab, BqIcon, BqButton, BqInput } from "@beeq/vue";
 
-      // In main.ts, apply the TechFlow theme (import styles.css separately):
+      // In main.ts, apply the TechFlow theme:
       // document.documentElement.setAttribute('bq-theme', 'techflow');
 
       const activeTab = ref("home");
@@ -1036,6 +1193,163 @@ Here is an almost production-ready custom theme called **TechFlow** — a theme 
       </section>
       <h1 v-if="activeTab === 'settings'">Settings tab!</h1>
     </template>
+
+    <style>
+    /* -------------------------------------------------------------------------- */
+    /* BASE THEME VARIABLES                                                       */
+    /* -------------------------------------------------------------------------- */
+    [bq-theme="techflow"],
+    .techflow {
+      --bq-font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      --bq-brand-light: #a8f0e6;
+      --bq-brand:       #00836e;
+      --bq-brand-dark:  #005a4f;
+      --bq-accent-light: #e8d5f2;
+      --bq-accent:       #9d4edd;
+      --bq-accent-dark:  #5a189a;
+      --bq-success-light: #a1e4cb;
+      --bq-success:       #05b981;
+      --bq-success-dark:  #047857;
+      --bq-danger-light:  #fecaca;
+      --bq-danger:        #ef4444;
+      --bq-danger-dark:   #991b1b;
+      --bq-warning-light: #fef3c7;
+      --bq-warning:       #f59e0b;
+      --bq-warning-dark:  #92400e;
+      --bq-info-light:    #bfdbfe;
+      --bq-info:          #3b82f6;
+      --bq-info-dark:     #1e3a8a;
+      --bq-focus:         #00836e;
+      --bq-white:         #ffffff;
+      --bq-black:         #000000;
+      --bq-neutral-50:    #f9fafb;
+      --bq-neutral-100:   #f3f4f6;
+      --bq-neutral-200:   #e5e7eb;
+      --bq-neutral-300:   #d1d5db;
+      --bq-neutral-400:   #9ca3af;
+      --bq-neutral-500:   #6b7280;
+      --bq-neutral-600:   #4b5563;
+      --bq-neutral-700:   #374151;
+      --bq-neutral-800:   #1f2937;
+      --bq-neutral-900:   #111827;
+      --bq-neutral-950:   #0f172a;
+      --bq-neutral-1000:  #030712;
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /* LIGHT MODE                                                                 */
+    /* -------------------------------------------------------------------------- */
+    [bq-theme="techflow"]:not([bq-mode]),
+    [bq-theme="techflow"][bq-mode="light"],
+    .techflow:not([bq-mode]),
+    .techflow.light {
+      --bq-background--primary:   #ffffff;
+      --bq-background--secondary: #f9fafb;
+      --bq-background--tertiary:  #f3f4f6;
+      --bq-background--alt:       #e5e7eb;
+      --bq-background--inverse:   #111827;
+      --bq-background--brand:     #a8f0e6;
+      --bq-background--overlay:   rgba(0, 0, 0, 0.5);
+      --bq-icon--primary:   #1f2937;
+      --bq-icon--secondary: #6b7280;
+      --bq-icon--inverse:   #f9fafb;
+      --bq-icon--brand:     #00836e;
+      --bq-icon--alt:       #ffffff;
+      --bq-icon--info:      #1d4ed8;
+      --bq-icon--success:   #047857;
+      --bq-icon--warning:   #92400e;
+      --bq-icon--danger:    #b91c1c;
+      --bq-stroke--primary:   #e5e7eb;
+      --bq-stroke--secondary: #d1d5db;
+      --bq-stroke--tertiary:  #9ca3af;
+      --bq-stroke--inverse:   #ffffff;
+      --bq-stroke--brand:     #00836e;
+      --bq-stroke--alt:       #f3f4f6;
+      --bq-stroke--success:   #047857;
+      --bq-stroke--warning:   #92400e;
+      --bq-stroke--danger:    #b91c1c;
+      --bq-text--primary:   #111827;
+      --bq-text--secondary: #6b7280;
+      --bq-text--inverse:   #f9fafb;
+      --bq-text--brand:     #00836e;
+      --bq-text--alt:       #ffffff;
+      --bq-text--info:      #1d4ed8;
+      --bq-text--success:   #047857;
+      --bq-text--warning:   #92400e;
+      --bq-text--danger:    #b91c1c;
+      --bq-ui--primary:     #ffffff;
+      --bq-ui--secondary:   #f3f4f6;
+      --bq-ui--tertiary:    #e5e7eb;
+      --bq-ui--inverse:     #111827;
+      --bq-ui--brand:       #00836e;
+      --bq-ui--brand-alt:   #a8f0e6;
+      --bq-ui--alt:         #f9fafb;
+      --bq-ui--success:     #047857;
+      --bq-ui--success-alt: #a1e4cb;
+      --bq-ui--warning:     #92400e;
+      --bq-ui--warning-alt: #fef3c7;
+      --bq-ui--danger:      #b91c1c;
+      --bq-ui--danger-alt:  #fecaca;
+      --bq-state--hover:    rgba(0, 0, 0, 0.08);
+      --bq-state--active:   rgba(0, 0, 0, 0.12);
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /* DARK MODE                                                                  */
+    /* -------------------------------------------------------------------------- */
+    [bq-theme="techflow"][bq-mode="dark"],
+    .techflow.dark {
+      --bq-background--primary:   #030712;
+      --bq-background--secondary: #0f172a;
+      --bq-background--tertiary:  #1f2937;
+      --bq-background--alt:       #374151;
+      --bq-background--inverse:   #f9fafb;
+      --bq-background--brand:     #009b88;
+      --bq-background--overlay:   rgba(0, 0, 0, 0.7);
+      --bq-icon--primary:   #f3f4f6;
+      --bq-icon--secondary: #9ca3af;
+      --bq-icon--inverse:   #1f2937;
+      --bq-icon--brand:     #00d9c4;
+      --bq-icon--alt:       #ffffff;
+      --bq-icon--info:      #60a5fa;
+      --bq-icon--success:   #34d399;
+      --bq-icon--warning:   #fbbf24;
+      --bq-icon--danger:    #f87171;
+      --bq-stroke--primary:   #374151;
+      --bq-stroke--secondary: #4b5563;
+      --bq-stroke--tertiary:  #9ca3af;
+      --bq-stroke--inverse:   #0f172a;
+      --bq-stroke--brand:     #00d9c4;
+      --bq-stroke--alt:       #1f2937;
+      --bq-stroke--success:   #34d399;
+      --bq-stroke--warning:   #fbbf24;
+      --bq-stroke--danger:    #f87171;
+      --bq-text--primary:   #f9fafb;
+      --bq-text--secondary: #9ca3af;
+      --bq-text--inverse:   #1f2937;
+      --bq-text--brand:     #00d9c4;
+      --bq-text--alt:       #ffffff;
+      --bq-text--info:      #60a5fa;
+      --bq-text--success:   #34d399;
+      --bq-text--warning:   #fbbf24;
+      --bq-text--danger:    #f87171;
+      --bq-ui--primary:     #1f2937;
+      --bq-ui--secondary:   #374151;
+      --bq-ui--tertiary:    #4b5563;
+      --bq-ui--inverse:     #f9fafb;
+      --bq-ui--brand:       #00d9c4;
+      --bq-ui--brand-alt:   #009b88;
+      --bq-ui--alt:         #0f172a;
+      --bq-ui--success:     #34d399;
+      --bq-ui--success-alt: #10b981;
+      --bq-ui--warning:     #fbbf24;
+      --bq-ui--warning-alt: #f59e0b;
+      --bq-ui--danger:      #f87171;
+      --bq-ui--danger-alt:  #ef4444;
+      --bq-state--hover:    rgba(255, 255, 255, 0.10);
+      --bq-state--active:   rgba(255, 255, 255, 0.15);
+    }
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>

--- a/apps/beeq-docs/theming/themes-and-modes.mdx
+++ b/apps/beeq-docs/theming/themes-and-modes.mdx
@@ -359,6 +359,7 @@ Here is a working example showing how to read the user's preferred color scheme 
     import { BqIcon, BqSwitch } from "@beeq/angular/standalone";
 
     @Component({
+      selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqSwitch],
       styleUrl: "./styles.css",

--- a/apps/beeq-docs/theming/themes-and-modes.mdx
+++ b/apps/beeq-docs/theming/themes-and-modes.mdx
@@ -209,7 +209,7 @@ Here is a working example showing how to read the user's preferred color scheme 
   </script>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css" expandable
+    ```css styles.css icon="css3" expandable
     @import "@beeq/core/dist/beeq/beeq.css";
 
     .nav-bar {
@@ -377,7 +377,7 @@ Here is a working example showing how to read the user's preferred color scheme 
           <div class="content"></div>
         </main>
       `,
-      style: `
+      styles: [`
             @import "@beeq/core/dist/beeq/beeq.css";
 
             .nav-bar {
@@ -423,7 +423,7 @@ Here is a working example showing how to read the user's preferred color scheme 
               height: 10rem;
               width: 100%;
             }
-      `,
+      `],
     })
     export class AppComponent implements OnInit {
       private readonly document = inject(DOCUMENT);

--- a/apps/beeq-docs/theming/themes-and-modes.mdx
+++ b/apps/beeq-docs/theming/themes-and-modes.mdx
@@ -209,7 +209,7 @@ Here is a working example showing how to read the user's preferred color scheme 
   </script>
 `}>
   <CodeGroup>
-    ```css CSS icon="css" expandable
+    ```css styles.css icon="css" expandable
     @import "@beeq/core/dist/beeq/beeq.css";
 
     .nav-bar {
@@ -362,7 +362,6 @@ Here is a working example showing how to read the user's preferred color scheme 
       selector: "app-root",
       standalone: true,
       imports: [BqIcon, BqSwitch],
-      styleUrl: "./styles.css",
       template: `
         <header class="nav-bar">
           <div class="nav-bar__main">
@@ -377,6 +376,53 @@ Here is a working example showing how to read the user's preferred color scheme 
           <h1>Dashboard</h1>
           <div class="content"></div>
         </main>
+      `,
+      style: `
+            @import "@beeq/core/dist/beeq/beeq.css";
+
+            .nav-bar {
+              display: flex;
+              justify-content: center;
+              background-color: var(--bq-ui--primary);
+              border-bottom: 1px solid var(--bq-stroke--primary);
+            }
+
+            .nav-bar__main {
+              flex: 1;
+              display: flex;
+              align-items: center;
+              flex-direction: column;
+              justify-content: end;
+              gap: var(--bq-spacing-xl);
+              padding: var(--bq-spacing-m);
+              max-width: 1440px;
+
+              @media (min-width: 600px) {
+                flex-direction: row;
+              }
+            }
+
+            .nav-bar__mode {
+              display: flex;
+              align-items: center;
+              gap: var(--bq-spacing-xs);
+              color: var(--bq-text--primary);
+            }
+
+            .main {
+              padding: var(--bq-spacing-m);
+
+              h1 {
+                margin-block-end: var(--bq-spacing-l);
+              }
+            }
+
+            .content {
+              background: var(--bq-ui--alt);
+              border: 2px dashed var(--bq-stroke--primary);
+              height: 10rem;
+              width: 100%;
+            }
       `,
     })
     export class AppComponent implements OnInit {
@@ -436,6 +482,54 @@ Here is a working example showing how to read the user's preferred color scheme 
         <div class="content" />
       </main>
     </template>
+
+    <style>
+    @import "@beeq/core/dist/beeq/beeq.css";
+
+    .nav-bar {
+      display: flex;
+      justify-content: center;
+      background-color: var(--bq-ui--primary);
+      border-bottom: 1px solid var(--bq-stroke--primary);
+    }
+
+    .nav-bar__main {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      flex-direction: column;
+      justify-content: end;
+      gap: var(--bq-spacing-xl);
+      padding: var(--bq-spacing-m);
+      max-width: 1440px;
+
+      @media (min-width: 600px) {
+        flex-direction: row;
+      }
+    }
+
+    .nav-bar__mode {
+      display: flex;
+      align-items: center;
+      gap: var(--bq-spacing-xs);
+      color: var(--bq-text--primary);
+    }
+
+    .main {
+      padding: var(--bq-spacing-m);
+
+      h1 {
+        margin-block-end: var(--bq-spacing-l);
+      }
+    }
+
+    .content {
+      background: var(--bq-ui--alt);
+      border: 2px dashed var(--bq-stroke--primary);
+      height: 10rem;
+      width: 100%;
+    }
+    </style>
     ```
   </CodeGroup>
 </CodeLivePreview>

--- a/apps/beeq-docs/theming/themes-and-modes.mdx
+++ b/apps/beeq-docs/theming/themes-and-modes.mdx
@@ -209,9 +209,7 @@ Here is a working example showing how to read the user's preferred color scheme 
   </script>
 `}>
   <CodeGroup>
-    ```css styles.css icon="css3" expandable
-    @import "@beeq/core/dist/beeq/beeq.css";
-
+    ```css styles.css icon="css" expandable
     .nav-bar {
       display: flex;
       justify-content: center;
@@ -378,51 +376,49 @@ Here is a working example showing how to read the user's preferred color scheme 
         </main>
       `,
       styles: [`
-            @import "@beeq/core/dist/beeq/beeq.css";
+        .nav-bar {
+          display: flex;
+          justify-content: center;
+          background-color: var(--bq-ui--primary);
+          border-bottom: 1px solid var(--bq-stroke--primary);
+        }
 
-            .nav-bar {
-              display: flex;
-              justify-content: center;
-              background-color: var(--bq-ui--primary);
-              border-bottom: 1px solid var(--bq-stroke--primary);
-            }
+        .nav-bar__main {
+          flex: 1;
+          display: flex;
+          align-items: center;
+          flex-direction: column;
+          justify-content: end;
+          gap: var(--bq-spacing-xl);
+          padding: var(--bq-spacing-m);
+          max-width: 1440px;
 
-            .nav-bar__main {
-              flex: 1;
-              display: flex;
-              align-items: center;
-              flex-direction: column;
-              justify-content: end;
-              gap: var(--bq-spacing-xl);
-              padding: var(--bq-spacing-m);
-              max-width: 1440px;
+          @media (min-width: 600px) {
+            flex-direction: row;
+          }
+        }
 
-              @media (min-width: 600px) {
-                flex-direction: row;
-              }
-            }
+        .nav-bar__mode {
+          display: flex;
+          align-items: center;
+          gap: var(--bq-spacing-xs);
+          color: var(--bq-text--primary);
+        }
 
-            .nav-bar__mode {
-              display: flex;
-              align-items: center;
-              gap: var(--bq-spacing-xs);
-              color: var(--bq-text--primary);
-            }
+        .main {
+          padding: var(--bq-spacing-m);
 
-            .main {
-              padding: var(--bq-spacing-m);
+          h1 {
+            margin-block-end: var(--bq-spacing-l);
+          }
+        }
 
-              h1 {
-                margin-block-end: var(--bq-spacing-l);
-              }
-            }
-
-            .content {
-              background: var(--bq-ui--alt);
-              border: 2px dashed var(--bq-stroke--primary);
-              height: 10rem;
-              width: 100%;
-            }
+        .content {
+          background: var(--bq-ui--alt);
+          border: 2px dashed var(--bq-stroke--primary);
+          height: 10rem;
+          width: 100%;
+        }
       `],
     })
     export class AppComponent implements OnInit {
@@ -484,51 +480,49 @@ Here is a working example showing how to read the user's preferred color scheme 
     </template>
 
     <style>
-    @import "@beeq/core/dist/beeq/beeq.css";
-
-    .nav-bar {
-      display: flex;
-      justify-content: center;
-      background-color: var(--bq-ui--primary);
-      border-bottom: 1px solid var(--bq-stroke--primary);
-    }
-
-    .nav-bar__main {
-      flex: 1;
-      display: flex;
-      align-items: center;
-      flex-direction: column;
-      justify-content: end;
-      gap: var(--bq-spacing-xl);
-      padding: var(--bq-spacing-m);
-      max-width: 1440px;
-
-      @media (min-width: 600px) {
-        flex-direction: row;
+      .nav-bar {
+        display: flex;
+        justify-content: center;
+        background-color: var(--bq-ui--primary);
+        border-bottom: 1px solid var(--bq-stroke--primary);
       }
-    }
 
-    .nav-bar__mode {
-      display: flex;
-      align-items: center;
-      gap: var(--bq-spacing-xs);
-      color: var(--bq-text--primary);
-    }
+      .nav-bar__main {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        flex-direction: column;
+        justify-content: end;
+        gap: var(--bq-spacing-xl);
+        padding: var(--bq-spacing-m);
+        max-width: 1440px;
 
-    .main {
-      padding: var(--bq-spacing-m);
-
-      h1 {
-        margin-block-end: var(--bq-spacing-l);
+        @media (min-width: 600px) {
+          flex-direction: row;
+        }
       }
-    }
 
-    .content {
-      background: var(--bq-ui--alt);
-      border: 2px dashed var(--bq-stroke--primary);
-      height: 10rem;
-      width: 100%;
-    }
+      .nav-bar__mode {
+        display: flex;
+        align-items: center;
+        gap: var(--bq-spacing-xs);
+        color: var(--bq-text--primary);
+      }
+
+      .main {
+        padding: var(--bq-spacing-m);
+
+        h1 {
+          margin-block-end: var(--bq-spacing-l);
+        }
+      }
+
+      .content {
+        background: var(--bq-ui--alt);
+        border: 2px dashed var(--bq-stroke--primary);
+        height: 10rem;
+        width: 100%;
+      }
     </style>
     ```
   </CodeGroup>


### PR DESCRIPTION
## Description

This PR updates a broad batch of Mintlify component and theming documentation pages, aligning them with the documentation structure and framework example conventions established by the newer migrations.

Included in this PR:
- migrate `Accordion` Angular examples to standalone components
- migrate `Alert` Angular examples to standalone components
- migrate `Avatar` Angular examples to standalone components
- migrate `Badge` Angular examples to standalone components
- migrate `Breadcrumb` Angular examples to standalone components
- migrate `Button` Angular examples to standalone components
- migrate `Card` Angular examples to standalone components
- migrate `Checkbox` Angular examples to the full standalone component pattern
- migrate `Date Picker` Angular examples to the full standalone component pattern
- migrate `Dialog` Angular examples to the full standalone component pattern
- migrate `Divider` Angular examples to standalone components
- migrate `Dropdown` Angular examples to standalone components
- migrate `Empty State` Angular examples to standalone components
- migrate `Icon` Angular examples to standalone components
- migrate `Input` Angular examples to the full standalone component pattern
- migrate `Notification` Angular examples to the full standalone component pattern
- migrate `Page Title` Angular examples to standalone components
- migrate `Progress` Angular examples to the full standalone component pattern
- migrate `Radio` Angular examples to the full standalone component pattern
- migrate `Select` Angular examples to the full standalone component pattern
- migrate `Spinner` Angular examples to the full standalone component pattern
- migrate `Status` Angular examples to standalone components
- migrate `Table` Angular examples to standalone components
- migrate `Tag` Angular examples to standalone components
- migrate `Toast` Angular examples to the full standalone component pattern
- migrate `Tooltip` Angular examples to the full standalone component pattern
- migrate theming Angular examples to the full standalone component pattern
- normalize `CodeLivePreview` CSS tabs to `styles.css`
- keep React examples using `import "./styles.css";`
- move Angular and Vue example styles inline when a CSS tab is present
- align `Tooltip` docs with Mintlify `CodeLivePreview` / `CodeGroup` structure
- align preview script usage with `previewRoot` in component docs
- normalize anatomy/image structure for `Button` and `Card` docs

## Documentation

All changes are documentation-only. No component source code was modified.

- `apps/beeq-docs/components/accordion.mdx`
- `apps/beeq-docs/components/alert.mdx`
- `apps/beeq-docs/components/avatar.mdx`
- `apps/beeq-docs/components/badge.mdx`
- `apps/beeq-docs/components/breadcrumb.mdx`
- `apps/beeq-docs/components/button.mdx`
- `apps/beeq-docs/components/card.mdx`
- `apps/beeq-docs/components/checkbox.mdx`
- `apps/beeq-docs/components/date-picker.mdx`
- `apps/beeq-docs/components/dialog.mdx`
- `apps/beeq-docs/components/divider.mdx`
- `apps/beeq-docs/components/dropdown.mdx`
- `apps/beeq-docs/components/empty-state.mdx`
- `apps/beeq-docs/components/icon.mdx`
- `apps/beeq-docs/components/input.mdx`
- `apps/beeq-docs/components/notification.mdx`
- `apps/beeq-docs/components/page-title.mdx`
- `apps/beeq-docs/components/progress.mdx`
- `apps/beeq-docs/components/radio.mdx`
- `apps/beeq-docs/components/select.mdx`
- `apps/beeq-docs/components/spinner.mdx`
- `apps/beeq-docs/components/status.mdx`
- `apps/beeq-docs/components/table.mdx`
- `apps/beeq-docs/components/tag.mdx`
- `apps/beeq-docs/components/toast.mdx`
- `apps/beeq-docs/components/tooltip.mdx`
- `apps/beeq-docs/theming/component-css-variables.mdx`
- `apps/beeq-docs/theming/custom-theme.mdx`
- `apps/beeq-docs/theming/themes-and-modes.mdx`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [ ] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes

- ❌ Dedicated light/dark SVG variants are still missing for some updated anatomy/state sections, especially `Button`, and a dedicated anatomy asset is still missing for `Card`. The MDX structure has been aligned, but those assets still need follow-up replacement when delivered.