### PR TITLE
fix(Notification): wrap close icon slot content in flex container

### DIFF
--- a/packages/beeq/src/components/notification/bq-notification.tsx
+++ b/packages/beeq/src/components/notification/bq-notification.tsx
@@ -344,7 +344,7 @@ export class BqNotification {
             <bq-button
               appearance="text"
               border="s"
-              class="absolute inset-ie-m [&::part(button)]:p-1"
+              class="absolute inset-ie-m [&::part(button)]:p-0"
               label="Close"
               onBqClick={() => this.hide()}
               onlyIcon

--- a/packages/beeq/src/components/notification/bq-notification.tsx
+++ b/packages/beeq/src/components/notification/bq-notification.tsx
@@ -351,11 +351,9 @@ export class BqNotification {
               part="btn-close"
               size="small"
             >
-              <div class="flex">
-                <slot name="btn-close">
-                  <bq-icon aria-hidden="true" name="x" />
-                </slot>
-              </div>
+              <slot class="flex" name="btn-close">
+                <bq-icon aria-hidden="true" name="x" />
+              </slot>
             </bq-button>
           )}
           {/* ICON */}

--- a/packages/beeq/src/components/notification/bq-notification.tsx
+++ b/packages/beeq/src/components/notification/bq-notification.tsx
@@ -344,7 +344,7 @@ export class BqNotification {
             <bq-button
               appearance="text"
               border="s"
-              class="absolute inset-ie-m [&::part(button)]:p-0"
+              class="absolute inset-ie-m [&::part(button)]:p-1"
               label="Close"
               onBqClick={() => this.hide()}
               onlyIcon

--- a/packages/beeq/src/components/notification/bq-notification.tsx
+++ b/packages/beeq/src/components/notification/bq-notification.tsx
@@ -351,9 +351,11 @@ export class BqNotification {
               part="btn-close"
               size="small"
             >
-              <slot name="btn-close">
-                <bq-icon aria-hidden="true" name="x" />
-              </slot>
+              <div class="flex">
+                <slot name="btn-close">
+                  <bq-icon aria-hidden="true" name="x" />
+                </slot>
+              </div>
             </bq-button>
           )}
           {/* ICON */}


### PR DESCRIPTION
## Description
Adjusts the Notification close button content layout by wrapping the `btn-close` slot content in a `div.flex` container.

This change updates `packages/beeq/src/components/notification/bq-notification.tsx` so the default close icon and slotted close content are rendered inside a flex wrapper, improving their visual alignment inside the close button while preserving the existing behavior.

## Related Issue
Fixes #1668

## Documentation
No documentation changes were required for this update.

## Screenshots (if applicable)
Please add before/after screenshots for the Notification close button in Storybook.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
This change is limited to the Notification close button presentation and does not change the component API or close interaction behavior.