### PR TITLE
fix(Button): remove forced pointer cursor from host element

### DIFF
--- a/packages/beeq/src/components/button/scss/bq-button.scss
+++ b/packages/beeq/src/components/button/scss/bq-button.scss
@@ -25,7 +25,7 @@
 }
 
 :host {
-  @apply is-auto relative inline-block cursor-pointer rounded-[--bq-button--border-radius];
+  @apply is-auto relative inline-block rounded-[--bq-button--border-radius];
 }
 
 :host([block]),


### PR DESCRIPTION
## Description
Removes the forced `cursor-pointer` style from the `bq-button` host element.

This PR updates `packages/beeq/src/components/button/scss/bq-button.scss` so the `:host` selector no longer applies `cursor-pointer`. This allows the cursor behavior to be driven by the actual interactive element and inherited styles instead of being forced at the host level, improving consistency across button states and usages.

## Related Issue
Fixes #1689

## Documentation
No documentation changes were required for this update.

## Screenshots (if applicable)
Please add before/after screenshots if the cursor behavior was demonstrated visually.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
This change is limited to button cursor styling and does not modify the component API or interaction behavior.