### PR TITLE
fix(notification): keep close button padding

### DIFF
--- a/packages/beeq/src/components/notification/__tests__/bq-notification.e2e.tsx
+++ b/packages/beeq/src/components/notification/__tests__/bq-notification.e2e.tsx
@@ -106,6 +106,14 @@ describe('bq-notification', () => {
     expect(closeBtn).not.toBeNull();
   });
 
+  it('should keep the default close button padding', async () => {
+    const { root } = await render(<bq-notification open>Notification title</bq-notification>);
+
+    const closeBtn = root.shadowRoot?.querySelector('[part="btn-close"]');
+    expect(closeBtn).not.toBeNull();
+    expect(closeBtn).not.toHaveClass('[&::part(button)]:p-0');
+  });
+
   it('should hide the close button when `disable-close` is set', async () => {
     const { root } = await render(
       <bq-notification open disable-close>

--- a/packages/beeq/src/components/notification/bq-notification.tsx
+++ b/packages/beeq/src/components/notification/bq-notification.tsx
@@ -344,7 +344,7 @@ export class BqNotification {
             <bq-button
               appearance="text"
               border="s"
-              class="absolute inset-ie-m [&::part(button)]:p-0"
+              class="absolute inset-ie-m"
               label="Close"
               onBqClick={() => this.hide()}
               onlyIcon


### PR DESCRIPTION
## Summary

- preserves the notification close button padding
- adds an e2e assertion to guard the close button spacing

Closes #1668.

## Test plan

- `git diff --check`