### PR TITLE
fix(Button): keep ghost button height consistent and prevent text selection

### DIFF
--- a/packages/beeq/src/components/button/__tests__/bq-button.e2e.tsx
+++ b/packages/beeq/src/components/button/__tests__/bq-button.e2e.tsx
@@ -315,8 +315,42 @@ describe('bq-button', () => {
     const mediumStyle = computedStyle('bq-button[size="medium"] >>> [part="button"]', styleProps);
     const largeStyle = computedStyle('bq-button[size="large"] >>> [part="button"]', styleProps);
 
-    expect(smallStyle).toEqual({ height: '32px', padding: '4px 8px' });
-    expect(mediumStyle).toEqual({ height: '48px', padding: '12px 16px' });
-    expect(largeStyle).toEqual({ height: '56px', padding: '16px 24px' });
+    expect(smallStyle).toEqual({ height: '32px', padding: '2px 8px' });
+    expect(mediumStyle).toEqual({ height: '48px', padding: '10px 16px' });
+    expect(largeStyle).toEqual({ height: '56px', padding: '14px 24px' });
+  });
+
+  it('ghost buttons should be the same height as their non-ghost counterparts', async () => {
+    const { root } = await render(
+      <div>
+        <bq-button size="small">Button</bq-button>
+        <bq-button size="small" appearance="primary" variant="ghost">
+          Button
+        </bq-button>
+        <bq-button size="medium">Button</bq-button>
+        <bq-button size="medium" appearance="primary" variant="ghost">
+          Button
+        </bq-button>
+        <bq-button size="large">Button</bq-button>
+        <bq-button size="large" appearance="primary" variant="ghost">
+          Button
+        </bq-button>
+      </div>,
+    );
+
+    await waitForStable(root);
+
+    const styleProps = ['height'] as const;
+
+    const smallDefault = computedStyle('bq-button[size="small"]:not([variant]) >>> [part="button"]', styleProps);
+    const smallGhost = computedStyle('bq-button[size="small"][variant="ghost"] >>> [part="button"]', styleProps);
+    const mediumDefault = computedStyle('bq-button[size="medium"]:not([variant]) >>> [part="button"]', styleProps);
+    const mediumGhost = computedStyle('bq-button[size="medium"][variant="ghost"] >>> [part="button"]', styleProps);
+    const largeDefault = computedStyle('bq-button[size="large"]:not([variant]) >>> [part="button"]', styleProps);
+    const largeGhost = computedStyle('bq-button[size="large"][variant="ghost"] >>> [part="button"]', styleProps);
+
+    expect(smallGhost.height).toBe(smallDefault.height);
+    expect(mediumGhost.height).toBe(mediumDefault.height);
+    expect(largeGhost.height).toBe(largeDefault.height);
   });
 });

--- a/packages/beeq/src/components/button/__tests__/bq-button.e2e.tsx
+++ b/packages/beeq/src/components/button/__tests__/bq-button.e2e.tsx
@@ -342,11 +342,11 @@ describe('bq-button', () => {
 
     const styleProps = ['height'] as const;
 
-    const smallDefault = computedStyle('bq-button[size="small"]:not([variant]) >>> [part="button"]', styleProps);
+    const smallDefault = computedStyle('bq-button[size="small"][variant="standard"] >>> [part="button"]', styleProps);
     const smallGhost = computedStyle('bq-button[size="small"][variant="ghost"] >>> [part="button"]', styleProps);
-    const mediumDefault = computedStyle('bq-button[size="medium"]:not([variant]) >>> [part="button"]', styleProps);
+    const mediumDefault = computedStyle('bq-button[size="medium"][variant="standard"] >>> [part="button"]', styleProps);
     const mediumGhost = computedStyle('bq-button[size="medium"][variant="ghost"] >>> [part="button"]', styleProps);
-    const largeDefault = computedStyle('bq-button[size="large"]:not([variant]) >>> [part="button"]', styleProps);
+    const largeDefault = computedStyle('bq-button[size="large"][variant="standard"] >>> [part="button"]', styleProps);
     const largeGhost = computedStyle('bq-button[size="large"][variant="ghost"] >>> [part="button"]', styleProps);
 
     expect(smallGhost.height).toBe(smallDefault.height);

--- a/packages/beeq/src/components/button/scss/bq-button.scss
+++ b/packages/beeq/src/components/button/scss/bq-button.scss
@@ -10,6 +10,8 @@
     @apply box-border flex cursor-[inherit] items-center justify-center font-medium leading-regular;
     @apply rounded-[--bq-button--border-radius] border-[length:--bq-button--border-width] border-[color:--bq-button--border-color];
     @apply transition-[background-color,border-color,color] duration-300 ease-in-out;
+    // Prevent text selection on click
+    @apply select-none;
     // `DISABLED` state
     @apply disabled:cursor-not-allowed disabled:opacity-60;
     // `FOCUS` state
@@ -46,7 +48,7 @@
 }
 
 .bq-button--primary.ghost {
-  @apply border-m border-solid border-brand bg-transparent text-brand;
+  @apply [--bq-button--border-color:var(--bq-stroke--brand)] bg-transparent text-brand;
   // Primary `HOVER` state
   @apply hover:enabled:bg-hover-ui-primary;
   // Primary `ACTIVE` state
@@ -70,7 +72,7 @@
 }
 
 .bq-button--secondary.ghost {
-  @apply border-m border-solid border-tertiary bg-transparent text-primary;
+  @apply [--bq-button--border-color:var(--bq-stroke--tertiary)] bg-transparent text-primary;
   // Secondary `HOVER` state
   @apply hover:enabled:bg-hover-ui-secondary;
   // Secondary `ACTIVE` state

--- a/packages/beeq/src/components/button/scss/bq-button.scss
+++ b/packages/beeq/src/components/button/scss/bq-button.scss
@@ -81,7 +81,7 @@
 }
 
 .bq-button--link {
-  @apply bg-transparent text-brand no-underline;
+  @apply cursor-pointer bg-transparent text-brand no-underline;
   // Primary `HOVER` state
   @apply [&:not(.disabled)]:hover:bg-hover-ui-primary;
   // Primary `ACTIVE` state

--- a/packages/beeq/src/components/button/scss/bq-button.scss
+++ b/packages/beeq/src/components/button/scss/bq-button.scss
@@ -16,6 +16,7 @@
     @apply disabled:cursor-not-allowed disabled:opacity-60;
     // `FOCUS` state
     @apply focus-visible:focus;
+    @apply border-solid;
     // Internal workaround to allow overriding icon color via CSS variables from slotted bq-buttons
     // @see: packages/beeq/src/components/side-menu/scss/bq-side-menu.scss
     @apply [&_::slotted(bq-icon)]:[--bq-icon--color:_var(--bq-button--icon-color,_currentColor)];

--- a/packages/beeq/src/components/button/scss/bq-button.scss
+++ b/packages/beeq/src/components/button/scss/bq-button.scss
@@ -8,7 +8,7 @@
   // Common button base style
   .bq-button {
     @apply box-border flex cursor-[inherit] items-center justify-center font-medium leading-regular;
-    @apply rounded-[--bq-button--border-radius] border-[length:--bq-button--border-width] border-[color:--bq-button--border-color];
+    @apply rounded-[--bq-button--border-radius] border-solid border-[length:--bq-button--border-width] border-[color:--bq-button--border-color];
     @apply transition-[background-color,border-color,color] duration-300 ease-in-out;
     // Prevent text selection on click
     @apply select-none;
@@ -16,7 +16,6 @@
     @apply disabled:cursor-not-allowed disabled:opacity-60;
     // `FOCUS` state
     @apply focus-visible:focus;
-    @apply border-solid;
     // Internal workaround to allow overriding icon color via CSS variables from slotted bq-buttons
     // @see: packages/beeq/src/components/side-menu/scss/bq-side-menu.scss
     @apply [&_::slotted(bq-icon)]:[--bq-icon--color:_var(--bq-button--icon-color,_currentColor)];

--- a/packages/beeq/src/components/button/scss/bq-button.variables.scss
+++ b/packages/beeq/src/components/button/scss/bq-button.variables.scss
@@ -24,14 +24,14 @@
   --bq-button--border-width: theme(borderWidth.m);
 
   --bq-button--small-paddingX: theme(spacing.xs);
-  --bq-button--small-paddingY: calc(theme(spacing.xs2) - theme(borderWidth.m));
+  --bq-button--small-paddingY: calc(theme(spacing.xs2) - var(--bq-button--border-width));
   --bq-button--small-font-size: theme(fontSize.m);
 
   --bq-button--medium-paddingX: theme(spacing.m);
-  --bq-button--medium-paddingY: calc(theme(spacing.s) - theme(borderWidth.m));
+  --bq-button--medium-paddingY: calc(theme(spacing.s) - var(--bq-button--border-width));
   --bq-button--medium-font-size: theme(fontSize.m);
 
   --bq-button--large-paddingX: theme(spacing.l);
-  --bq-button--large-paddingY: calc(theme(spacing.m) - theme(borderWidth.m));
+  --bq-button--large-paddingY: calc(theme(spacing.m) - var(--bq-button--border-width));
   --bq-button--large-font-size: theme(fontSize.m);
 }

--- a/packages/beeq/src/components/button/scss/bq-button.variables.scss
+++ b/packages/beeq/src/components/button/scss/bq-button.variables.scss
@@ -21,17 +21,17 @@
   --bq-button--border-color: theme(borderColor.transparent);
   --bq-button--border-radius: theme(borderRadius.m);
   --bq-button--border-style: solid;
-  --bq-button--border-width: theme(borderWidth.0);
+  --bq-button--border-width: theme(borderWidth.m);
 
   --bq-button--small-paddingX: theme(spacing.xs);
-  --bq-button--small-paddingY: theme(spacing.xs2);
+  --bq-button--small-paddingY: calc(theme(spacing.xs2) - theme(borderWidth.m));
   --bq-button--small-font-size: theme(fontSize.m);
 
   --bq-button--medium-paddingX: theme(spacing.m);
-  --bq-button--medium-paddingY: theme(spacing.s);
+  --bq-button--medium-paddingY: calc(theme(spacing.s) - theme(borderWidth.m));
   --bq-button--medium-font-size: theme(fontSize.m);
 
   --bq-button--large-paddingX: theme(spacing.l);
-  --bq-button--large-paddingY: theme(spacing.m);
+  --bq-button--large-paddingY: calc(theme(spacing.m) - theme(borderWidth.m));
   --bq-button--large-font-size: theme(fontSize.m);
 }


### PR DESCRIPTION
## Description
Keeps `bq-button` ghost variants visually aligned with their non-ghost counterparts by preserving the same final height across sizes, without hardcoding button heights.

This PR updates `packages/beeq/src/components/button/scss/bq-button.variables.scss` and `packages/beeq/src/components/button/scss/bq-button.scss` so button sizing accounts for border width through padding calculations, while ghost variants only override the border color instead of redefining border size. This ensures that default and ghost buttons can sit side by side without visible height differences.

It also adds `select-none` to `.bq-button` inside the shadow DOM so the button label does not become selectable and the interaction feels like a proper button after removing the host-level cursor rule.

Additionally, `packages/beeq/src/components/button/__tests__/bq-button.e2e.tsx` has been updated to validate the adjusted padding values and to verify that ghost buttons match the height of their non-ghost equivalents.

## Related Issue
Fixes https://github.com/Endava/BEEQ/issues/1693

## Documentation
No documentation changes were required for this update.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [ ] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
This change is limited to button styling and interaction polish. It does not modify the component API, but it does ensure more consistent visual alignment and button behavior across variants.