### PR TITLE
fix(Sonar): resolve maintainability warnings in utilities, tests, and config

### DIFF
--- a/packages/beeq/src/components/dialog/__tests__/bq-dialog.e2e.tsx
+++ b/packages/beeq/src/components/dialog/__tests__/bq-dialog.e2e.tsx
@@ -141,17 +141,7 @@ describe('bq-dialog', () => {
     await waitForStable(root);
 
     const panel = getDialogPanel(dialog);
-    vi.spyOn(panel, 'getBoundingClientRect').mockReturnValue({
-      top: 0,
-      right: 100,
-      bottom: 100,
-      left: 0,
-      width: 100,
-      height: 100,
-      x: 0,
-      y: 0,
-      toJSON: () => ({}),
-    } as DOMRect);
+    vi.spyOn(panel, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 100, 100));
 
     window.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0, clientX: 200, clientY: 200 }));
     await waitForChanges();

--- a/packages/beeq/src/components/drawer/__tests__/bq-drawer.e2e.tsx
+++ b/packages/beeq/src/components/drawer/__tests__/bq-drawer.e2e.tsx
@@ -212,17 +212,7 @@ describe('bq-drawer', () => {
     const drawer = root as HTMLBqDrawerElement;
 
     const panel = getDrawerPanel(drawer);
-    vi.spyOn(panel, 'getBoundingClientRect').mockReturnValue({
-      top: 0,
-      right: 100,
-      bottom: 100,
-      left: 0,
-      width: 100,
-      height: 100,
-      x: 0,
-      y: 0,
-      toJSON: () => ({}),
-    } as DOMRect);
+    vi.spyOn(panel, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 100, 100));
 
     window.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0, clientX: 200, clientY: 50 }));
     await waitForChanges();

--- a/packages/beeq/src/components/icon/helper/request.ts
+++ b/packages/beeq/src/components/icon/helper/request.ts
@@ -36,7 +36,7 @@ const sanitizeSvgElement = (svg: SVGElement): void => {
  * @returns True if the element is valid, false otherwise
  */
 const validateElement = (element: Element): boolean => {
-  if (!element || element.nodeType !== Node.ELEMENT_NODE) return false;
+  if (element?.nodeType !== Node.ELEMENT_NODE) return false;
   if (element.nodeName.toLowerCase() === 'script') return false;
 
   // Check for malicious attributes using modern array methods

--- a/packages/beeq/src/global/scripts/zeroheight-svg-loader.js
+++ b/packages/beeq/src/global/scripts/zeroheight-svg-loader.js
@@ -16,7 +16,7 @@ const proxyFetch = {
   },
 };
 
-if (!window.proxied) {
-  window.proxied = true;
-  window.fetch = new Proxy(fetch, proxyFetch);
+if (!globalThis.proxied) {
+  globalThis.proxied = true;
+  globalThis.fetch = new Proxy(fetch, proxyFetch);
 }

--- a/packages/beeq/src/shared/utils/props.ts
+++ b/packages/beeq/src/shared/utils/props.ts
@@ -16,19 +16,14 @@ export const validatePropValue = <T extends E[keyof E], E extends Element>(
   element: E,
   propertyName: TValidProperty<E, T>,
 ): void => {
-  const propertyValue = element[propertyName as string];
-  const propertyLabel =
-    typeof propertyName === 'string'
-      ? propertyName
-      : typeof propertyName === 'number'
-        ? propertyName.toString()
-        : (JSON.stringify(propertyName) ?? 'unknown');
+  const propertyKey = propertyName as string;
+  const propertyValue = element[propertyKey];
   // Early return if the property value is one of the accepted values
   if (ACCEPTED_VALUES.includes(propertyValue)) return;
   // Override property with fallback value
-  element[propertyName as string] = fallbackValue;
+  element[propertyKey] = fallbackValue;
   // Notify developer in the browser console
   console.warn(
-    `[${element.tagName.toUpperCase()}] Please notice that "${propertyLabel}" should be one of ${ACCEPTED_VALUES.join('|')}`,
+    `[${element.tagName.toUpperCase()}] Please notice that "${propertyKey}" should be one of ${ACCEPTED_VALUES.join('|')}`,
   );
 };

--- a/packages/beeq/src/shared/utils/props.ts
+++ b/packages/beeq/src/shared/utils/props.ts
@@ -1,5 +1,5 @@
 export type TExtractProp<T> = T[keyof T] extends infer U ? U : never;
-export type TValidProperty<E, T> = Extract<TExtractProp<{ [K in keyof E]: E[K] extends T ? K : never }>, string>;
+export type TValidProperty<E, T> = TExtractProp<{ [K in keyof E]: E[K] extends T ? K : never }>;
 
 /**
  * Validate the element property value, if is one of the accepted values
@@ -16,13 +16,19 @@ export const validatePropValue = <T extends E[keyof E], E extends Element>(
   element: E,
   propertyName: TValidProperty<E, T>,
 ): void => {
-  const propertyValue = element[propertyName];
+  const propertyValue = element[propertyName as string];
+  const propertyLabel =
+    typeof propertyName === 'string'
+      ? propertyName
+      : typeof propertyName === 'number'
+        ? propertyName.toString()
+        : (JSON.stringify(propertyName) ?? 'unknown');
   // Early return if the property value is one of the accepted values
   if (ACCEPTED_VALUES.includes(propertyValue)) return;
   // Override property with fallback value
-  element[propertyName] = fallbackValue;
+  element[propertyName as string] = fallbackValue;
   // Notify developer in the browser console
   console.warn(
-    `[${element.tagName.toUpperCase()}] Please notice that "${propertyName}" should be one of ${ACCEPTED_VALUES.join('|')}`,
+    `[${element.tagName.toUpperCase()}] Please notice that "${propertyLabel}" should be one of ${ACCEPTED_VALUES.join('|')}`,
   );
 };

--- a/packages/beeq/src/shared/utils/props.ts
+++ b/packages/beeq/src/shared/utils/props.ts
@@ -1,5 +1,5 @@
 export type TExtractProp<T> = T[keyof T] extends infer U ? U : never;
-export type TValidProperty<E, T> = TExtractProp<{ [K in keyof E]: E[K] extends T ? K : never }>;
+export type TValidProperty<E, T> = Extract<TExtractProp<{ [K in keyof E]: E[K] extends T ? K : never }>, string>;
 
 /**
  * Validate the element property value, if is one of the accepted values
@@ -16,15 +16,13 @@ export const validatePropValue = <T extends E[keyof E], E extends Element>(
   element: E,
   propertyName: TValidProperty<E, T>,
 ): void => {
-  const propertyValue = element[propertyName as string];
+  const propertyValue = element[propertyName];
   // Early return if the property value is one of the accepted values
   if (ACCEPTED_VALUES.includes(propertyValue)) return;
   // Override property with fallback value
-  element[propertyName as string] = fallbackValue;
+  element[propertyName] = fallbackValue;
   // Notify developer in the browser console
   console.warn(
-    `[${element.tagName.toUpperCase()}] Please notice that "${String(
-      propertyName,
-    )}" should be one of ${ACCEPTED_VALUES.join('|')}`,
+    `[${element.tagName.toUpperCase()}] Please notice that "${propertyName}" should be one of ${ACCEPTED_VALUES.join('|')}`,
   );
 };

--- a/packages/beeq/src/shared/utils/transition.ts
+++ b/packages/beeq/src/shared/utils/transition.ts
@@ -73,7 +73,7 @@ const transition = async (direction: string, element: HTMLElement, animation: st
   // Replace start classes with end classes, then wait for the transition to finish
   removeClasses(element, startClasses);
   addClasses(element, endClasses);
-  await afterTransition(element as HTMLElementWithAnimations);
+  await afterTransition(element);
 
   // Remove end and genesis classes
   removeClasses(element, endClasses);

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,4 @@
-const { resolve } = require('path');
+const { resolve } = require('node:path');
 
 /** @type {import('postcss-load-config').Config} */
 module.exports = {

--- a/tools/src/generators/plop/plopfile.mjs
+++ b/tools/src/generators/plop/plopfile.mjs
@@ -1,4 +1,4 @@
-export default function (
+export default function plopfile(
   /** @type {import('plop').NodePlopAPI} */
   plop,
 ) {


### PR DESCRIPTION
## Description
Resolves the open SonarCloud medium and low maintainability warnings with small, behavior-preserving updates across config, utilities, tests, and generator code.

This PR updates `postcss.config.js` to use the `node:` protocol for the built-in `path` module, and simplifies the SVG validation guard in `packages/beeq/src/components/icon/helper/request.ts` by switching to optional chaining.

It also cleans up several low-severity warnings by replacing redundant type assertions in the dialog and drawer e2e tests with real `DOMRect` instances, using `globalThis` instead of `window` in `packages/beeq/src/global/scripts/zeroheight-svg-loader.js`, tightening the property key typing in `packages/beeq/src/shared/utils/props.ts`, removing an unnecessary assertion in `packages/beeq/src/shared/utils/transition.ts`, and naming the default export in `tools/src/generators/plop/plopfile.mjs`.

The changes are intentionally narrow and do not alter component APIs or expected runtime behavior. They primarily improve consistency, portability, and code clarity while bringing the flagged files in line with Sonar rules.

## Related Issue
Fixes the open SonarCloud maintainability warnings

## Checklist
- [x] I have read the [[CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md)](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [[CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md)](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [ ] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.