### PR TITLE
fix(Tests): remove redundant DOMRect assertions in dialog and drawer e2e tests

### DIFF
--- a/packages/beeq/src/components/dialog/__tests__/bq-dialog.e2e.tsx
+++ b/packages/beeq/src/components/dialog/__tests__/bq-dialog.e2e.tsx
@@ -141,17 +141,7 @@ describe('bq-dialog', () => {
     await waitForStable(root);
 
     const panel = getDialogPanel(dialog);
-    vi.spyOn(panel, 'getBoundingClientRect').mockReturnValue({
-      top: 0,
-      right: 100,
-      bottom: 100,
-      left: 0,
-      width: 100,
-      height: 100,
-      x: 0,
-      y: 0,
-      toJSON: () => ({}),
-    } as DOMRect);
+    vi.spyOn(panel, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 100, 100));
 
     window.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0, clientX: 200, clientY: 200 }));
     await waitForChanges();

--- a/packages/beeq/src/components/drawer/__tests__/bq-drawer.e2e.tsx
+++ b/packages/beeq/src/components/drawer/__tests__/bq-drawer.e2e.tsx
@@ -212,17 +212,7 @@ describe('bq-drawer', () => {
     const drawer = root as HTMLBqDrawerElement;
 
     const panel = getDrawerPanel(drawer);
-    vi.spyOn(panel, 'getBoundingClientRect').mockReturnValue({
-      top: 0,
-      right: 100,
-      bottom: 100,
-      left: 0,
-      width: 100,
-      height: 100,
-      x: 0,
-      y: 0,
-      toJSON: () => ({}),
-    } as DOMRect);
+    vi.spyOn(panel, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 100, 100));
 
     window.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0, clientX: 200, clientY: 50 }));
     await waitForChanges();


### PR DESCRIPTION
## Description
Removes redundant type assertions flagged by SonarCloud in the dialog and drawer e2e tests.

This PR updates `packages/beeq/src/components/dialog/__tests__/bq-dialog.e2e.tsx` and `packages/beeq/src/components/drawer/__tests__/bq-drawer.e2e.tsx` by replacing manually shaped objects cast as `DOMRect` with real `DOMRect` instances. This keeps the tests clear, preserves the same behavior, and removes unnecessary assertions that the receiver already accepts.

The change is intentionally limited to test code and does not affect component runtime behavior or APIs.

## Related Issue
Fixes the SonarCloud low-severity warnings about unnecessary assertions in:
- `packages/beeq/src/components/dialog/__tests__/bq-dialog.e2e.tsx`
- `packages/beeq/src/components/drawer/__tests__/bq-drawer.e2e.tsx`

## Documentation
No documentation changes were required for this update.

## Checklist
- [x] I have read the [[CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md)](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [[CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md)](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [ ] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.
