### PR TITLE
fix(Config): use node:path in postcss config

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,4 @@
-const { resolve } = require('path');
+const { resolve } = require('node:path');
 
 /** @type {import('postcss-load-config').Config} */
 module.exports = {


### PR DESCRIPTION
## Description
Updates the PostCSS configuration to use the `node:` protocol for the built-in `path` module, as recommended by SonarCloud.

This PR changes `postcss.config.js` from `require('path')` to `require('node:path')`. The update is small and behavior-preserving, but it aligns the configuration with the modern Node.js convention for importing built-in modules.

The change is intentionally limited to configuration code and does not affect runtime behavior, styling output, or component APIs.

## Related Issue
Fixes the SonarCloud medium-severity warning in:
- `postcss.config.js`

## Documentation
No documentation changes were required for this update.

## Checklist
- [x] I have read the [[CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md)](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [[CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md)](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [ ] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.
