### PR TITLE
fix(Utils): use explicit property key in validatePropValue warning

### DIFF
--- a/packages/beeq/src/shared/utils/props.ts
+++ b/packages/beeq/src/shared/utils/props.ts
@@ -16,15 +16,14 @@ export const validatePropValue = <T extends E[keyof E], E extends Element>(
   element: E,
   propertyName: TValidProperty<E, T>,
 ): void => {
-  const propertyValue = element[propertyName as string];
+  const propertyKey = propertyName as string;
+  const propertyValue = element[propertyKey];
   // Early return if the property value is one of the accepted values
   if (ACCEPTED_VALUES.includes(propertyValue)) return;
   // Override property with fallback value
-  element[propertyName as string] = fallbackValue;
+  element[propertyKey] = fallbackValue;
   // Notify developer in the browser console
   console.warn(
-    `[${element.tagName.toUpperCase()}] Please notice that "${String(
-      propertyName,
-    )}" should be one of ${ACCEPTED_VALUES.join('|')}`,
+    `[${element.tagName.toUpperCase()}] Please notice that "${propertyKey}" should be one of ${ACCEPTED_VALUES.join('|')}`,
   );
 };


### PR DESCRIPTION
## Description
Improves the warning message generated by `validatePropValue` by using an explicit property key string instead of coercing the property name directly.

This PR updates `packages/beeq/src/shared/utils/props.ts` so the warning message uses a clearly derived property key rather than relying on generic string coercion. The change preserves the existing behavior of the helper while making the log message more intentional and avoiding ambiguous formatting.

The update is intentionally small and limited to the shared utility helper. It does not change the public API or the validation flow used by components.

## Related Issue
Improves the warning message handling in:
- `packages/beeq/src/shared/utils/props.ts`

## Checklist
- [x] I have read the [[CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md)](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [[CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md)](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [ ] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.