### PR TITLE
fix(Utils): remove redundant transition assertion

### DIFF
--- a/packages/beeq/src/shared/utils/transition.ts
+++ b/packages/beeq/src/shared/utils/transition.ts
@@ -73,7 +73,7 @@ const transition = async (direction: string, element: HTMLElement, animation: st
   // Replace start classes with end classes, then wait for the transition to finish
   removeClasses(element, startClasses);
   addClasses(element, endClasses);
-  await afterTransition(element as HTMLElementWithAnimations);
+  await afterTransition(element);
 
   // Remove end and genesis classes
   removeClasses(element, endClasses);


### PR DESCRIPTION
## Description
Removes a redundant type assertion from the shared transition helper.

This PR updates `packages/beeq/src/shared/utils/transition.ts` by removing an unnecessary assertion in the `afterTransition` call. The change keeps the existing behavior intact while making the implementation a little clearer and less noisy.

The update is intentionally small and limited to the transition utility helper. It does not change the public API or the transition flow used by components.

## Related Issue
Improves the transition helper implementation in:
- `packages/beeq/src/shared/utils/transition.ts`

## Checklist
- [x] I have read the [[CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md)](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [[CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md)](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [ ] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.