### PR TITLE
fix(Tools): name plop default export

### DIFF
--- a/tools/src/generators/plop/plopfile.mjs
+++ b/tools/src/generators/plop/plopfile.mjs
@@ -1,4 +1,4 @@
-export default function (
+export default function plopfile(
   /** @type {import('plop').NodePlopAPI} */
   plop,
 ) {


### PR DESCRIPTION
## Description
Adds an explicit name to the default-exported function in the Plop generator file.

This PR updates `tools/src/generators/plop/plopfile.mjs` by naming the default export instead of leaving it anonymous. The change preserves the existing behavior while making the export a little clearer and easier to identify in tooling and stack traces.

The update is intentionally small and limited to the generator configuration. It does not change generator behavior or the generated output.

## Related Issue
Improves the Plop generator export in:
- `tools/src/generators/plop/plopfile.mjs`

## Checklist
- [x] I have read the [[CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md)](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [[CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md)](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [ ] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.