### PR TITLE
ci(Config): refactor browser setup from Puppeteer to Playwright for automation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,10 @@ jobs:
           command: pnpm exec nx affected -t build --exclude='*,!tag:publishable' --parallel=3 --base=$NX_BASE --head=$NX_HEAD --verbose
       - run:
           name: 🧪 Run E2E Tests
-          command: pnpm exec nx affected -t e2e --exclude='*,!tag:core' --parallel=3 --base=$NX_BASE --head=$NX_HEAD --verbose
+          # Browser e2e tests use the Playwright Docker image configured on this
+          # CircleCI job. Nx managed agents use separate launch templates, so keep
+          # this target on the coordinator unless the agents also install browsers.
+          command: pnpm exec nx affected -t e2e --exclude='*,!tag:core' --parallel=3 --base=$NX_BASE --head=$NX_HEAD --verbose --no-agents
       - run:
           name: 📚 Build Storybook
           command: pnpm exec nx run beeq:storybook-build --output-style=stream --verbose

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ commands:
       - restore_cache:
           name: 💫 Restore node_modules cache
           keys:
-            - node-modules-{{ arch }}-{{ checksum "pnpm-lock.yaml" }}
+            - node-modules-{{ arch }}-{{ checksum "package.json" }}-{{ checksum "pnpm-lock.yaml" }}
             - node-modules-{{ arch }}-
             - node-modules-
 
@@ -75,7 +75,7 @@ commands:
       # Save the node_modules cache
       - save_cache:
           name: 💾 Save node_modules cache
-          key: node-modules-{{ arch }}-{{ checksum "pnpm-lock.yaml" }}
+          key: node-modules-{{ arch }}-{{ checksum "package.json" }}-{{ checksum "pnpm-lock.yaml" }}
           paths:
             - ./node_modules
             - ./packages/beeq/node_modules
@@ -84,12 +84,30 @@ commands:
             - ./packages/beeq-vue/node_modules
             - ./packages/beeq-tailwindcss/node_modules
 
-  setup-browser-tools:
+  setup-playwright:
     steps:
+      - restore_cache:
+          name: 💫 Restore Playwright browser cache
+          keys:
+            - playwright-browsers-{{ arch }}-{{ checksum "package.json" }}-{{ checksum "pnpm-lock.yaml" }}
+            - playwright-browsers-{{ arch }}-
+            - playwright-browsers-
+
       - run:
-          name: 🎭 Install Playwright browser
-          command: pnpm exec playwright install chromium --only-shell
-          no_output_timeout: 15m
+          name: 🎭 Install Playwright Chromium
+          command: |
+            node --version
+            pnpm exec playwright --version
+            pnpm exec playwright install chromium --only-shell
+            pnpm exec playwright install --list
+            ls -lah ~/.cache/ms-playwright || true
+          no_output_timeout: 20m
+
+      - save_cache:
+          name: 💾 Save Playwright browser cache
+          key: playwright-browsers-{{ arch }}-{{ checksum "package.json" }}-{{ checksum "pnpm-lock.yaml" }}
+          paths:
+            - ~/.cache/ms-playwright
 
 # ---------------------------------------------------------------------------- #
 #                                     Jobs                                     #
@@ -105,7 +123,7 @@ jobs:
       - checkout
       - setup-node
       - setup-deps
-      - setup-browser-tools
+      - setup-playwright
       # Start Nx Cloud and run all tasks
       - run:
           name: 🧾 NX report

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ env-vars: &env-vars
   NX_BRANCH: << pipeline.git.branch >>
   NX_VERBOSE_LOGGING: "true"
   NODE_OPTIONS: "--max-old-space-size=4096"
+  PLAYWRIGHT_BROWSERS_PATH: "/ms-playwright"
 
 # ---------------------------------------------------------------------------- #
 #                                Reusable steps                                #
@@ -84,30 +85,14 @@ commands:
             - ./packages/beeq-vue/node_modules
             - ./packages/beeq-tailwindcss/node_modules
 
-  setup-playwright:
+  verify-playwright:
     steps:
-      - restore_cache:
-          name: 💫 Restore Playwright browser cache
-          keys:
-            - playwright-browsers-{{ arch }}-{{ checksum "package.json" }}-{{ checksum "pnpm-lock.yaml" }}
-            - playwright-browsers-{{ arch }}-
-            - playwright-browsers-
-
       - run:
-          name: 🎭 Install Playwright Chromium
+          name: 🎭 Verify Playwright browsers
           command: |
-            node --version
             pnpm exec playwright --version
-            pnpm exec playwright install chromium --only-shell
-            pnpm exec playwright install --list
-            ls -lah ~/.cache/ms-playwright || true
-          no_output_timeout: 20m
-
-      - save_cache:
-          name: 💾 Save Playwright browser cache
-          key: playwright-browsers-{{ arch }}-{{ checksum "package.json" }}-{{ checksum "pnpm-lock.yaml" }}
-          paths:
-            - ~/.cache/ms-playwright
+            test -d "$PLAYWRIGHT_BROWSERS_PATH"
+            ls -lah "$PLAYWRIGHT_BROWSERS_PATH"
 
 # ---------------------------------------------------------------------------- #
 #                                     Jobs                                     #
@@ -116,14 +101,14 @@ commands:
 jobs:
   main:
     docker:
-      - image: cimg/node:26.3.0-browsers
+      - image: mcr.microsoft.com/playwright:v1.59.1-noble
     resource_class: large
     environment: *env-vars
     steps:
       - checkout
       - setup-node
       - setup-deps
-      - setup-playwright
+      - verify-playwright
       # Start Nx Cloud and run all tasks
       - run:
           name: 🧾 NX report

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ version: 2.1
 
 orbs:
   nx: nrwl/nx@1.7.0
-  browser-tools: circleci/browser-tools@1.5.3
 
 # ---------------------------------------------------------------------------- #
 #                             Environment Variables                            #
@@ -13,7 +12,6 @@ orbs:
 env-vars: &env-vars
   NX_BRANCH: << pipeline.git.branch >>
   NX_VERBOSE_LOGGING: "true"
-  PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
   NODE_OPTIONS: "--max-old-space-size=4096"
 
 # ---------------------------------------------------------------------------- #
@@ -88,14 +86,10 @@ commands:
 
   setup-browser-tools:
     steps:
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
       - run:
-          name: 🔍 Verify Chrome Installation
-          command: |
-            google-chrome --version
-            chromedriver --version
-            echo "export PUPPETEER_EXECUTABLE_PATH=$(which google-chrome)" >> $BASH_ENV
+          name: 🎭 Install Playwright browser
+          command: pnpm exec playwright install chromium
+          no_output_timeout: 5m
 
 # ---------------------------------------------------------------------------- #
 #                                     Jobs                                     #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,8 +88,8 @@ commands:
     steps:
       - run:
           name: 🎭 Install Playwright browser
-          command: pnpm exec playwright install chromium
-          no_output_timeout: 5m
+          command: pnpm exec playwright install chromium --only-shell
+          no_output_timeout: 15m
 
 # ---------------------------------------------------------------------------- #
 #                                     Jobs                                     #

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "clean": "run-s clean:*",
     "clean:build": "pnpm dlx rimraf .stencil dist",
     "clean:modules": "pnpm dlx rimraf ./node_modules ./**/node_modules ./packages/**/node_modules",
-    "postinstall": "pnpm exec playwright install chromium",
     "g": "plop --cwd tools/src/generators/plop"
   },
   "dependencies": {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

This change removes the `browser-tools` CircleCI orb and associated Puppeteer configurations, replacing them with a direct Playwright Chromium installation command within the CI build steps. It centralizes browser provisioning for CI environments using Playwright.

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

N/A

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->
