### PR TITLE
fix(components): use nullish assignment in radio-group and toast

### DIFF
--- a/packages/beeq/src/components/radio-group/bq-radio-group.tsx
+++ b/packages/beeq/src/components/radio-group/bq-radio-group.tsx
@@ -329,9 +329,7 @@ export class BqRadioGroup {
     }
 
     // Priority 3: First enabled radio (fallback)
-    if (!focusableRadio) {
-      focusableRadio = this.cachedRadioElements.find((radio) => !radio.disabled);
-    }
+    focusableRadio ??= this.cachedRadioElements.find((radio) => !radio.disabled);
 
     // Apply tabIndex to all radios
     this.cachedRadioElements.forEach((radio) => {


### PR DESCRIPTION
## Description
This PR updates two component initialization and fallback paths to use nullish coalescing assignment for clearer, more concise logic.

- `bq-radio-group`: updates the fallback radio selection logic when choosing the first enabled radio
- `bq-toast`: updates the toast portal initialization logic

These changes are limited to assignment style and do not alter component behavior.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.