### PR TITLE
fix(step-item): keep numeric prefix circular when titles wrap

### DIFF
--- a/packages/beeq/src/components/step-item/scss/bq-step-item.scss
+++ b/packages/beeq/src/components/step-item/scss/bq-step-item.scss
@@ -55,7 +55,7 @@
 }
 
 .bq-step-item__prefix.numeric {
-  @apply flex items-center justify-center rounded-full;
+  @apply shrink-0 flex items-center justify-center rounded-full;
   @apply bg-[--bq-step-item--prefix-num-bg-color] bs-[--bq-step-item--prefix-num-size] is-[--bq-step-item--prefix-num-size];
   @apply text-m font-semibold leading-regular text-primary;
 


### PR DESCRIPTION
## Description
This PR fixes a layout regression in `bq-step-item` where the numeric prefix circle could shrink when a horizontal step title wrapped onto multiple lines.

- `bq-step-item`: prevents the numeric prefix from shrinking in horizontal layouts so the circle keeps its shape when titles wrap

This change is limited to layout stability and does not change step behavior or interaction.

## Related Issue
Fixes https://github.com/Endava/BEEQ/issues/1723

## Checklist
- [x] I have read the [[CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md)](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [[CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md)](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.


`fix(step-item): prevent numeric prefix from shrinking on wrapped titles`