### PR TITLE
refactor(tag): migrate Tailwind styles to native SCSS

### DIFF
--- a/packages/beeq/src/components/tag/__tests__/bq-tag.e2e.tsx
+++ b/packages/beeq/src/components/tag/__tests__/bq-tag.e2e.tsx
@@ -50,6 +50,18 @@ describe('bq-tag', () => {
     expect(closeIcon).not.toBeNull();
   });
 
+  it('should render the close icon with alt text color for custom color removable tags', async () => {
+    const customColor = '#ff5733' as HTMLBqTagElement['color'];
+    const { root } = await render(
+      <bq-tag color={customColor} removable>
+        Tag
+      </bq-tag>,
+    );
+    const closeIcon = root.shadowRoot.querySelector('bq-icon[name="x-circle"]');
+
+    expect(closeIcon).toEqualAttribute('color', 'text--alt');
+  });
+
   it('should render a basic tag without icon', async () => {
     const { root } = await render(<bq-tag>Tag</bq-tag>);
     const slot = root.shadowRoot.querySelector('slot:not([name])');
@@ -134,17 +146,17 @@ describe('bq-tag', () => {
     const tag = root as HTMLBqTagElement;
     const wrapper = root.shadowRoot.querySelector('[part="wrapper"]');
 
-    expect(wrapper).not.toHaveClass('active');
+    expect(tag).not.toHaveAttribute('selected');
 
     await userEvent.click(wrapper);
     await waitForChanges();
     expect(tag.selected).toBe(true);
-    expect(wrapper).toHaveClass('active');
+    expect(tag).toHaveAttribute('selected');
 
     await userEvent.click(wrapper);
     await waitForChanges();
     expect(tag.selected).toBe(false);
-    expect(wrapper).not.toHaveClass('active');
+    expect(tag).not.toHaveAttribute('selected');
   });
 
   it('should emit bqClick when clickable tag is clicked', async () => {

--- a/packages/beeq/src/components/tag/bq-tag.tsx
+++ b/packages/beeq/src/components/tag/bq-tag.tsx
@@ -244,24 +244,27 @@ export class BqTag {
     return this.color !== undefined ? !TAG_COLOR.includes(this.color) : false;
   }
 
-  private get computedHostClasses() {
+  private get computedHostStyles() {
     return {
-      '--bq-tag--icon-prefix-size': `${iconSize(this.size)}px`,
-      ...(this.border && { '--bq-tag--border-radius': `var(--bq-radius--${this.border})` }),
-      ...(this.color && { '--bq-tag--background-color': getColorCSSVariable(this.color) ?? this.color }),
-      ...(this.hasCustomColor && { '--bq-text--primary': `var(--bq-text--alt)` }),
+      '--_tag-icon-prefix-size': `${iconSize(this.size)}px`,
+      ...(this.border && { '--_tag-border-radius': `var(--bq-radius--${this.border})` }),
+      ...(this.hasCustomColor && {
+        '--_tag-background-color': getColorCSSVariable(this.color) ?? this.color,
+        '--_tag-text-color': `var(--bq-text--alt)`,
+      }),
     };
   }
 
   private get computeWrapperClasses() {
     return {
-      [`bq-tag bq-tag__${this.size}`]: true,
-      [`bq-tag__${this.color || 'default'} bq-tag__${this.variant}`]: !this.hasCustomColor,
-      'is-clickable': this.isClickable,
-      'is-removable': this.removable,
-      active: this.isClickable && this.selected,
-      'has-border': !!this.border,
+      'bq-tag': true,
     };
+  }
+
+  private get closeIconColor(): string {
+    if (this.hasCustomColor) return 'text--alt';
+
+    return this.color ? (textColor(this.color)[this.variant] ?? 'text--primary') : 'text--primary';
   }
 
   private get computeButtonInteractiveProps() {
@@ -286,7 +289,7 @@ export class BqTag {
     const ariaHidden = this.hidden ? 'true' : 'false';
 
     return (
-      <Host aria-hidden={ariaHidden} hidden={this.hidden || undefined} style={this.computedHostClasses}>
+      <Host aria-hidden={ariaHidden} hidden={this.hidden || undefined} style={this.computedHostStyles}>
         <TagElement
           class={this.computeWrapperClasses}
           disabled={this.isClickable ? this.disabled : undefined}
@@ -294,7 +297,7 @@ export class BqTag {
           {...this.computeButtonInteractiveProps}
         >
           <span
-            class={{ 'bq-tag__prefix inline-flex': true, '!hidden': !this.hasPrefix }}
+            class={{ 'bq-tag__prefix': true, 'is-hidden': !this.hasPrefix }}
             part="prefix"
             ref={(spanElem) => {
               this.prefixElem = spanElem;
@@ -302,14 +305,7 @@ export class BqTag {
           >
             <slot name="prefix" onSlotchange={this.handleSlotChange} />
           </span>
-          <div
-            class={{
-              'text-xs': this.size === 'xsmall',
-              'text-s': this.size === 'small',
-              'text-m': this.size === 'medium',
-            }}
-            part="text"
-          >
+          <div class="bq-tag__text" part="text">
             <slot />
           </div>
           {this.isRemovable && !this.disabled && (
@@ -317,19 +313,14 @@ export class BqTag {
             <bq-button
               appearance="text"
               border="s"
-              class="bq-tag__close [&::part(button)]:border-none [&::part(button)]:p-0"
+              class="bq-tag__close"
               label="Close"
               onClick={this.handleClose}
               onlyIcon
               part="btn-close"
               size="small"
             >
-              <bq-icon
-                aria-hidden="true"
-                color={this.color && !this.hasCustomColor ? textColor(this.color)[this.variant] : 'text--primary'}
-                name="x-circle"
-                size={iconSize(this.size)}
-              />
+              <bq-icon aria-hidden="true" color={this.closeIconColor} name="x-circle" size={iconSize(this.size)} />
             </bq-button>
           )}
         </TagElement>

--- a/packages/beeq/src/components/tag/scss/bq-tag.scss
+++ b/packages/beeq/src/components/tag/scss/bq-tag.scss
@@ -2,12 +2,10 @@
 /*                                 Tag styles                                 */
 /* -------------------------------------------------------------------------- */
 
+@import './bq-tag.variables';
+
 @layer bq.reset, bq.tokens, bq.themes, bq.base, bq.utilities, bq.overrides,
   bq-tag.tokens, bq-tag.base, bq-tag.structure, bq-tag.variants, bq-tag.states, bq-tag.parts;
-
-@layer bq-tag.tokens {
-  @import './bq-tag.variables';
-}
 
 /* ---------------------------------- Host ---------------------------------- */
 

--- a/packages/beeq/src/components/tag/scss/bq-tag.scss
+++ b/packages/beeq/src/components/tag/scss/bq-tag.scss
@@ -1,106 +1,197 @@
 /* -------------------------------------------------------------------------- */
-/*                        Tag styles                        */
+/*                                 Tag styles                                 */
 /* -------------------------------------------------------------------------- */
 
-@import './bq-tag.variables';
+@layer bq.reset, bq.tokens, bq.themes, bq.base, bq.utilities, bq.overrides,
+  bq-tag.tokens, bq-tag.base, bq-tag.structure, bq-tag.variants, bq-tag.states, bq-tag.parts;
 
-:host {
-  @apply relative inline-block;
+@layer bq-tag.tokens {
+  @import './bq-tag.variables';
 }
 
-:host([hidden]) {
-  @apply hidden;
-}
+/* ---------------------------------- Host ---------------------------------- */
 
-.bq-tag {
-  @apply box-border inline-flex select-none flex-row items-center justify-center bg-[--bq-tag--background-color];
-  @apply gap-[--bq-tag--medium-gap] font-medium leading-regular text-primary p-b-[--bq-tag--medium-padding-y] p-i-[--bq-tag--medium-padding-x];
-  @apply rounded-[--bq-tag--border-radius] border-[length:--bq-tag--border-width] border-[color:--bq-tag--border-color];
-  @apply transition-colors duration-300 ease-in-out;
+@layer bq-tag.base {
+  :host {
+    --_tag-background-color: var(--bq-tag--background-color);
+    --_tag-border-color: var(--bq-tag--border-color);
+    --_tag-border-radius: var(--bq-tag--border-radius);
+    --_tag-gap: var(--bq-tag--medium-gap);
+    --_tag-icon-prefix-size: 24px;
+    --_tag-padding-block: var(--bq-tag--medium-padding-y);
+    --_tag-padding-inline: var(--bq-tag--medium-padding-x);
+    --_tag-text-color: var(--bq-text--primary);
+    --_tag-text-font-size: var(--bq-font-size--m);
 
-  border-style: var(--bq-tag--border-style);
-}
-
-/* ---------------------------------- Size ---------------------------------- */
-
-.bq-tag__xsmall,
-.bq-tag__small {
-  @apply gap-[--bq-tag--small-gap] p-b-[--bq-tag--small-padding-y] p-i-[--bq-tag--small-padding-x];
-
-  /* Apply predefined border radius only if the border property have NO VALUE */
-  &:not(.has-border) {
-    @apply rounded-[--bq-tag--small-border-radius];
-  }
-}
-
-/* --------------------------------- Action --------------------------------- */
-
-.bq-tag__default.is-clickable {
-  @apply cursor-pointer;
-  // Focus
-  @apply focus-visible:focus;
-  // Hover
-  @apply hover:enabled:bg-[color-mix(in_srgb,_var(--bq-tag--background-color),_var(--bq-hover)_20%)];
-  // Active/Selected
-  @apply [&.active]:text-alt [&.active]:[--bq-tag--background-color:--bq-ui--brand];
-  // Disabled
-  @apply disabled:cursor-not-allowed disabled:border-none disabled:opacity-60;
-}
-
-/* ------------------------------ Color styles ------------------------------ */
-
-.bq-tag__error {
-  &.bq-tag__filled {
-    @apply bg-ui-danger text-alt;
+    position: relative;
+    display: inline-block;
   }
 
-  &.bq-tag__outline {
-    @apply bg-ui-danger-alt text-danger [--bq-tag--border-color:--bq-stroke--danger];
+  :host([hidden]) {
+    display: none;
   }
 }
 
-.bq-tag__gray {
-  &.bq-tag__filled {
-    @apply bg-ui-tertiary text-alt;
-  }
+/* ---------------------------------- Base ---------------------------------- */
 
-  &.bq-tag__outline {
-    @apply bg-ui-primary text-primary [--bq-tag--border-color:--bq-stroke--tertiary];
-  }
-}
-
-.bq-tag__info {
-  &.bq-tag__filled {
-    @apply bg-ui-brand text-alt;
-  }
-
-  &.bq-tag__outline {
-    @apply bg-ui-brand-alt text-brand [--bq-tag--border-color:--bq-stroke--brand];
-  }
-}
-
-.bq-tag__success {
-  &.bq-tag__filled {
-    @apply bg-ui-success text-alt;
-  }
-
-  &.bq-tag__outline {
-    @apply bg-ui-success-alt text-success [--bq-tag--border-color:--bq-tag--border-success];
+@layer bq-tag.base {
+  .bq-tag {
+    box-sizing: border-box;
+    display: inline-flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    gap: var(--_tag-gap);
+    padding-block: var(--_tag-padding-block);
+    padding-inline: var(--_tag-padding-inline);
+    color: var(--_tag-text-color);
+    font-weight: var(--bq-font-weight--medium);
+    line-height: var(--bq-font-line-height--regular);
+    user-select: none;
+    background-color: var(--_tag-background-color);
+    border-color: var(--_tag-border-color);
+    border-radius: var(--_tag-border-radius);
+    border-style: var(--bq-tag--border-style);
+    border-width: var(--bq-tag--border-width);
+    transition-timing-function: ease-in-out;
+    transition-duration: 300ms;
+    transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
   }
 }
 
-.bq-tag__warning {
-  &.bq-tag__filled {
-    @apply bg-ui-warning text-alt;
+/* ------------------------------- Structure -------------------------------- */
+
+@layer bq-tag.structure {
+  .bq-tag__prefix {
+    display: inline-flex;
   }
 
-  &.bq-tag__outline {
-    @apply border-warning bg-ui-warning-alt text-warning;
+  .bq-tag__text {
+    font-size: var(--_tag-text-font-size);
   }
 }
 
-/* --------------- Apply the right size to the bq-icon prefix --------------- */
+/* -------------------------------- Variants -------------------------------- */
 
-.bq-tag__prefix ::slotted(bq-icon) {
-  --bq-icon--size: var(--bq-tag--icon-prefix-size) !important;
+@layer bq-tag.variants {
+  :host([size='xsmall']),
+  :host([size='small']) {
+    --_tag-border-radius: var(--bq-tag--small-border-radius);
+    --_tag-gap: var(--bq-tag--small-gap);
+    --_tag-padding-block: var(--bq-tag--small-padding-y);
+    --_tag-padding-inline: var(--bq-tag--small-padding-x);
+  }
+
+  :host([size='xsmall']) {
+    --_tag-text-font-size: var(--bq-font-size--xs);
+  }
+
+  :host([size='small']) {
+    --_tag-text-font-size: var(--bq-font-size--s);
+  }
+
+  :host([color='error'][variant='filled']) {
+    --_tag-background-color: var(--bq-ui--danger);
+    --_tag-text-color: var(--bq-text--alt);
+  }
+
+  :host([color='error'][variant='outline']) {
+    --_tag-background-color: var(--bq-ui--danger-alt);
+    --_tag-border-color: var(--bq-stroke--danger);
+    --_tag-text-color: var(--bq-text--danger);
+  }
+
+  :host([color='gray'][variant='filled']) {
+    --_tag-background-color: var(--bq-ui--tertiary);
+    --_tag-text-color: var(--bq-text--alt);
+  }
+
+  :host([color='gray'][variant='outline']) {
+    --_tag-background-color: var(--bq-ui--primary);
+    --_tag-border-color: var(--bq-stroke--tertiary);
+    --_tag-text-color: var(--bq-text--primary);
+  }
+
+  :host([color='info'][variant='filled']) {
+    --_tag-background-color: var(--bq-ui--brand);
+    --_tag-text-color: var(--bq-text--alt);
+  }
+
+  :host([color='info'][variant='outline']) {
+    --_tag-background-color: var(--bq-ui--brand-alt);
+    --_tag-border-color: var(--bq-stroke--brand);
+    --_tag-text-color: var(--bq-text--brand);
+  }
+
+  :host([color='success'][variant='filled']) {
+    --_tag-background-color: var(--bq-ui--success);
+    --_tag-text-color: var(--bq-text--alt);
+  }
+
+  :host([color='success'][variant='outline']) {
+    --_tag-background-color: var(--bq-ui--success-alt);
+    --_tag-border-color: var(--bq-stroke--success);
+    --_tag-text-color: var(--bq-text--success);
+  }
+
+  :host([color='warning'][variant='filled']) {
+    --_tag-background-color: var(--bq-ui--warning);
+    --_tag-text-color: var(--bq-text--alt);
+  }
+
+  :host([color='warning'][variant='outline']) {
+    --_tag-background-color: var(--bq-ui--warning-alt);
+    --_tag-border-color: var(--bq-stroke--warning);
+    --_tag-text-color: var(--bq-text--warning);
+  }
+}
+
+/* --------------------------------- States --------------------------------- */
+
+@layer bq-tag.states {
+  :host([selected][clickable]:not([color], [removable])) {
+    --_tag-background-color: var(--bq-ui--brand);
+    --_tag-text-color: var(--bq-text--alt);
+  }
+
+  :host([clickable]:not([color], [removable])) .bq-tag {
+    cursor: pointer;
+  }
+
+  :host([clickable]:not([color], [removable])) .bq-tag:focus-visible {
+    outline: var(--bq-ring-width, 2px) solid var(--bq-ring-color-focus, var(--bq-focus));
+    outline-offset: var(--bq-ring-offset-width, 1px);
+  }
+
+  :host([clickable]:not([color], [removable])) .bq-tag:hover:enabled {
+    background-color: color-mix(in srgb, var(--_tag-background-color), var(--bq-hover) 20%);
+  }
+
+  :host([disabled][clickable]:not([color], [removable])) .bq-tag:disabled {
+    cursor: not-allowed;
+    border-style: none;
+    opacity: 0.6;
+  }
+
+  .bq-tag__prefix.is-hidden {
+    display: none;
+  }
+}
+
+/* ---------------------------------- Slots --------------------------------- */
+
+@layer bq-tag.structure {
+  .bq-tag__prefix ::slotted(bq-icon) {
+    /* stylelint-disable-next-line declaration-no-important -- slotted bq-icon keeps its own default size otherwise */
+    --bq-icon--size: var(--_tag-icon-prefix-size) !important;
+  }
+}
+
+/* ---------------------------------- Parts --------------------------------- */
+
+@layer bq-tag.parts {
+  .bq-tag__close::part(button) {
+    padding: 0;
+    border: none;
+  }
 }

--- a/packages/beeq/src/components/tag/scss/bq-tag.variables.scss
+++ b/packages/beeq/src/components/tag/scss/bq-tag.variables.scss
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- */
-/*                   Tag custom properties                  */
+/*                           Tag custom properties                            */
 /* -------------------------------------------------------------------------- */
 
 :host {
@@ -17,19 +17,19 @@
    * @prop --bq-tag--medium-padding-x - Tag medium padding horizontal
    * @prop --bq-tag--medium-padding-y - Tag medium padding vertical
    */
-  --bq-tag--background-color: theme(backgroundColor.ui.secondary);
+  --bq-tag--background-color: var(--bq-ui--secondary);
 
-  --bq-tag--border-color: theme(colors.transparent);
-  --bq-tag--border-radius: theme(borderRadius.s);
+  --bq-tag--border-color: transparent;
+  --bq-tag--border-radius: var(--bq-radius--s);
   --bq-tag--border-style: solid;
-  --bq-tag--border-width: theme(borderWidth.s);
+  --bq-tag--border-width: var(--bq-stroke-s);
 
-  --bq-tag--small-border-radius: theme(borderRadius.xs);
-  --bq-tag--small-gap: theme(spacing.xs2);
+  --bq-tag--small-border-radius: var(--bq-radius--xs);
+  --bq-tag--small-gap: var(--bq-spacing-xs2);
   --bq-tag--small-padding-x: calc(var(--bq-spacing-xs) - var(--bq-tag--border-width));
   --bq-tag--small-padding-y: calc(var(--bq-spacing-xs3) - var(--bq-tag--border-width));
 
-  --bq-tag--medium-gap: theme(spacing.xs);
+  --bq-tag--medium-gap: var(--bq-spacing-xs);
   --bq-tag--medium-padding-x: calc(var(--bq-spacing-s) - var(--bq-tag--border-width));
   --bq-tag--medium-padding-y: calc(var(--bq-spacing-xs2) - var(--bq-tag--border-width));
 }


### PR DESCRIPTION
## Description
Migrates `tag` from Tailwind runtime styling to native SCSS/CSS.

This removes Tailwind `@apply`, replaces `theme(...)` usage with BEEQ CSS custom properties, and moves visual Tailwind utility classes out of component render output into scoped semantic SCSS hooks.

Refactor and reorganize styles by responsibility.

Migrated components:
- `tag`

## Documentation
Generated component documentation was not changed.

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF_CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.