### PR TITLE
refactor(progress): migrate Tailwind styles to SCSS

### DIFF
--- a/packages/beeq/src/components/progress/__tests__/bq-progress.e2e.tsx
+++ b/packages/beeq/src/components/progress/__tests__/bq-progress.e2e.tsx
@@ -9,6 +9,16 @@ const getTooltip = (element: HTMLBqProgressElement) =>
   element.shadowRoot?.querySelector<HTMLBqTooltipElement>('bq-tooltip');
 const getIndeterminate = (element: HTMLBqProgressElement) =>
   element.shadowRoot?.querySelector<HTMLDivElement>('[part="indeterminate"]');
+const getComputedColor = (color: string) => {
+  const element = document.createElement('div');
+  element.style.color = color;
+  document.body.append(element);
+
+  const computedColor = getComputedStyle(element).color;
+  element.remove();
+
+  return computedColor;
+};
 
 describe('bq-progress', () => {
   afterEach(() => {
@@ -49,7 +59,7 @@ describe('bq-progress', () => {
     const label = getLabel(bqProgress);
 
     expect(label).toEqualAttribute('aria-hidden', 'true');
-    expect(label).toHaveClass('invisible');
+    expect(getComputedStyle(label).visibility).toBe('hidden');
   });
 
   it('should render the progress bar with tooltip', async () => {
@@ -78,9 +88,8 @@ describe('bq-progress', () => {
 
     await waitForStable(bqProgress);
 
-    expect(getProgressBar(bqProgress)).toHaveClass('progress-bar__error');
-    expect(getLabel(bqProgress)).toHaveClass('text-danger');
-    expect(bqProgress.style.getPropertyValue('--bq-progress-bar--indicatorColor')).toBe('var(--bq-ui--danger)');
+    expect(bqProgress).toEqualAttribute('type', 'error');
+    expect(getComputedStyle(getLabel(bqProgress)).color).toBe(getComputedColor('var(--bq-text--danger)'));
   });
 
   it('should render the large thickness styles', async () => {
@@ -89,7 +98,7 @@ describe('bq-progress', () => {
 
     await waitForStable(bqProgress);
 
-    expect(bqProgress.style.getPropertyValue('--bq-progress-bar--height')).toBe('var(--bq-spacing-xs)');
+    expect(getComputedStyle(getProgressBar(bqProgress)).blockSize).toBe('8px');
   });
 
   it('should clamp the value to the supported range', async () => {
@@ -118,14 +127,18 @@ describe('bq-progress', () => {
     const { root } = await render(<bq-progress borderShape="rounded" value={60} />);
     const bqProgress = root as HTMLBqProgressElement;
 
-    expect(getProgressBar(bqProgress)).toHaveClass('progress-bar__border-shape');
+    await waitForStable(bqProgress);
+
+    expect(getComputedStyle(getProgressBar(bqProgress)).borderRadius).toBe('9999px');
   });
 
   it('should render the square border shape without rounded styles', async () => {
     const { root } = await render(<bq-progress borderShape="square" value={60} />);
     const bqProgress = root as HTMLBqProgressElement;
 
-    expect(getProgressBar(bqProgress)).not.toHaveClass('progress-bar__border-shape');
+    await waitForStable(bqProgress);
+
+    expect(getComputedStyle(getProgressBar(bqProgress)).borderRadius).toBe('0px');
   });
 
   it('should not render tooltip content for indeterminate progress', async () => {

--- a/packages/beeq/src/components/progress/bq-progress.tsx
+++ b/packages/beeq/src/components/progress/bq-progress.tsx
@@ -139,20 +139,12 @@ export class BqProgress {
   // ===================================
 
   render() {
-    const style = {
-      ...(this.thickness === 'large' && { '--bq-progress-bar--height': 'var(--bq-spacing-xs)' }),
-      ...(this.type === 'error' && { '--bq-progress-bar--indicatorColor': 'var(--bq-ui--danger)' }),
-    };
-
     return (
-      <Host style={style}>
-        <div class="flex items-center" part="wrapper">
-          <div class="is-full relative flex items-center" part="progress">
+      <Host border-shape={this.borderShape}>
+        <div class="bq-progress" part="wrapper">
+          <div class="bq-progress__track" part="progress">
             <progress
-              class={{
-                [`progress-bar progress-bar__${this.type} ${this.thickness}`]: true,
-                'progress-bar__border-shape rounded-full': this.borderShape === 'rounded',
-              }}
+              class="bq-progress__bar"
               max="100"
               part="progress-bar"
               value={this.indeterminate ? undefined : this.value}
@@ -160,35 +152,21 @@ export class BqProgress {
             {this.enableTooltip && !this.indeterminate && (
               <bq-tooltip
                 alwaysVisible={true}
-                class="absolute [&::part(panel)]:absolute"
+                class="bq-progress__tooltip"
                 distance={16}
                 exportparts="base,trigger,panel"
-                style={{ insetInlineStart: `${this.value}%`, fontVariant: 'tabular-nums' }}
+                style={{ insetInlineStart: `${this.value}%` }}
               >
-                <div class="bs-1 is-1 absolute" slot="trigger"></div>
+                <div class="bq-progress__tooltip-trigger" slot="trigger"></div>
                 {this.value}
               </bq-tooltip>
             )}
-            {this.indeterminate && (
-              <div
-                class={{
-                  'progress-bar__indeterminate bs-[--bq-progress-bar--height] is-[--bq-progress-bar--indeterminateWidth] absolute bg-[--bq-progress-bar--indicatorColor]': true,
-                  'rounded-full': this.borderShape === 'rounded',
-                }}
-                part="indeterminate"
-              />
-            )}
+            {this.indeterminate && <div class="bq-progress__indeterminate" part="indeterminate" />}
           </div>
           <div
             aria-hidden={!this.label || this.indeterminate ? 'true' : 'false'}
-            class={{
-              'ms-xs font-medium leading-regular': true,
-              'text-primary': this.type !== 'error',
-              'text-danger': this.type === 'error',
-              'is-0 invisible ms-0': !this.label || this.indeterminate,
-            }}
+            class="bq-progress__label"
             part="label"
-            style={{ fontVariant: 'tabular-nums' }}
           >
             <span>{this.value}%</span>
           </div>

--- a/packages/beeq/src/components/progress/scss/bq-progress.scss
+++ b/packages/beeq/src/components/progress/scss/bq-progress.scss
@@ -1,54 +1,140 @@
 /* -------------------------------------------------------------------------- */
-/*                        Progress styles                        */
+/*                               Progress styles                              */
 /* -------------------------------------------------------------------------- */
 
 @import './bq-progress.variables';
 
-@layer component {
-  @keyframes move-indeterminate {
-    0% {
-      inset-inline-start: 0;
-    }
-
-    100% {
-      inset-inline-start: calc(100% - var(--bq-progress-bar--indeterminateWidth));
-    }
+@keyframes move-indeterminate {
+  0% {
+    inset-inline-start: 0;
   }
 
-  .animate-indeterminate {
-    animation: move-indeterminate 1s linear 0s infinite alternate-reverse;
+  100% {
+    inset-inline-start: calc(100% - var(--bq-progress-bar--indeterminateWidth));
   }
 }
 
-.progress-bar {
-  @apply relative appearance-none bs-[--bq-progress-bar--height] is-full;
+/* ---------------------------------- Host ---------------------------------- */
+
+:host {
+  --_progress-bar-height: var(--bq-progress-bar--height);
+  --_progress-bar-indicator-color: var(--bq-progress-bar--indicatorColor);
+  --_progress-label-color: var(--bq-text--primary);
 }
 
-.progress-bar::-webkit-progress-bar {
-  @apply bg-[--bq-progress-bar--trackColor];
+/* ---------------------------------- Base ---------------------------------- */
+
+.bq-progress {
+  display: flex;
+  align-items: center;
 }
 
-.progress-bar::-webkit-progress-value {
-  @apply bg-[--bq-progress-bar--indicatorColor];
+/* ------------------------------- Structure -------------------------------- */
+
+.bq-progress__track {
+  position: relative;
+  display: flex;
+  align-items: center;
+  inline-size: 100%;
 }
 
-.progress-bar::-moz-progress-bar {
-  @apply animate-indeterminate bg-[--bq-progress-bar--indicatorColor];
+.bq-progress__bar {
+  position: relative;
+  appearance: none;
+  block-size: var(--_progress-bar-height);
+  inline-size: 100%;
+  border-radius: var(--bq-radius--full);
 }
 
-.progress-bar:indeterminate::-moz-progress-bar {
-  @apply bg-[--bq-progress-bar--trackColor];
+.bq-progress__tooltip {
+  position: absolute;
+  font-variant: tabular-nums;
 }
 
-.progress-bar.progress-bar__border-shape::-webkit-progress-value,
-.progress-bar.progress-bar__border-shape::-webkit-progress-bar {
-  @apply rounded-full;
+.bq-progress__tooltip-trigger {
+  position: absolute;
+  block-size: var(--bq-spacing-xs2);
+  inline-size: var(--bq-spacing-xs2);
 }
 
-.progress-bar__indeterminate {
-  @apply animate-indeterminate;
+.bq-progress__label {
+  visibility: hidden;
+  overflow: hidden;
+  inline-size: 0;
+  margin-inline-start: 0;
+  color: var(--_progress-label-color);
+  font-weight: var(--bq-font-weight--medium);
+  line-height: var(--bq-font-line-height--regular);
+  font-variant: tabular-nums;
 }
 
-.progress-bar.progress-bar__border-shape::-moz-progress-bar {
-  @apply animate-indeterminate rounded-full;
+/* -------------------------------- Variants -------------------------------- */
+
+:host([thickness='large']) {
+  --_progress-bar-height: var(--bq-spacing-xs);
+}
+
+:host([type='error']) {
+  --_progress-bar-indicator-color: var(--bq-ui--danger);
+  --_progress-label-color: var(--bq-text--danger);
+}
+
+:host([border-shape='square']) .bq-progress__bar,
+:host([border-shape='square']) .bq-progress__indeterminate {
+  border-radius: 0;
+}
+
+:host([border-shape='square']) .bq-progress__bar::-webkit-progress-value,
+:host([border-shape='square']) .bq-progress__bar::-webkit-progress-bar {
+  border-radius: 0;
+}
+
+:host([border-shape='square']) .bq-progress__bar::-moz-progress-bar {
+  border-radius: 0;
+}
+
+/* --------------------------------- States --------------------------------- */
+
+:host([label]:not([indeterminate])) .bq-progress__label {
+  visibility: visible;
+  overflow: visible;
+  inline-size: auto;
+  margin-inline-start: var(--bq-spacing-xs);
+}
+
+.bq-progress__indeterminate {
+  position: absolute;
+  block-size: var(--_progress-bar-height);
+  inline-size: var(--bq-progress-bar--indeterminateWidth);
+  background-color: var(--_progress-bar-indicator-color);
+  border-radius: var(--bq-radius--full);
+  animation: move-indeterminate 1s linear 0s infinite alternate-reverse;
+}
+
+/* ---------------------------------- Parts --------------------------------- */
+
+.bq-progress__tooltip::part(panel) {
+  position: absolute;
+}
+
+/* ----------------------------- Native / vendor ---------------------------- */
+
+.bq-progress__bar::-webkit-progress-bar {
+  background-color: var(--bq-progress-bar--trackColor);
+  border-radius: var(--bq-radius--full);
+}
+
+.bq-progress__bar::-webkit-progress-value {
+  background-color: var(--_progress-bar-indicator-color);
+  border-radius: var(--bq-radius--full);
+}
+
+.bq-progress__bar::-moz-progress-bar {
+  background-color: var(--_progress-bar-indicator-color);
+  border-radius: var(--bq-radius--full);
+  animation: move-indeterminate 1s linear 0s infinite alternate-reverse;
+}
+
+.bq-progress__bar:indeterminate::-moz-progress-bar {
+  background-color: var(--bq-progress-bar--trackColor);
 }

--- a/packages/beeq/src/components/progress/scss/bq-progress.variables.scss
+++ b/packages/beeq/src/components/progress/scss/bq-progress.variables.scss
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- */
-/*                   Progress custom properties                  */
+/*                         Progress custom properties                         */
 /* -------------------------------------------------------------------------- */
 
 :host {
@@ -9,8 +9,8 @@
    * @prop --bq-progress-bar--indicatorColor - The progress bar color (inside the track area)
    * @prop --bq-progress-bar--trackColor - The progress bar track area (the grey one)
    */
-  --bq-progress-bar--height: theme(height.1);
+  --bq-progress-bar--height: var(--bq-spacing-xs2);
   --bq-progress-bar--indeterminateWidth: 25%;
-  --bq-progress-bar--indicatorColor: theme(backgroundColor.ui.brand);
-  --bq-progress-bar--trackColor: theme(backgroundColor.ui.secondary);
+  --bq-progress-bar--indicatorColor: var(--bq-ui--brand);
+  --bq-progress-bar--trackColor: var(--bq-ui--secondary);
 }


### PR DESCRIPTION
## Description
Migrates `progress` from Tailwind runtime styling to native SCSS/CSS.

This removes Tailwind `@apply`, replaces `theme(...)` usage with BEEQ CSS custom properties, and moves visual Tailwind utility classes out of component render output into scoped semantic SCSS hooks.

Refactor and reorganize styles by responsibility.

Migrated components:
- `progress`

## Documentation
Generated component documentation was not changed.


## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE_OF_CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.
