### PR TITLE
fix(date-picker): use stable keys for calendar rows

### DIFF
--- a/packages/beeq/src/components/date-picker/components/CalendarMonthView.tsx
+++ b/packages/beeq/src/components/date-picker/components/CalendarMonthView.tsx
@@ -161,9 +161,9 @@ export const CalendarMonthView: FunctionalComponent<TCalendarMonthViewProps> = (
       role="grid"
       tabIndex={-1}
     >
-      {rows.map((row, rowIndex) => (
+      {rows.map((row) => (
         // biome-ignore lint/a11y/useFocusableInteractive: gridcell is a structural ARIA container; focus is managed by the child <button> via roving tabindex
-        <div class="bq-date-picker__month-row" role="row" key={`month-row-${rowIndex}`}>
+        <div class="bq-date-picker__month-row" role="row" key={`month-row-${row.map(({ month }) => month).join('-')}`}>
           {row.map(({ month, name }) => {
             const state = buildMonthCellState(year, month, focusedMonth, minISO, maxISO, effectiveSelection, type);
             return renderMonthCell({ month, name, state, onMonthSelect, onMonthFocus, onMonthHover });

--- a/packages/beeq/src/components/date-picker/components/CalendarYearView.tsx
+++ b/packages/beeq/src/components/date-picker/components/CalendarYearView.tsx
@@ -154,9 +154,9 @@ export const CalendarYearView: FunctionalComponent<TCalendarYearViewProps> = ({
       role="grid"
       tabIndex={-1}
     >
-      {rows.map((row, rowIndex) => (
+      {rows.map((row) => (
         // biome-ignore lint/a11y/useFocusableInteractive: gridcell is a structural ARIA container; focus is managed by the child <button> via roving tabindex
-        <div class="bq-date-picker__year-row" key={`year-row-${rowIndex}`} role="row">
+        <div class="bq-date-picker__year-row" key={`year-row-${row.join('-')}`} role="row">
           {row.map((year) => {
             const state = buildYearCellState(year, focusedYear, minISO, maxISO, effectiveSelection, type);
             return renderYearCell({ year, state, onYearSelect, onYearFocus, onYearHover });


### PR DESCRIPTION
## Description
Updated the date picker month and year grid row keys to use stable row values instead of array indexes, resolving SonarQube `typescript:S6479` warnings.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE_OF_CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.
