### PR TITLE
refactor(Datepicker): make ISO comparison logic more readable

### DIFF
--- a/packages/beeq/src/components/date-picker/helper/calendar.ts
+++ b/packages/beeq/src/components/date-picker/helper/calendar.ts
@@ -83,7 +83,10 @@ export const isSameYear = (a: Date | null, b: Date | null): boolean =>
   !!a && !!b && a.getFullYear() === b.getFullYear();
 
 /** ISO-string based comparison; safe for `YYYY-MM-DD`. */
-export const compareISO = (a: string, b: string): number => (a === b ? 0 : a < b ? -1 : 1);
+export const compareISO = (a: string, b: string): number => {
+  if (a === b) return 0;
+  return a < b ? -1 : 1;
+};
 
 /* -------------------------------------------------------------------------- */
 /*                                Month matrix                                */


### PR DESCRIPTION
## Description
Refactored the `compareISO` helper to remove the nested ternary and use an explicit comparison branch, resolving the SonarQube `typescript:S3358` warning without changing behavior.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE_OF_CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.
