### PR TITLE
refactor(option-group): migrate Tailwind styles to SCSS

### DIFF
--- a/packages/beeq/src/components/option-group/bq-option-group.tsx
+++ b/packages/beeq/src/components/option-group/bq-option-group.tsx
@@ -91,27 +91,19 @@ export class BqOptionGroup {
 
   render() {
     return (
-      <div class="bg-ui-primary">
-        <legend class="bq-option-group m-be-[--bq-option-group--gapY-list]" part="label">
-          <span class="option-group__prefix flex items-center" part="prefix">
+      <div class="bq-option-group">
+        <legend class="bq-option-group__header" part="label">
+          <span class="bq-option-group__prefix" part="prefix">
             <slot name="header-prefix" />
           </span>
-          <span
-            class="bq-option-group__label is-auto inline-block overflow-hidden text-ellipsis whitespace-nowrap"
-            part="label"
-          >
+          <span class="bq-option-group__label" part="label">
             <slot name="header-label" />
           </span>
           <span class="bq-option-group__suffix" part="suffix">
             <slot name="header-suffix" />
           </span>
         </legend>
-        <div
-          aria-label="Options"
-          class="bq-option-group__container flex flex-col gap-[--bq-option-group--gapY-list]"
-          part="group"
-          role="group"
-        >
+        <div aria-label="Options" class="bq-option-group__container" part="group" role="group">
           <slot />
         </div>
       </div>

--- a/packages/beeq/src/components/option-group/scss/bq-option-group.scss
+++ b/packages/beeq/src/components/option-group/scss/bq-option-group.scss
@@ -1,27 +1,57 @@
 /* -------------------------------------------------------------------------- */
-/*                                Option group styles                */
+/*                              Option group styles                           */
 /* -------------------------------------------------------------------------- */
 
 @import './bq-option-group.variables';
 
+/* ---------------------------------- Host ---------------------------------- */
+
 :host {
-  @apply block;
+  display: block;
 }
 
-.bq-option-group {
-  @apply flex overflow-hidden overflow-ellipsis;
-  @apply bg-[--bq-option-group--background] text-[length:--bq-option-group--font-size] leading-[--bq-option-group--line-height];
-  @apply pe-[--bq-option-group--label-padding-end] ps-[--bq-option-group--label-padding-start] p-b-[--bq-option-group--label-paddingY] p-i-[--bq-option-group--label-paddingY];
+/* ---------------------------------- Base ---------------------------------- */
 
-  &__child {
-    @apply flex items-center;
-  }
+.bq-option-group {
+  background-color: var(--bq-ui--primary);
+}
+
+/* ------------------------------- Structure -------------------------------- */
+
+.bq-option-group__header {
+  display: flex;
+  overflow: hidden;
+  margin-block-end: var(--bq-option-group--gapY-list);
+  padding-block: var(--bq-option-group--label-paddingY);
+  padding-inline: var(--bq-option-group--label-paddingY);
+  font-size: var(--bq-option-group--font-size);
+  line-height: var(--bq-option-group--line-height);
+  text-overflow: ellipsis;
+  background-color: var(--bq-option-group--background);
+}
+
+.bq-option-group__prefix {
+  display: flex;
+  align-items: center;
 }
 
 .bq-option-group__label {
-  @apply pe-[--bq-option-group--label-text-padding-end] ps-[--bq-option-group--label-text-padding-start];
+  display: inline-block;
+  overflow: hidden;
+  inline-size: auto;
+  padding-inline: var(--bq-option-group--label-text-padding-start) var(--bq-option-group--label-text-padding-end);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
+.bq-option-group__container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--bq-option-group--gapY-list);
+}
+
+/* ---------------------------------- Slots --------------------------------- */
+
 .bq-option-group__container ::slotted(bq-option) {
-  @apply ps-[--bq-option-group--container-padding-start];
+  padding-inline-start: var(--bq-option-group--container-padding-start);
 }

--- a/packages/beeq/src/components/option-group/scss/bq-option-group.variables.scss
+++ b/packages/beeq/src/components/option-group/scss/bq-option-group.variables.scss
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- */
-/*                          Option group custom properties           */
+/*                      Option group custom properties                       */
 /* -------------------------------------------------------------------------- */
 
 :host {
@@ -14,16 +14,16 @@
   * @prop --bq-option-group--label-text-padding-end - option group text within label padding start
   * @prop --bq-option-group--container-padding-start - option group container padding start
   */
-  --bq-option-group--background: theme(backgroundColor.ui.primary);
-  --bq-option-group--font-size: theme(fontSize.s);
-  --bq-option-group--line-height: theme(lineHeight.regular);
+  --bq-option-group--background: var(--bq-ui--primary);
+  --bq-option-group--font-size: var(--bq-font-size--s);
+  --bq-option-group--line-height: var(--bq-font-line-height--regular);
 
-  --bq-option-group--label-padding-start: theme(spacing.s);
-  --bq-option-group--label-padding-end: theme(spacing.s);
-  --bq-option-group--label-paddingY: theme(spacing.xs);
+  --bq-option-group--label-padding-start: var(--bq-spacing-s);
+  --bq-option-group--label-padding-end: var(--bq-spacing-s);
+  --bq-option-group--label-paddingY: var(--bq-spacing-xs);
 
-  --bq-option-group--label-text-padding-start: theme(spacing.s);
-  --bq-option-group--label-text-padding-end: theme(spacing.s);
+  --bq-option-group--label-text-padding-start: var(--bq-spacing-s);
+  --bq-option-group--label-text-padding-end: var(--bq-spacing-s);
 
-  --bq-option-group--container-padding-start: theme(spacing.xxl);
+  --bq-option-group--container-padding-start: var(--bq-spacing-xxl);
 }

--- a/tools/src/executors/icons/lib/extract.ts
+++ b/tools/src/executors/icons/lib/extract.ts
@@ -1,6 +1,6 @@
 import { basename, join, posix } from 'node:path';
 
-import * as decompress from 'decompress';
+import decompress, { type File as DecompressFile } from 'decompress';
 import fsExtra from 'fs-extra';
 
 import { asIconsError, IconsExecutorError } from './errors.ts';
@@ -108,10 +108,10 @@ const extractIcons = async ({
 }: ExtractOptions): Promise<ExtractResult> => {
   const matchPrefix = posix.join(svgFolder, assetsFolder);
 
-  let entries: decompress.File[];
+  let entries: DecompressFile[];
   try {
     entries = await decompress(archiveFilePath, {
-      filter: (entry: decompress.File) => isTargetIconEntry(entry.path, entry.type, matchPrefix),
+      filter: (entry: DecompressFile) => isTargetIconEntry(entry.path, entry.type, matchPrefix),
     });
   } catch (error) {
     throw asIconsError('extract', `Failed to read archive "${archiveFilePath}"`, error, { archiveFilePath });


### PR DESCRIPTION
## Description
Migrates `option-group` from Tailwind runtime styling to native SCSS/CSS.

This removes Tailwind `@apply` and moves visual Tailwind utility classes out of component render output into scoped semantic SCSS hooks.

Refactor and reorganize styles by responsibility.

Migrated components:
- `option-group`

## Documentation
Generated component documentation was not changed.

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.