### PR TITLE
fix(icons): import decompress as callable default

### DIFF
--- a/tools/src/executors/icons/lib/extract.ts
+++ b/tools/src/executors/icons/lib/extract.ts
@@ -1,6 +1,6 @@
 import { basename, join, posix } from 'node:path';
 
-import * as decompress from 'decompress';
+import decompress, { type File as DecompressFile } from 'decompress';
 import fsExtra from 'fs-extra';
 
 import { asIconsError, IconsExecutorError } from './errors.ts';
@@ -108,10 +108,10 @@ const extractIcons = async ({
 }: ExtractOptions): Promise<ExtractResult> => {
   const matchPrefix = posix.join(svgFolder, assetsFolder);
 
-  let entries: decompress.File[];
+  let entries: DecompressFile[];
   try {
     entries = await decompress(archiveFilePath, {
-      filter: (entry: decompress.File) => isTargetIconEntry(entry.path, entry.type, matchPrefix),
+      filter: (entry: DecompressFile) => isTargetIconEntry(entry.path, entry.type, matchPrefix),
     });
   } catch (error) {
     throw asIconsError('extract', `Failed to read archive "${archiveFilePath}"`, error, { archiveFilePath });


### PR DESCRIPTION
```md
## Description

Fixes the `beeq:icons` build failure by importing `decompress` as its callable default export.

The previous namespace import made the compiled/runtime value non-callable in the Nx executor path, causing:

```text
[extract] Failed to read archive ".../2b75f3ad12b4.zip": decompress is not a function
```


## Checklist
- [x] I have read the [[CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md)](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [[CODE OF_CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md)](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.
```