### PR TITLE
refactor(radio-group): migrate Tailwind styles to SCSS

### DIFF
--- a/packages/beeq/src/components/radio-group/__tests__/bq-radio-group.e2e.tsx
+++ b/packages/beeq/src/components/radio-group/__tests__/bq-radio-group.e2e.tsx
@@ -53,10 +53,11 @@ describe('bq-radio-group', () => {
       </bq-radio-group>,
     );
     const bqRadioGroup = root as HTMLBqRadioGroupElement;
+    const group = bqRadioGroup.shadowRoot?.querySelector<HTMLElement>('[part="group"]') as HTMLElement;
 
-    expect(bqRadioGroup.shadowRoot?.querySelector('[part="base"]')).toHaveClass('has-fieldset');
     expect(getTextContent(getLabelSlot(bqRadioGroup), { recurse: true })).toBe('Radio group label');
-    expect(bqRadioGroup.shadowRoot?.querySelector('[part="group"]')).toHaveClass('bq-radio-group--horizontal');
+    expect(bqRadioGroup).toHaveAttribute('fieldset');
+    expect(getComputedStyle(group).flexDirection).toBe('row');
   });
 
   it('should become valid only after one option is selected when required', async () => {
@@ -323,10 +324,13 @@ describe('bq-radio-group', () => {
     const bqRadioGroup = root as HTMLBqRadioGroupElement;
 
     await setProps({ orientation: 'invalid' });
+    const group = bqRadioGroup.shadowRoot?.querySelector<HTMLElement>('[part="group"]') as HTMLElement;
 
     expect(bqRadioGroup.orientation).toBe('vertical');
-    expect(bqRadioGroup.shadowRoot?.querySelector('[part="group"]')).toHaveClass('bq-radio-group--vertical');
-    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      '[BQ-RADIO-GROUP] Please notice that "orientation" should be one of horizontal|vertical',
+    );
+    expect(getComputedStyle(group).flexDirection).toBe('column');
 
     warn.mockRestore();
   });

--- a/packages/beeq/src/components/radio-group/bq-radio-group.tsx
+++ b/packages/beeq/src/components/radio-group/bq-radio-group.tsx
@@ -451,14 +451,14 @@ export class BqRadioGroup {
           aria-controls="bq-radiogroup"
           aria-disabled={this.disabled}
           aria-labelledby="bq-radio-group__label"
-          class={{ 'bq-radio-group': true, 'has-fieldset': this.fieldset }}
+          class="bq-radio-group"
           disabled={this.disabled}
           part="base"
         >
           <legend part="label">
             <slot id="bq-radiogroup__label" name="label" />
           </legend>
-          <div class={`bq-radio-group--${this.orientation}`} part="group">
+          <div part="group">
             <slot id="bq-radiogroup" onSlotchange={this.handleSlotChange} />
           </div>
         </fieldset>

--- a/packages/beeq/src/components/radio-group/scss/bq-radio-group.scss
+++ b/packages/beeq/src/components/radio-group/scss/bq-radio-group.scss
@@ -1,23 +1,35 @@
 /* -------------------------------------------------------------------------- */
-/*                                Radio group styles                               */
+/*                              Radio group styles                             */
 /* -------------------------------------------------------------------------- */
 
+/* ---------------------------------- Host ---------------------------------- */
+
 :host {
-  @apply inline-block;
+  display: inline-block;
 }
 
+/* ---------------------------------- Base ---------------------------------- */
+
 .bq-radio-group {
-  @apply m-b-0 m-i-0;
+  margin-block: 0;
+  margin-inline: 0;
+}
 
-  &:not(.has-fieldset) {
-    @apply border-0 m-b-0 m-i-0 p-b-0 p-i-0;
-  }
+/* ------------------------------- Structure -------------------------------- */
 
-  &--horizontal {
-    @apply flex;
-  }
+[part='group'] {
+  display: flex;
+  flex-direction: column;
+}
 
-  &--vertical {
-    @apply flex flex-col;
-  }
+/* -------------------------------- Variants -------------------------------- */
+
+:host(:not([fieldset])) .bq-radio-group {
+  padding-block: 0;
+  padding-inline: 0;
+  border: 0;
+}
+
+:host([orientation='horizontal']) [part='group'] {
+  flex-direction: row;
 }


### PR DESCRIPTION
## Description
Migrates `radio-group` from Tailwind runtime styling to native SCSS/CSS.

This removes Tailwind `@apply` and moves visual Tailwind utility classes out of component render output into scoped semantic SCSS hooks.

Refactor and reorganize styles by responsibility.

Migrated components:
- `radio-group`

## Documentation
Generated component documentation was not changed.

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.