### PR TITLE
refactor(alert): migrate Tailwind styles to native SCSS

### DIFF
--- a/packages/beeq/src/components/alert/__tests__/bq-alert.e2e.tsx
+++ b/packages/beeq/src/components/alert/__tests__/bq-alert.e2e.tsx
@@ -219,14 +219,14 @@ describe('bq-alert', () => {
 
   it('should hide the icon when hideIcon is true', async () => {
     const { root } = await render(
-      <bq-alert type="info" hide-icon>
+      <bq-alert open type="info" hide-icon>
         Alert title
       </bq-alert>,
     );
 
-    const iconOutline = root.shadowRoot.querySelector('[part="icon-outline"]');
+    const iconOutline = root.shadowRoot.querySelector<HTMLElement>('[part="icon-outline"]');
     expect(iconOutline).not.toBeNull();
-    expect(iconOutline).toHaveClass('!hidden');
+    expect(getComputedStyle(iconOutline).display).toBe('none');
   });
 
   it('should close when the close button is clicked', async () => {

--- a/packages/beeq/src/components/alert/bq-alert.tsx
+++ b/packages/beeq/src/components/alert/bq-alert.tsx
@@ -293,19 +293,18 @@ export class BqAlert {
     return (
       <Host
         aria-hidden={!this.open ? 'true' : 'false'}
-        class={{ 'is-sticky': this.sticky }}
         hidden={!this.open ? 'true' : 'false'}
         role="alert"
         style={style}
       >
         <div
-          class={{ [`bq-alert bq-alert__${this.type}`]: true, 'is-sticky': this.sticky }}
-          data-transition-enter="transition ease-out duration-300"
-          data-transition-enter-end="opacity-100"
-          data-transition-enter-start="opacity-0"
-          data-transition-leave="transition ease-in duration-200"
-          data-transition-leave-end="opacity-0"
-          data-transition-leave-start="opacity-100"
+          class="bq-alert"
+          data-transition-enter="is-entering"
+          data-transition-enter-end="is-enter-end"
+          data-transition-enter-start="is-enter-start"
+          data-transition-leave="is-leaving"
+          data-transition-leave-end="is-leave-end"
+          data-transition-leave-start="is-leave-start"
           part="wrapper"
           ref={(div) => {
             this.alertElement = div;
@@ -316,7 +315,7 @@ export class BqAlert {
             <bq-button
               appearance="text"
               border="s"
-              class="absolute end-s [&::part(label)]:inline-flex"
+              class="bq-alert__close-button"
               exportparts="button:btn-close"
               label="Close alert"
               onBqClick={() => this.hide()}
@@ -329,33 +328,21 @@ export class BqAlert {
             </bq-button>
           )}
           {/* ICON */}
-          <div
-            class={{
-              [`bq-alert__icon--${this.type} me-s flex text-left align-top`]: true,
-              '!hidden': this.hideIcon,
-            }}
-            part="icon-outline"
-          >
+          <div class="bq-alert__icon" part="icon-outline">
             <slot name="icon">
               {this.type !== 'default' && <bq-icon exportparts="base,svg" name={this.iconName} part="icon" />}
             </slot>
           </div>
           {/* MAIN */}
-          <div class="flex flex-col items-start gap-[--bq-alert--content-footer-gap]" part="main">
-            <div class="flex flex-col gap-[--bq-alert--title-body-gap]" part="content">
+          <div class="bq-alert__main" part="main">
+            <div class="bq-alert__content" part="content">
               {/* TITLE */}
-              <div
-                class={{
-                  'title-font font-semibold text-primary leading-regular': true,
-                  'flex items-center': this.sticky,
-                }}
-                part="title"
-              >
+              <div class="bq-alert__title" part="title">
                 <slot />
               </div>
               {/* BODY */}
               <div
-                class={{ 'text-primary text-s leading-regular': true, '!hidden': !this.hasContent }}
+                class={{ 'bq-alert__body': true, 'is-empty': !this.hasContent }}
                 part="body"
                 ref={(div) => {
                   this.bodyElem = div;
@@ -366,7 +353,7 @@ export class BqAlert {
             </div>
             {/* FOOTER */}
             <div
-              class={{ 'flex items-start gap-xs': true, '!hidden': !this.hasFooter }}
+              class={{ 'bq-alert__footer': true, 'is-empty': !this.hasFooter }}
               part="footer"
               ref={(div) => {
                 this.footerElem = div;

--- a/packages/beeq/src/components/alert/scss/bq-alert.scss
+++ b/packages/beeq/src/components/alert/scss/bq-alert.scss
@@ -2,10 +2,12 @@
 /*                        Alert styles                        */
 /* -------------------------------------------------------------------------- */
 
-@import './bq-alert.variables';
+@use 'sass:meta';
+@layer bq.reset, bq.tokens, bq.themes, bq.base, bq.utilities, bq.overrides,
+  bq-alert.tokens, bq-alert.base, bq-alert.structure, bq-alert.variants, bq-alert.states;
 
-:host {
-  @apply block;
+@layer bq-alert.tokens {
+  @include meta.load-css('./bq-alert.variables');
 }
 
 :host(.is-hidden) {

--- a/packages/beeq/src/components/alert/scss/bq-alert.scss
+++ b/packages/beeq/src/components/alert/scss/bq-alert.scss
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- */
-/*                        Alert styles                        */
+/*                                Alert styles                                */
 /* -------------------------------------------------------------------------- */
 
 @use 'sass:meta';
@@ -10,70 +10,174 @@
   @include meta.load-css('./bq-alert.variables');
 }
 
-:host(.is-hidden) {
-  @apply hidden;
+/* ---------------------------------- Host ---------------------------------- */
+
+@layer bq-alert.base {
+  :host {
+    --_alert-background: var(--bq-alert--background-default);
+    --_alert-border-color: var(--bq-alert--border-default);
+    --_alert-icon-color: var(--bq-alert--icon-color-default);
+
+    display: block;
+  }
+
+  :host(.is-hidden) {
+    display: none;
+  }
 }
 
-:host(.is-sticky) {
-  @apply fixed inset-0 z-[var(--bq-alert--z-index)] is-full inset-bs-0;
+@layer bq-alert.variants {
+  :host([sticky]) {
+    position: fixed;
+    inset-block: 0;
+    inset-inline: 0;
+    inline-size: 100%;
+    z-index: var(--bq-alert--z-index);
+  }
+}
 
+/* ---------------------------------- Base ---------------------------------- */
+
+@layer bq-alert.base {
   .bq-alert {
-    @apply items-center justify-center rounded-none;
+    position: relative;
+    display: flex;
+    min-inline-size: var(--bq-alert--min-width);
+    padding-block: var(--bq-alert--padding);
+    padding-inline: var(--bq-alert--padding);
+    background-color: var(--_alert-background);
+    border-color: var(--_alert-border-color);
+    border-radius: var(--bq-alert--border-radius);
+    border-style: var(--bq-alert--border-style);
+    border-width: var(--bq-alert--border-width);
+    transition-duration: 150ms;
+    transition-property: all;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   }
 }
 
-.bq-alert {
-  @apply relative flex transition-all min-is-[--bq-alert--min-width] p-b-[--bq-alert--padding] p-i-[--bq-alert--padding];
-  @apply rounded-[var(--bq-alert--border-radius)] border-[length:--bq-alert--border-width];
+/* ------------------------------- Structure -------------------------------- */
 
-  border-style: var(--bq-alert--border-style);
-}
-
-/**
- * Set the alert background and border color based on the type value selected
- */
-
-.bq-alert__default {
-  @apply border-[color:--bq-alert--border-default] bg-[color:--bq-alert--background-default];
-}
-
-.bq-alert__error {
-  @apply border-[color:--bq-alert--border-error] bg-[color:--bq-alert--background-error];
-}
-
-.bq-alert__info {
-  @apply border-[color:--bq-alert--border-info] bg-[color:--bq-alert--background-info];
-}
-
-.bq-alert__success {
-  @apply border-[color:--bq-alert--border-success] bg-[color:--bq-alert--background-success];
-}
-
-.bq-alert__warning {
-  @apply border-[color:--bq-alert--border-warning] bg-[color:--bq-alert--background-warning];
-}
-
-/**
- * Set the alert icon color based on the type value selected
- */
-.bq-alert__icon {
-  &--default {
-    @apply text-[color:--bq-alert--icon-color-default];
+@layer bq-alert.structure {
+  .bq-alert__close-button {
+    position: absolute;
+    inset-inline-end: var(--bq-spacing-s);
   }
 
-  &--error {
-    @apply text-[color:--bq-alert--icon-color-error];
+  .bq-alert__close-button::part(label) {
+    display: inline-flex;
   }
 
-  &--info {
-    @apply text-[color:--bq-alert--icon-color-info];
+  .bq-alert__icon {
+    display: flex;
+    margin-inline-end: var(--bq-spacing-s);
+    color: var(--_alert-icon-color);
+    text-align: left;
+    vertical-align: top;
   }
 
-  &--success {
-    @apply text-[color:--bq-alert--icon-color-success];
+  .bq-alert__main {
+    display: flex;
+    flex-direction: column;
+    gap: var(--bq-alert--content-footer-gap);
+    align-items: flex-start;
   }
 
-  &--warning {
-    @apply text-[color:--bq-alert--icon-color-warning];
+  .bq-alert__content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--bq-alert--title-body-gap);
+  }
+
+  .bq-alert__title {
+    color: var(--bq-text--primary);
+    font-weight: var(--bq-font-weight--semibold);
+    line-height: var(--bq-font-line-height--regular);
+  }
+
+  .bq-alert__body {
+    color: var(--bq-text--primary);
+    font-size: var(--bq-font-size--s);
+    line-height: var(--bq-font-line-height--regular);
+  }
+
+  .bq-alert__footer {
+    display: flex;
+    gap: var(--bq-spacing-xs);
+    align-items: flex-start;
+  }
+}
+
+/* -------------------------------- Variants -------------------------------- */
+
+@layer bq-alert.variants {
+  :host([type='error']) {
+    --_alert-background: var(--bq-alert--background-error);
+    --_alert-border-color: var(--bq-alert--border-error);
+    --_alert-icon-color: var(--bq-alert--icon-color-error);
+  }
+
+  :host([type='info']) {
+    --_alert-background: var(--bq-alert--background-info);
+    --_alert-border-color: var(--bq-alert--border-info);
+    --_alert-icon-color: var(--bq-alert--icon-color-info);
+  }
+
+  :host([type='success']) {
+    --_alert-background: var(--bq-alert--background-success);
+    --_alert-border-color: var(--bq-alert--border-success);
+    --_alert-icon-color: var(--bq-alert--icon-color-success);
+  }
+
+  :host([type='warning']) {
+    --_alert-background: var(--bq-alert--background-warning);
+    --_alert-border-color: var(--bq-alert--border-warning);
+    --_alert-icon-color: var(--bq-alert--icon-color-warning);
+  }
+
+  :host([sticky]) .bq-alert {
+    align-items: center;
+    justify-content: center;
+    border-radius: 0;
+  }
+
+  :host([sticky]) .bq-alert__title {
+    display: flex;
+    align-items: center;
+  }
+}
+
+/* --------------------------------- States --------------------------------- */
+
+@layer bq-alert.states {
+  :host([hide-icon]) .bq-alert__icon,
+  .bq-alert__body.is-empty,
+  .bq-alert__footer.is-empty {
+    display: none;
+  }
+
+  .bq-alert.is-entering,
+  .bq-alert.is-leaving {
+    transition-property: opacity;
+  }
+
+  .bq-alert.is-entering {
+    transition-duration: 300ms;
+    transition-timing-function: ease-out;
+  }
+
+  .bq-alert.is-leaving {
+    transition-duration: 200ms;
+    transition-timing-function: ease-in;
+  }
+
+  .bq-alert.is-enter-start,
+  .bq-alert.is-leave-end {
+    opacity: 0;
+  }
+
+  .bq-alert.is-enter-end,
+  .bq-alert.is-leave-start {
+    opacity: 1;
   }
 }

--- a/packages/beeq/src/components/alert/scss/bq-alert.variables.scss
+++ b/packages/beeq/src/components/alert/scss/bq-alert.variables.scss
@@ -32,34 +32,34 @@
    * @prop --bq-alert--min-width: The alert min width
    */
 
-  --bq-alert--background: theme(colors.ui.secondary);
+  --bq-alert--background: var(--bq-ui--secondary);
 
-  --bq-alert--border-radius: theme(borderRadius.s);
+  --bq-alert--border-radius: var(--bq-radius--s);
 
-  --bq-alert--content-footer-gap: theme(spacing.s);
-  --bq-alert--title-body-gap: theme(spacing.s);
+  --bq-alert--content-footer-gap: var(--bq-spacing-s);
+  --bq-alert--title-body-gap: var(--bq-spacing-s);
 
-  --bq-alert--background-info: theme(backgroundColor.ui.brand-alt);
-  --bq-alert--background-success: theme(backgroundColor.ui.success-alt);
-  --bq-alert--background-warning: theme(backgroundColor.ui.warning-alt);
-  --bq-alert--background-error: theme(backgroundColor.ui.danger-alt);
-  --bq-alert--background-default: theme(backgroundColor.ui.primary);
+  --bq-alert--background-info: var(--bq-ui--brand-alt);
+  --bq-alert--background-success: var(--bq-ui--success-alt);
+  --bq-alert--background-warning: var(--bq-ui--warning-alt);
+  --bq-alert--background-error: var(--bq-ui--danger-alt);
+  --bq-alert--background-default: var(--bq-ui--primary);
 
-  --bq-alert--border-info: theme(borderColor.brand);
-  --bq-alert--border-success: theme(borderColor.success);
-  --bq-alert--border-warning: theme(borderColor.warning);
-  --bq-alert--border-error: theme(borderColor.danger);
-  --bq-alert--border-default: theme(borderColor.secondary);
-  --bq-alert--border-width: theme(borderWidth.s);
+  --bq-alert--border-info: var(--bq-stroke--brand);
+  --bq-alert--border-success: var(--bq-stroke--success);
+  --bq-alert--border-warning: var(--bq-stroke--warning);
+  --bq-alert--border-error: var(--bq-stroke--danger);
+  --bq-alert--border-default: var(--bq-stroke--secondary);
+  --bq-alert--border-width: var(--bq-stroke-s);
   --bq-alert--border-style: solid;
 
-  --bq-alert--icon-color-info: theme(fill.brand);
-  --bq-alert--icon-color-success: theme(fill.success);
-  --bq-alert--icon-color-warning: theme(fill.warning);
-  --bq-alert--icon-color-error: theme(fill.danger);
-  --bq-alert--icon-color-default: theme(fill.primary);
+  --bq-alert--icon-color-info: var(--bq-icon--brand);
+  --bq-alert--icon-color-success: var(--bq-icon--success);
+  --bq-alert--icon-color-warning: var(--bq-icon--warning);
+  --bq-alert--icon-color-error: var(--bq-icon--danger);
+  --bq-alert--icon-color-default: var(--bq-icon--primary);
 
-  --bq-alert--padding: theme(padding.s);
+  --bq-alert--padding: var(--bq-spacing-s);
 
   --bq-alert--min-width: 320px;
 }


### PR DESCRIPTION
## Description
Migrates `alert` from Tailwind runtime styling to native SCSS/CSS.

This removes Tailwind `@apply` and moves visual Tailwind utility classes out of component render output into scoped semantic SCSS hooks.

Refactor and reorganize styles by responsibility.

Migrated components:
- `alert`

## Documentation
Generated component documentation was not changed.

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.