### PR TITLE
refactor(toast): migrate Tailwind styles to SCSS

### DIFF
--- a/packages/beeq/src/components/toast/__tests__/bq-toast.e2e.tsx
+++ b/packages/beeq/src/components/toast/__tests__/bq-toast.e2e.tsx
@@ -20,28 +20,28 @@ describe('bq-toast', () => {
     const { root } = await render(<bq-toast />);
 
     expect(root).toHaveAttribute('aria-hidden');
-    expect(root).toHaveClass('is-hidden');
+    expect(root).toEqualAttribute('hidden', 'true');
   });
 
   it('should render as hidden with `open="false"`', async () => {
     const { root } = await render(<bq-toast open={false} />);
 
     expect(root).toEqualAttribute('aria-hidden', 'true');
-    expect(root).toHaveClass('is-hidden');
+    expect(root).toEqualAttribute('hidden', 'true');
   });
 
   it('should render as open', async () => {
     const { root } = await render(<bq-toast open />);
 
     expect(root).toEqualAttribute('aria-hidden', 'false');
-    expect(root).not.toHaveClass('is-hidden');
+    expect(root).toEqualAttribute('hidden', 'false');
   });
 
   it('should render as open with `open="true"`', async () => {
     const { root } = await render(<bq-toast open={true} />);
 
     expect(root).toEqualAttribute('aria-hidden', 'false');
-    expect(root).not.toHaveClass('is-hidden');
+    expect(root).toEqualAttribute('hidden', 'false');
   });
 
   it('should display text', async () => {
@@ -93,10 +93,14 @@ describe('bq-toast', () => {
   });
 
   it('should hide the icon when `hide-icon` is set', async () => {
-    const { root } = await render(<bq-toast hide-icon>Text</bq-toast>);
+    await render(
+      <bq-toast hide-icon open>
+        Text
+      </bq-toast>,
+    );
 
-    const iconHolder = root.shadowRoot.querySelector('[part="icon"]');
-    expect(iconHolder).toHaveClass('!hidden');
+    const style = computedStyle('bq-toast >>> [part="icon"]', ['display']);
+    expect(style).toEqual({ display: 'none' });
   });
 
   it('should emit bqShow event when shown', async () => {

--- a/packages/beeq/src/components/toast/bq-toast.tsx
+++ b/packages/beeq/src/components/toast/bq-toast.tsx
@@ -262,20 +262,10 @@ export class BqToast {
   // ===================================
 
   render() {
-    const style = {
-      ...(this.border && { '--bq-toast--border-radius': `var(--bq-radius--${this.border})` }),
-    };
-
     return (
-      <Host
-        aria-hidden={!this.open ? 'true' : 'false'}
-        class={{ 'is-hidden': !this.open }}
-        hidden={!this.open ? 'true' : 'false'}
-        role="status"
-        style={style}
-      >
+      <Host aria-hidden={!this.open ? 'true' : 'false'} hidden={!this.open ? 'true' : 'false'} role="status">
         <output class="bq-toast" part="wrapper">
-          <div class={{ [`bq-toast--icon ${this.type}`]: true, '!hidden': this.hideIcon }} part="icon">
+          <div class="bq-toast__icon" part="icon">
             <slot name="icon">
               <bq-icon exportparts="base,svg" name={this.iconName} size="24" slot="icon" />
             </slot>

--- a/packages/beeq/src/components/toast/scss/bq-toast.scss
+++ b/packages/beeq/src/components/toast/scss/bq-toast.scss
@@ -2,50 +2,111 @@
 /*                                Toast styles                                */
 /* -------------------------------------------------------------------------- */
 
-@import './bq-toast.variables';
+@use 'sass:meta';
+@layer bq.reset, bq.tokens, bq.themes, bq.base, bq.utilities, bq.overrides,
+  bq-toast.tokens, bq-toast.base, bq-toast.structure, bq-toast.variants, bq-toast.states;
 
-:host {
-  @apply inline-block;
+@layer bq-toast.tokens {
+  @include meta.load-css('bq-toast.variables');
 }
 
-:host(.is-hidden) {
-  @apply hidden;
+/* ---------------------------------- Host ---------------------------------- */
+
+@layer bq-toast.base {
+  :host {
+    --_toast-border-radius: var(--bq-toast--border-radius);
+    --_toast-icon-color: var(--bq-toast--icon-color-info);
+
+    display: inline-block;
+  }
 }
 
-.bq-toast {
-  @include animation-slide-in;
-  @apply flex items-center gap-[--bq-toast--gap] p-b-[--bq-toast--padding-y] p-i-[--bq-toast--padding-x];
-  @apply rounded-[--bq-toast--border-radius] bg-[--bq-toast--background] shadow-[shadow:--bq-toast--box-shadow];
-  @apply border-[length:--bq-toast--border-width] border-[color:--bq-toast--border-color];
+/* ---------------------------------- Base ---------------------------------- */
 
-  border-style: var(--bq-toast--border-style);
+@layer bq-toast.base {
+  .bq-toast {
+    @include animation-slide-in;
+
+    display: flex;
+    gap: var(--bq-toast--gap);
+    align-items: center;
+    padding-block: var(--bq-toast--padding-y);
+    padding-inline: var(--bq-toast--padding-x);
+    background-color: var(--bq-toast--background);
+    border-color: var(--bq-toast--border-color);
+    border-radius: var(--_toast-border-radius);
+    border-style: var(--bq-toast--border-style);
+    border-width: var(--bq-toast--border-width);
+    box-shadow: var(--bq-toast--box-shadow);
+  }
 }
 
-.bq-toast--icon {
-  @apply flex;
+/* ------------------------------- Structure -------------------------------- */
 
-  &.info {
-    @apply text-[--bq-toast--icon-color-info];
+@layer bq-toast.structure {
+  .bq-toast__icon {
+    display: flex;
+    color: var(--_toast-icon-color);
+  }
+}
+
+/* -------------------------------- Variants -------------------------------- */
+
+@layer bq-toast.variants {
+  :host([border='none']) {
+    --_toast-border-radius: var(--bq-radius--none);
   }
 
-  &.success {
-    @apply text-[--bq-toast--icon-color-success];
+  :host([border='xs2']) {
+    --_toast-border-radius: var(--bq-radius--xs2);
   }
 
-  &.alert {
-    @apply text-[--bq-toast--icon-color-alert];
+  :host([border='xs']) {
+    --_toast-border-radius: var(--bq-radius--xs);
   }
 
-  &.error {
-    @apply text-[--bq-toast--icon-color-error];
+  :host([border='m']) {
+    --_toast-border-radius: var(--bq-radius--m);
   }
 
-  &.loading {
+  :host([border='l']) {
+    --_toast-border-radius: var(--bq-radius--l);
+  }
+
+  :host([border='full']) {
+    --_toast-border-radius: var(--bq-radius--full);
+  }
+
+  :host([type='success']) {
+    --_toast-icon-color: var(--bq-toast--icon-color-success);
+  }
+
+  :host([type='alert']) {
+    --_toast-icon-color: var(--bq-toast--icon-color-alert);
+  }
+
+  :host([type='error']) {
+    --_toast-icon-color: var(--bq-toast--icon-color-error);
+  }
+
+  :host([type='loading']) {
+    --_toast-icon-color: var(--bq-toast--icon-color-loading);
+  }
+
+  :host([type='loading']) .bq-toast__icon {
     @include animation-spin;
-    @apply text-[--bq-toast--icon-color-loading];
   }
 
-  &.custom {
-    @apply text-[--bq-toast--icon-color-custom];
+  :host([type='custom']) {
+    --_toast-icon-color: var(--bq-toast--icon-color-custom);
+  }
+}
+
+/* --------------------------------- States --------------------------------- */
+
+@layer bq-toast.states {
+  :host(:not([open])),
+  :host([hide-icon]) .bq-toast__icon {
+    display: none;
   }
 }

--- a/packages/beeq/src/components/toast/scss/bq-toast.variables.scss
+++ b/packages/beeq/src/components/toast/scss/bq-toast.variables.scss
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- */
-/*                          Toast custom properties           */
+/*                          Toast custom properties                           */
 /* -------------------------------------------------------------------------- */
 
 :host {
@@ -21,22 +21,22 @@
    * @prop --bq-toast--icon-color-custom - Toast icon color when type is 'custom'
    */
 
-  --bq-toast--background: theme(backgroundColor.ui.primary);
-  --bq-toast--box-shadow: theme(boxShadow.l);
+  --bq-toast--background: var(--bq-ui--primary);
+  --bq-toast--box-shadow: var(--bq-box-shadow--l);
 
-  --bq-toast--padding-y: theme(spacing.s);
-  --bq-toast--padding-x: theme(spacing.m);
-  --bq-toast--gap: theme(spacing.xs);
+  --bq-toast--padding-y: var(--bq-spacing-s);
+  --bq-toast--padding-x: var(--bq-spacing-m);
+  --bq-toast--gap: var(--bq-spacing-xs);
 
-  --bq-toast--border-radius: theme(borderRadius.s);
+  --bq-toast--border-radius: var(--bq-radius--s);
   --bq-toast--border-width: unset;
   --bq-toast--border-style: none;
-  --bq-toast--border-color: theme(colors.transparent);
+  --bq-toast--border-color: transparent;
 
-  --bq-toast--icon-color-info: theme(fill.brand);
-  --bq-toast--icon-color-success: theme(fill.success);
-  --bq-toast--icon-color-alert: theme(fill.warning);
-  --bq-toast--icon-color-error: theme(fill.danger);
-  --bq-toast--icon-color-loading: theme(fill.brand);
-  --bq-toast--icon-color-custom: theme(fill.primary);
+  --bq-toast--icon-color-info: var(--bq-icon--brand);
+  --bq-toast--icon-color-success: var(--bq-icon--success);
+  --bq-toast--icon-color-alert: var(--bq-icon--warning);
+  --bq-toast--icon-color-error: var(--bq-icon--danger);
+  --bq-toast--icon-color-loading: var(--bq-icon--brand);
+  --bq-toast--icon-color-custom: var(--bq-icon--primary);
 }


### PR DESCRIPTION
## Description
Migrates `toast` from Tailwind runtime styling to native SCSS/CSS.

This removes Tailwind `@apply` and `theme(...)`, and moves visual Tailwind utility classes out of component render output into scoped semantic SCSS hooks.

Refactor and reorganize styles by responsibility.

Migrated components:
- `toast`

## Documentation
Generated component documentation was not changed.

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.