### PR TITLE
refactor(tag): load variables through token layer

### DIFF
--- a/packages/beeq/src/components/tag/scss/bq-tag.scss
+++ b/packages/beeq/src/components/tag/scss/bq-tag.scss
@@ -2,9 +2,13 @@
 /*                                 Tag styles                                 */
 /* -------------------------------------------------------------------------- */
 
-@import './bq-tag.variables';
+@use 'sass:meta';
 @layer bq.reset, bq.tokens, bq.themes, bq.base, bq.utilities, bq.overrides,
   bq-tag.tokens, bq-tag.base, bq-tag.structure, bq-tag.variants, bq-tag.states, bq-tag.parts;
+
+@layer bq-tag.tokens {
+  @include meta.load-css('./bq-tag.variables');
+}
 
 /* ---------------------------------- Host ---------------------------------- */
 


### PR DESCRIPTION
## Description
Updates `tag` to load component variables through the `bq-tag.tokens` layer.

This replaces the top-level variables `@import` with `sass:meta.load-css()`, keeping the token declarations inside the component token layer while avoiding SonarCloud `@import` position issues.

Updated components:
- `tag`

## Documentation
Generated component documentation was not changed.

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.