### PR TITLE
refactor(breadcrumb-item): migrate Tailwind styles to SCSS

### DIFF
--- a/packages/beeq/src/components/breadcrumb-item/__tests__/bq-breadcrumb-item.e2e.tsx
+++ b/packages/beeq/src/components/breadcrumb-item/__tests__/bq-breadcrumb-item.e2e.tsx
@@ -30,7 +30,7 @@ describe('bq-breadcrumb-item', () => {
   it('should render `button` tag', async () => {
     const { root } = await render(<bq-breadcrumb-item>Home</bq-breadcrumb-item>);
 
-    const element = root.shadowRoot.querySelector('.breadcrumb-item');
+    const element = root.shadowRoot.querySelector('[part="item"]');
 
     expect(element?.tagName.toLowerCase()).toBe('button');
   });
@@ -38,7 +38,7 @@ describe('bq-breadcrumb-item', () => {
   it('should render `a` tag', async () => {
     const { root } = await render(<bq-breadcrumb-item href="https://example.com/">Home</bq-breadcrumb-item>);
 
-    const element = root.shadowRoot.querySelector('.breadcrumb-item');
+    const element = root.shadowRoot.querySelector('[part="item"]');
 
     expect(element?.tagName.toLowerCase()).toBe('a');
   });
@@ -50,7 +50,7 @@ describe('bq-breadcrumb-item', () => {
       </bq-breadcrumb-item>,
     );
 
-    const element = root.shadowRoot?.querySelector<HTMLAnchorElement>('.breadcrumb-item');
+    const element = root.shadowRoot?.querySelector<HTMLAnchorElement>('[part="item"]');
 
     expect(element.target).toBe('_blank');
     expect(element.rel).toBe('noreferrer noopener');
@@ -58,7 +58,7 @@ describe('bq-breadcrumb-item', () => {
 
   it('should emit focus, click, and blur events', async () => {
     const { root, spyOnEvent } = await render(<bq-breadcrumb-item>Home</bq-breadcrumb-item>);
-    const element = root.shadowRoot?.querySelector<HTMLButtonElement>('.breadcrumb-item');
+    const element = root.shadowRoot?.querySelector<HTMLButtonElement>('[part="item"]');
 
     const bqFocus = spyOnEvent('bqFocus');
     const bqClick = spyOnEvent('bqClick');

--- a/packages/beeq/src/components/breadcrumb-item/bq-breadcrumb-item.tsx
+++ b/packages/beeq/src/components/breadcrumb-item/bq-breadcrumb-item.tsx
@@ -135,9 +135,9 @@ export class BqBreadcrumbItem {
     const TagElem = isLink ? 'a' : 'button';
 
     return (
-      <div class="flex items-center" part="base">
+      <div class="bq-breadcrumb-item" part="base">
         <TagElem
-          class="breadcrumb-item"
+          class="bq-breadcrumb-item__control"
           href={isLink ? this.href : undefined}
           onBlur={this.onBlur}
           onClick={this.onClick}
@@ -146,12 +146,12 @@ export class BqBreadcrumbItem {
           rel={isLink && this.target ? 'noreferrer noopener' : undefined}
           target={isLink ? this.target : undefined}
         >
-          <span class="flex items-center gap-xs2" part="content">
+          <span class="bq-breadcrumb-item__content" part="content">
             <slot></slot>
           </span>
         </TagElem>
         {/* @internal use only */}
-        <span class="breadcrumb-separator" part="separator">
+        <span class="bq-breadcrumb-item__separator" part="separator">
           <slot name="separator"></slot>
         </span>
       </div>

--- a/packages/beeq/src/components/breadcrumb-item/scss/bq-breadcrumb-item.scss
+++ b/packages/beeq/src/components/breadcrumb-item/scss/bq-breadcrumb-item.scss
@@ -1,28 +1,82 @@
 /* -------------------------------------------------------------------------- */
-/*                                Breadcrumb item styles                */
+/*                            Breadcrumb item styles                          */
 /* -------------------------------------------------------------------------- */
 
-@import './bq-breadcrumb-item.variables';
+@use 'sass:meta';
+@layer bq.reset, bq.tokens, bq.themes, bq.base, bq.public, bq.overrides,
+  bq-breadcrumb-item.tokens, bq-breadcrumb-item.base, bq-breadcrumb-item.states;
 
-:host([aria-current='page']) {
-  .breadcrumb-item {
-    @apply text-[color:--bq-breadcrumb-item--text-color-current];
+@layer bq-breadcrumb-item.tokens {
+  @include meta.load-css('./bq-breadcrumb-item.variables');
+}
+
+@layer bq-breadcrumb-item.base {
+  /* ---------------------------------- Host ---------------------------------- */
+
+  :host {
+    display: inline-block;
+  }
+
+  /* ---------------------------------- Base ---------------------------------- */
+
+  .bq-breadcrumb-item {
+    display: flex;
+    align-items: center;
+  }
+
+  .bq-breadcrumb-item__control {
+    padding-block: var(--bq-breadcrumb-item--paddingY);
+    padding-inline: var(--bq-breadcrumb-item--padding-start) var(--bq-breadcrumb-item--padding-end);
+    color: var(--bq-breadcrumb-item--text-color);
+    font-weight: var(--bq-font-weight--regular);
+    font-size: var(--bq-breadcrumb-item--text-size);
+    line-height: var(--bq-breadcrumb-item--line-height);
+    text-decoration: none;
+    background-color: var(--bq-breadcrumb-item--background);
+    border-color: var(--bq-breadcrumb-item--border-color);
+    border-style: var(--bq-breadcrumb-item--border-style);
+    border-width: var(--bq-breadcrumb-item--border-width);
+    border-radius: var(--bq-breadcrumb-item--border-radius);
+    box-shadow: var(--bq-breadcrumb-item--box-shadow);
+    cursor: pointer;
+    transition-timing-function: ease-in-out;
+    transition-duration: 300ms;
+    transition-property: color;
+  }
+
+  /* ------------------------------- Structure -------------------------------- */
+
+  .bq-breadcrumb-item__content {
+    display: flex;
+    align-items: center;
+    gap: var(--bq-spacing-xs2);
+  }
+
+  .bq-breadcrumb-item__separator {
+    display: flex;
+    align-items: center;
+    padding-inline: var(--bq-breadcrumb-item--padding-start-separator)
+      var(--bq-breadcrumb-item--padding-end-separator);
+    font-size: var(--bq-breadcrumb-item--text-size-separator);
   }
 }
 
-.breadcrumb-item {
-  @apply border-[length:--bq-breadcrumb-item--border-width] border-[color:--bq-breadcrumb-item--border-color];
-  @apply rounded-[--bq-breadcrumb-item--border-radius] bg-[--bq-breadcrumb-item--background] shadow-[shadow:--bq-breadcrumb-item--box-shadow];
-  @apply pe-[--bq-breadcrumb-item--padding-end] ps-[--bq-breadcrumb-item--padding-start] p-b-[--bq-breadcrumb-item--paddingY];
-  @apply text-[length:--bq-breadcrumb-item--text-size] font-regular leading-[--bq-breadcrumb-item--line-height] text-[color:--bq-breadcrumb-item--text-color];
-  @apply focus-visible:focus hover:text-hover-brand active:outline-none;
-  @apply transition-colors duration-300 ease-in-out;
-  @apply cursor-pointer no-underline;
+@layer bq-breadcrumb-item.states {
+  /* --------------------------------- States --------------------------------- */
 
-  border-style: var(--bq-avatar--border-style);
-}
+  :host([aria-current='page']) .bq-breadcrumb-item__control {
+    color: var(--bq-breadcrumb-item--text-color-current);
+  }
 
-.breadcrumb-separator {
-  @apply flex items-center text-[length:--bq-breadcrumb-item--text-size-separator];
-  @apply pe-[--bq-breadcrumb-item--padding-end-separator] ps-[--bq-breadcrumb-item--padding-start-separator];
+  .bq-breadcrumb-item__control:hover {
+    @include bq-color-mix(color, var(--bq-text--brand), hover);
+  }
+
+  .bq-breadcrumb-item__control:focus-visible {
+    @include bq-focus-ring;
+  }
+
+  .bq-breadcrumb-item__control:active {
+    outline: none;
+  }
 }

--- a/packages/beeq/src/components/breadcrumb-item/scss/bq-breadcrumb-item.variables.scss
+++ b/packages/beeq/src/components/breadcrumb-item/scss/bq-breadcrumb-item.variables.scss
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- */
-/*                          Breadcrumb item custom properties           */
+/*                      Breadcrumb item custom properties                     */
 /* -------------------------------------------------------------------------- */
 
 :host {
@@ -22,24 +22,24 @@
   * @prop --bq-breadcrumb-item--padding-end-separator: Padding end of the breadcrumb item separator.
   */
 
-  --bq-breadcrumb-item--background: theme(backgroundColor.transparent);
+  --bq-breadcrumb-item--background: transparent;
   --bq-breadcrumb-item--box-shadow: none;
 
-  --bq-breadcrumb-item--border-color: theme(borderColor.transparent);
+  --bq-breadcrumb-item--border-color: transparent;
   --bq-breadcrumb-item--border-style: none;
-  --bq-breadcrumb-item--border-width: theme(borderWidth.s);
-  --bq-breadcrumb-item--border-radius: theme(borderRadius.s);
+  --bq-breadcrumb-item--border-width: var(--bq-stroke-s);
+  --bq-breadcrumb-item--border-radius: var(--bq-radius--s);
 
-  --bq-breadcrumb-item--line-height: theme(lineHeight.regular);
-  --bq-breadcrumb-item--text-color: theme(textColor.secondary);
-  --bq-breadcrumb-item--text-color-current: theme(textColor.brand);
-  --bq-breadcrumb-item--text-size: theme(fontSize.s);
-  --bq-breadcrumb-item--text-size-separator: theme(fontSize.xs);
+  --bq-breadcrumb-item--line-height: var(--bq-font-line-height--regular);
+  --bq-breadcrumb-item--text-color: var(--bq-text--secondary);
+  --bq-breadcrumb-item--text-color-current: var(--bq-text--brand);
+  --bq-breadcrumb-item--text-size: var(--bq-font-size--s);
+  --bq-breadcrumb-item--text-size-separator: var(--bq-font-size--xs);
 
-  --bq-breadcrumb-item--padding-start: theme(spacing.xs2);
-  --bq-breadcrumb-item--padding-end: theme(spacing.xs2);
-  --bq-breadcrumb-item--paddingY: theme(spacing.xs);
+  --bq-breadcrumb-item--padding-start: var(--bq-spacing-xs2);
+  --bq-breadcrumb-item--padding-end: var(--bq-spacing-xs2);
+  --bq-breadcrumb-item--paddingY: var(--bq-spacing-xs);
 
-  --bq-breadcrumb-item--padding-start-separator: theme(spacing.xs2);
-  --bq-breadcrumb-item--padding-end-separator: theme(spacing.xs2);
+  --bq-breadcrumb-item--padding-start-separator: var(--bq-spacing-xs2);
+  --bq-breadcrumb-item--padding-end-separator: var(--bq-spacing-xs2);
 }


### PR DESCRIPTION
## Description
Migrates `breadcrumb-item` from Tailwind runtime styling to native SCSS/CSS.

This removes Tailwind `@apply` and `theme(...)`, and moves visual Tailwind utility classes out of component render output into scoped semantic SCSS hooks.

Refactor and reorganize styles by responsibility.

Migrated components:
- `breadcrumb-item`

## Documentation
Generated component documentation was not changed.

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.