### PR TITLE
refactor(tooltip): migrate Tailwind styles to SCSS

### DIFF
--- a/packages/beeq/src/components/tooltip/__tests__/bq-tooltip.e2e.tsx
+++ b/packages/beeq/src/components/tooltip/__tests__/bq-tooltip.e2e.tsx
@@ -285,7 +285,7 @@ describe('bq-tooltip', () => {
       </div>,
     );
     unmountFn = unmount;
-    const arrow = root.querySelector('bq-tooltip').shadowRoot.querySelector('.bq-tooltip--arrow');
+    const arrow = root.querySelector('bq-tooltip').shadowRoot.querySelector('.bq-tooltip__arrow');
     expect(arrow).toBeNull();
   });
 

--- a/packages/beeq/src/components/tooltip/bq-tooltip.tsx
+++ b/packages/beeq/src/components/tooltip/bq-tooltip.tsx
@@ -286,7 +286,7 @@ export class BqTooltip {
 
   render() {
     return (
-      <div class="bq-tooltip relative" part="base">
+      <div class="bq-tooltip" part="base">
         {/* TRIGGER */}
         {/**
          * NOTE: We could use a native HTML button as trigger container, but it causes issues with
@@ -297,7 +297,7 @@ export class BqTooltip {
         {/** biome-ignore lint/a11y/noStaticElementInteractions: bypass the "Static Elements should not be interactive." rule */}
         {/** biome-ignore lint/a11y/useKeyWithClickEvents: bypass the "Enforce to have the onClick mouse event with the onKeyUp, the onKeyDown, or the onKeyPress keyboard event." rule */}
         <div
-          class="bq-tooltip--trigger"
+          class="bq-tooltip__trigger"
           onClick={this.handleTriggerOnClick}
           onFocusin={this.handleTriggerFocusin}
           onFocusout={this.handleTriggerFocusout}
@@ -313,7 +313,7 @@ export class BqTooltip {
         {/* PANEL */}
         <div
           aria-hidden={this.isHidden}
-          class="bq-tooltip--panel"
+          class="bq-tooltip__panel"
           hidden={this.isHidden}
           part="panel"
           ref={(el: HTMLDivElement) => {
@@ -323,7 +323,7 @@ export class BqTooltip {
         >
           {!this.hideArrow && (
             <div
-              class="bq-tooltip--arrow"
+              class="bq-tooltip__arrow"
               ref={(el: HTMLDivElement) => {
                 this.arrow = el;
               }}

--- a/packages/beeq/src/components/tooltip/scss/bq-tooltip.scss
+++ b/packages/beeq/src/components/tooltip/scss/bq-tooltip.scss
@@ -1,25 +1,51 @@
 /* -------------------------------------------------------------------------- */
-/*                               Tooltip styles                               */
+/*                               Tooltip Styles                               */
 /* -------------------------------------------------------------------------- */
 
 @import './bq-tooltip.variables';
 
-.bq-tooltip--panel {
-  @include animation-fade-in;
-  @apply pointer-events-none fixed z-[--bq-tooltip--z-index] box-border bg-[--bq-tooltip--background-color];
-  @apply is-[--bq-tooltip--width] max-is-[--bq-tooltip--max-width] p-b-[--bq-tooltip--paddingY] p-i-[--bq-tooltip--paddingX];
-  @apply text-[length:--bq-tooltip--font-size] leading-[--bq-tooltip--line-height] text-[color:--bq-tooltip--text-color];
-  @apply rounded-[--bq-tooltip--border-radius] border-[length:--bq-tooltip--border-width] border-[color:--bq-tooltip--border-color];
-  @apply shadow-[shadow:--bq-tooltip--box-shadow];
+/* ---------------------------------- Base ---------------------------------- */
+
+.bq-tooltip {
+  position: relative;
 }
 
-.bq-tooltip--arrow {
-  &,
-  &::before {
-    @apply absolute -z-[1] bs-2 is-2;
-  }
+/* ------------------------------- Structure -------------------------------- */
 
-  &::before {
-    @apply start-0 rotate-45 bg-[--bq-tooltip--background-color] content-empty inset-bs-0;
-  }
+.bq-tooltip__panel {
+  @include animation-fade-in;
+
+  position: fixed;
+  z-index: var(--bq-tooltip--z-index);
+  box-sizing: border-box;
+  inline-size: var(--bq-tooltip--width);
+  max-inline-size: var(--bq-tooltip--max-width);
+  padding-block: var(--bq-tooltip--paddingY);
+  padding-inline: var(--bq-tooltip--paddingX);
+  color: var(--bq-tooltip--text-color);
+  font-size: var(--bq-tooltip--font-size);
+  line-height: var(--bq-tooltip--line-height);
+  pointer-events: none;
+  background-color: var(--bq-tooltip--background-color);
+  border-color: var(--bq-tooltip--border-color);
+  border-radius: var(--bq-tooltip--border-radius);
+  border-style: var(--bq-tooltip--border-style);
+  border-width: var(--bq-tooltip--border-width);
+  box-shadow: var(--bq-tooltip--box-shadow);
+}
+
+.bq-tooltip__arrow,
+.bq-tooltip__arrow::before {
+  position: absolute;
+  z-index: -1;
+  block-size: 0.5rem;
+  inline-size: 0.5rem;
+}
+
+.bq-tooltip__arrow::before {
+  inset-block: 0;
+  inset-inline-start: 0;
+  background-color: var(--bq-tooltip--background-color);
+  content: '';
+  transform: rotate(45deg);
 }

--- a/packages/beeq/src/components/tooltip/scss/bq-tooltip.variables.scss
+++ b/packages/beeq/src/components/tooltip/scss/bq-tooltip.variables.scss
@@ -17,23 +17,23 @@
    * @prop --bq-tooltip--border-width - Tooltip border width
    * @prop --bq-tooltip--z-index: Tooltip z-index
    */
-  --bq-tooltip--background-color: theme(backgroundColor.ui.inverse);
-  --bq-tooltip--box-shadow: theme(boxShadow.m);
+  --bq-tooltip--background-color: var(--bq-ui--inverse);
+  --bq-tooltip--box-shadow: var(--bq-box-shadow--m);
 
-  --bq-tooltip--font-size: theme(fontSize.m);
-  --bq-tooltip--line-height: theme(lineHeight.regular);
-  --bq-tooltip--text-color: theme(textColor.inverse);
+  --bq-tooltip--font-size: var(--bq-font-size--m);
+  --bq-tooltip--line-height: var(--bq-font-line-height--regular);
+  --bq-tooltip--text-color: var(--bq-text--inverse);
 
-  --bq-tooltip--paddingX: theme(padding.xs);
-  --bq-tooltip--paddingY: theme(padding.xs2);
+  --bq-tooltip--paddingX: var(--bq-spacing-xs);
+  --bq-tooltip--paddingY: var(--bq-spacing-xs2);
 
-  --bq-tooltip--border-color: theme(colors.transparent);
-  --bq-tooltip--border-radius: theme(borderRadius.s);
+  --bq-tooltip--border-color: transparent;
+  --bq-tooltip--border-radius: var(--bq-radius--s);
   --bq-tooltip--border-style: none;
   --bq-tooltip--border-width: unset;
 
   --bq-tooltip--max-width: 320px;
   --bq-tooltip--width: max-content;
 
-  --bq-tooltip--z-index: theme(zIndex.10);
+  --bq-tooltip--z-index: 10;
 }


### PR DESCRIPTION
## Description
Migrates `tooltip` from Tailwind runtime styling to native SCSS/CSS.

This removes Tailwind visual utility classes from component render output and moves styling into scoped semantic SCSS hooks.

Refactor and reorganize styles by responsibility.

Migrated components:
- `tooltip`

## Documentation
Generated component documentation was not changed.

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE_OF_CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.