### PR TITLE
fix(Tooltip): prevent positioning drift in scrollable containers

### DIFF
--- a/packages/beeq/package.json
+++ b/packages/beeq/package.json
@@ -14,8 +14,7 @@
   "dependencies": {
     "@floating-ui/core": "^1.7.4",
     "@floating-ui/dom": "^1.7.5",
-    "@stencil/core": "^4.41.3",
-    "composed-offset-position": "0.0.6"
+    "@stencil/core": "^4.41.3"
   },
   "repository": {
     "type": "git",

--- a/packages/beeq/package.json
+++ b/packages/beeq/package.json
@@ -10,9 +10,7 @@
   "collection:main": "./dist/collection/index.js",
   "customElements": "./custom-elements.json",
   "unpkg": "./dist/beeq/beeq.esm.js",
-  "files": [
-    "dist/"
-  ],
+  "files": ["dist/"],
   "dependencies": {
     "@floating-ui/core": "^1.7.4",
     "@floating-ui/dom": "^1.7.5",

--- a/packages/beeq/package.json
+++ b/packages/beeq/package.json
@@ -12,8 +12,8 @@
   "unpkg": "./dist/beeq/beeq.esm.js",
   "files": ["dist/"],
   "dependencies": {
-    "@floating-ui/core": "^1.7.4",
-    "@floating-ui/dom": "^1.7.5",
+    "@floating-ui/core": "^1.8.0",
+    "@floating-ui/dom": "^1.8.0",
     "@stencil/core": "^4.41.3"
   },
   "repository": {

--- a/packages/beeq/package.json
+++ b/packages/beeq/package.json
@@ -10,11 +10,14 @@
   "collection:main": "./dist/collection/index.js",
   "customElements": "./custom-elements.json",
   "unpkg": "./dist/beeq/beeq.esm.js",
-  "files": ["dist/"],
+  "files": [
+    "dist/"
+  ],
   "dependencies": {
     "@floating-ui/core": "^1.7.4",
     "@floating-ui/dom": "^1.7.5",
-    "@stencil/core": "^4.41.3"
+    "@stencil/core": "^4.41.3",
+    "composed-offset-position": "0.0.6"
   },
   "repository": {
     "type": "git",

--- a/packages/beeq/src/components/panel/bq-panel.tsx
+++ b/packages/beeq/src/components/panel/bq-panel.tsx
@@ -106,7 +106,7 @@ export class BqPanel {
   onPropChange() {
     if (!isClient()) return;
 
-    this.floatingUI?.init({ ...this.options });
+    this.floatingUI?.configure({ ...this.options });
   }
 
   // Events section
@@ -137,7 +137,7 @@ export class BqPanel {
   disconnectedCallback() {
     if (!isClient()) return;
 
-    this.floatingUI?.destroy();
+    this.floatingUI?.stop();
 
     // Ensure scroll lock is removed if the component is disconnected while the panel is open.
     if (this.open && !this.disableScrollLock) {
@@ -163,7 +163,7 @@ export class BqPanel {
   private showPanel() {
     if (!isClient()) return;
 
-    this.floatingUI?.update();
+    this.floatingUI?.reposition();
 
     // Lock the body scroll if the disableScrollLock prop is not true.
     if (!this.disableScrollLock) {

--- a/packages/beeq/src/components/panel/bq-panel.tsx
+++ b/packages/beeq/src/components/panel/bq-panel.tsx
@@ -136,6 +136,7 @@ export class BqPanel {
 
   connectedCallback() {
     if (!this.floatingUI || !this.open) return;
+
     this.showPanel();
   }
 

--- a/packages/beeq/src/components/panel/bq-panel.tsx
+++ b/packages/beeq/src/components/panel/bq-panel.tsx
@@ -134,6 +134,11 @@ export class BqPanel {
     this.handleOpenChange();
   }
 
+  connectedCallback() {
+    if (!this.floatingUI || !this.open) return;
+    this.showPanel();
+  }
+
   disconnectedCallback() {
     if (!isClient()) return;
 
@@ -163,7 +168,7 @@ export class BqPanel {
   private showPanel() {
     if (!isClient()) return;
 
-    this.floatingUI?.reposition();
+    this.floatingUI?.start();
 
     // Lock the body scroll if the disableScrollLock prop is not true.
     if (!this.disableScrollLock) {
@@ -173,6 +178,7 @@ export class BqPanel {
 
   private async hidePanel() {
     this.open = false;
+    this.floatingUI?.stop();
 
     // Unlock the body scroll if the disableScrollLock prop is not true.
     if (isClient() && !this.disableScrollLock) {

--- a/packages/beeq/src/components/tooltip/__tests__/bq-tooltip.e2e.tsx
+++ b/packages/beeq/src/components/tooltip/__tests__/bq-tooltip.e2e.tsx
@@ -19,6 +19,12 @@ const mkTooltip = () => (
 // userEvent.unhover() doesn't help — it targets document.body center, same coordinates.
 // Vitest exposes no API to move the cursor to arbitrary coords, so we use CDP directly.
 const moveOff = () => cdp().send('Input.dispatchMouseEvent', { type: 'mouseMoved', x: 0, y: 0 });
+const expectPanelVisibility = (panel: Element, visible: boolean) => {
+  expect(panel).toHaveAttribute('aria-hidden', String(!visible));
+  expect(panel.matches(':popover-open')).toBe(visible);
+};
+const getArrowOffset = (arrow: HTMLElement) =>
+  [arrow.style.top, arrow.style.right, arrow.style.bottom, arrow.style.left].find((value) => value === '-4px');
 let unmountFn: (() => void) | undefined;
 
 afterEach(async () => {
@@ -47,7 +53,7 @@ describe('bq-tooltip', () => {
     unmountFn = unmount;
 
     const panel = root.querySelector('bq-tooltip').shadowRoot.querySelector('[part="panel"]');
-    expect(panel).toHaveAttribute('hidden');
+    expectPanelVisibility(panel, false);
   });
 
   it('should be visible on hover', async () => {
@@ -58,11 +64,11 @@ describe('bq-tooltip', () => {
     const panel = tooltip.shadowRoot.querySelector('[part="panel"]');
     const trigger = tooltip.shadowRoot.querySelector('[part="trigger"]');
 
-    expect(panel).toHaveAttribute('hidden');
+    expectPanelVisibility(panel, false);
     await userEvent.hover(trigger);
     await waitForChanges();
 
-    expect(panel).not.toHaveAttribute('hidden');
+    expectPanelVisibility(panel, true);
   });
 
   it('should not be visible on hover if defaultPrevented', async () => {
@@ -78,7 +84,7 @@ describe('bq-tooltip', () => {
     await userEvent.hover(trigger);
     await waitForChanges();
 
-    expect(panel).toHaveAttribute('hidden');
+    expectPanelVisibility(panel, false);
     expect(bqHoverIn).toHaveReceivedEventTimes(1);
   });
 
@@ -93,12 +99,12 @@ describe('bq-tooltip', () => {
     await userEvent.hover(trigger);
     await waitForChanges();
 
-    expect(panel).not.toHaveAttribute('hidden');
+    expectPanelVisibility(panel, true);
 
     await moveOff();
     await waitForChanges();
 
-    expect(panel).toHaveAttribute('hidden');
+    expectPanelVisibility(panel, false);
   });
 
   it('should emit bqHoverIn and bqHoverOut events', async () => {
@@ -129,17 +135,17 @@ describe('bq-tooltip', () => {
 
     tooltip.displayOn = 'click';
     await waitForChanges();
-    expect(panel).toHaveAttribute('hidden');
+    expectPanelVisibility(panel, false);
 
     // Hover should NOT show it
     await userEvent.hover(trigger);
     await waitForChanges();
-    expect(panel).toHaveAttribute('hidden');
+    expectPanelVisibility(panel, false);
 
     // Click should show it
     await userEvent.click(trigger);
     await waitForChanges();
-    expect(panel).not.toHaveAttribute('hidden');
+    expectPanelVisibility(panel, true);
   });
 
   it('should not be visible on click if defaultPrevented', async () => {
@@ -152,13 +158,13 @@ describe('bq-tooltip', () => {
 
     tooltip.displayOn = 'click';
     await waitForChanges();
-    expect(panel).toHaveAttribute('hidden');
+    expectPanelVisibility(panel, false);
 
     tooltip.addEventListener('bqClick', (e: Event) => e.preventDefault(), { once: true });
     await userEvent.click(trigger);
     await waitForChanges();
 
-    expect(panel).toHaveAttribute('hidden');
+    expectPanelVisibility(panel, false);
   });
 
   it('should toggle visibility on repeated clicks when displayOn is click', async () => {
@@ -174,11 +180,11 @@ describe('bq-tooltip', () => {
 
     await userEvent.click(trigger);
     await waitForChanges();
-    expect(panel).not.toHaveAttribute('hidden');
+    expectPanelVisibility(panel, true);
 
     await userEvent.click(trigger);
     await waitForChanges();
-    expect(panel).toHaveAttribute('hidden');
+    expectPanelVisibility(panel, false);
   });
 
   it('should hide when Escape key is pressed when displayOn is click', async () => {
@@ -193,11 +199,11 @@ describe('bq-tooltip', () => {
 
     await userEvent.click(trigger);
     await waitForChanges();
-    expect(panel).not.toHaveAttribute('hidden');
+    expectPanelVisibility(panel, true);
 
     await userEvent.keyboard('{Escape}');
     await waitForChanges();
-    expect(panel).toHaveAttribute('hidden');
+    expectPanelVisibility(panel, false);
   });
 
   it('should show and hide via public methods', async () => {
@@ -206,15 +212,15 @@ describe('bq-tooltip', () => {
     const tooltip = root.querySelector('bq-tooltip') as HTMLBqTooltipElement;
     const panel = tooltip.shadowRoot.querySelector('[part="panel"]');
 
-    expect(panel).toHaveAttribute('hidden');
+    expectPanelVisibility(panel, false);
 
     await tooltip.show();
     await waitForChanges();
-    expect(panel).not.toHaveAttribute('hidden');
+    expectPanelVisibility(panel, true);
 
     await tooltip.hide();
     await waitForChanges();
-    expect(panel).toHaveAttribute('hidden');
+    expectPanelVisibility(panel, false);
   });
 
   it('should show in specified position', async () => {
@@ -251,7 +257,40 @@ describe('bq-tooltip', () => {
     unmountFn = unmount;
 
     const panel = root.querySelector('bq-tooltip').shadowRoot.querySelector('[part="panel"]');
-    expect(panel).not.toHaveAttribute('hidden');
+    expectPanelVisibility(panel, true);
+    expect(panel).toHaveAttribute('popover', 'manual');
+    expect(getComputedStyle(panel).position).toBe('absolute');
+  });
+
+  it('should retain the fixed-position fallback without the Popover API', async () => {
+    const prototype = HTMLElement.prototype;
+    const showPopover = Object.getOwnPropertyDescriptor(prototype, 'showPopover');
+    const hidePopover = Object.getOwnPropertyDescriptor(prototype, 'hidePopover');
+    let unmount: (() => void) | undefined;
+
+    Object.defineProperty(prototype, 'showPopover', { configurable: true, value: undefined });
+    Object.defineProperty(prototype, 'hidePopover', { configurable: true, value: undefined });
+
+    try {
+      const result = await render(mkTooltip());
+      unmount = result.unmount;
+
+      const tooltip = result.root.querySelector('bq-tooltip') as HTMLBqTooltipElement;
+      const panel = tooltip.shadowRoot.querySelector('[part="panel"]');
+
+      expect(panel).not.toHaveAttribute('popover');
+      expect(panel).toHaveAttribute('hidden');
+      expect(getComputedStyle(panel).position).toBe('fixed');
+
+      await tooltip.show();
+      await result.waitForChanges();
+      expect(panel).not.toHaveAttribute('hidden');
+      expect(panel).toHaveAttribute('aria-hidden', 'false');
+    } finally {
+      unmount?.();
+      if (showPopover) Object.defineProperty(prototype, 'showPopover', showPopover);
+      if (hidePopover) Object.defineProperty(prototype, 'hidePopover', hidePopover);
+    }
   });
 
   it('should stay visible when `always-visible` is set and hide() is called', async () => {
@@ -268,11 +307,27 @@ describe('bq-tooltip', () => {
     const tooltip = root.querySelector('bq-tooltip') as HTMLBqTooltipElement;
     const panel = tooltip.shadowRoot.querySelector('[part="panel"]');
 
-    expect(panel).not.toHaveAttribute('hidden');
+    expectPanelVisibility(panel, true);
 
     await tooltip.hide();
     await waitForChanges();
-    expect(panel).not.toHaveAttribute('hidden');
+    expectPanelVisibility(panel, true);
+  });
+
+  it('should react to `always-visible` changes', async () => {
+    const { root, unmount, waitForChanges } = await render(mkTooltip());
+    unmountFn = unmount;
+
+    const tooltip = root.querySelector('bq-tooltip') as HTMLBqTooltipElement;
+    const panel = tooltip.shadowRoot.querySelector('[part="panel"]');
+
+    tooltip.alwaysVisible = true;
+    await waitForChanges();
+    expectPanelVisibility(panel, true);
+
+    tooltip.alwaysVisible = false;
+    await waitForChanges();
+    expectPanelVisibility(panel, false);
   });
 
   it('should not render the arrow when `hide-arrow` is set', async () => {
@@ -287,6 +342,112 @@ describe('bq-tooltip', () => {
     unmountFn = unmount;
     const arrow = root.querySelector('bq-tooltip').shadowRoot.querySelector('.bq-tooltip--arrow');
     expect(arrow).toBeNull();
+  });
+
+  it('should replace the arrow reference when `hide-arrow` changes', async () => {
+    const { root, unmount, waitForChanges } = await render(
+      <div>
+        <bq-tooltip always-visible>
+          Yuhu! A tooltip!
+          <bq-button slot="trigger">Hover me!</bq-button>
+        </bq-tooltip>
+      </div>,
+    );
+    unmountFn = unmount;
+
+    const tooltip = root.querySelector('bq-tooltip') as HTMLBqTooltipElement;
+    const initialArrow = tooltip.shadowRoot.querySelector<HTMLElement>('.bq-tooltip--arrow');
+    await expect.poll(() => getArrowOffset(initialArrow)).toBe('-4px');
+
+    tooltip.hideArrow = true;
+    await waitForChanges();
+    expect(tooltip.shadowRoot.querySelector('.bq-tooltip--arrow')).toBeNull();
+
+    tooltip.hideArrow = false;
+    await waitForChanges();
+    await waitForStable(tooltip);
+
+    const replacementArrow = tooltip.shadowRoot.querySelector<HTMLElement>('.bq-tooltip--arrow');
+    expect(replacementArrow).not.toBe(initialArrow);
+    await expect.poll(() => getArrowOffset(replacementArrow)).toBe('-4px');
+  });
+
+  it('should clear the inline width when `same-width` is disabled', async () => {
+    const { root, unmount, waitForChanges } = await render(
+      <div>
+        <bq-tooltip always-visible>
+          Yuhu! A tooltip!
+          <bq-button slot="trigger">A wider trigger label</bq-button>
+        </bq-tooltip>
+      </div>,
+    );
+    unmountFn = unmount;
+
+    const tooltip = root.querySelector('bq-tooltip') as HTMLBqTooltipElement;
+    const panel = tooltip.shadowRoot.querySelector<HTMLElement>('[part="panel"]');
+    const trigger = tooltip.shadowRoot.querySelector<HTMLElement>('[part="trigger"]');
+
+    tooltip.sameWidth = true;
+    await waitForChanges();
+    await waitForStable(tooltip);
+    expect(parseFloat(panel.style.width)).toBeCloseTo(trigger.getBoundingClientRect().width, 0);
+
+    tooltip.sameWidth = false;
+    await waitForChanges();
+    expect(panel.style.width).toBe('');
+  });
+
+  it('should retain its trigger offset while a transformed ancestor scrolls', async () => {
+    const { root, unmount } = await render(
+      <div data-scroll-container style={{ height: '160px', overflow: 'auto', transform: 'translateZ(0)' }}>
+        <div style={{ height: '700px', paddingTop: '350px' }}>
+          <bq-tooltip always-visible placement="top">
+            Yuhu! A tooltip!
+            <bq-button slot="trigger">Hover me!</bq-button>
+          </bq-tooltip>
+        </div>
+      </div>,
+    );
+    unmountFn = unmount;
+
+    const scrollContainer = root as HTMLElement;
+    const tooltip = root.querySelector('bq-tooltip');
+    const panel = tooltip.shadowRoot.querySelector<HTMLElement>('[part="panel"]');
+    const trigger = tooltip.shadowRoot.querySelector<HTMLElement>('[part="trigger"]');
+
+    await waitForStable(tooltip);
+    const initialOffset = trigger.getBoundingClientRect().top - panel.getBoundingClientRect().bottom;
+
+    scrollContainer.scrollTop = 200;
+    scrollContainer.dispatchEvent(new Event('scroll'));
+    await expect
+      .poll(() => trigger.getBoundingClientRect().top - panel.getBoundingClientRect().bottom)
+      .toBeCloseTo(initialOffset, 0);
+  });
+
+  it('should resume positioning after reconnection', async () => {
+    const { root, unmount } = await render(
+      <div data-parent>
+        <bq-tooltip visible>
+          Yuhu! A tooltip!
+          <bq-button slot="trigger">Hover me!</bq-button>
+        </bq-tooltip>
+      </div>,
+    );
+    unmountFn = unmount;
+
+    const parent = root as HTMLElement;
+    const tooltip = root.querySelector('bq-tooltip');
+    const panel = tooltip.shadowRoot.querySelector('[part="panel"]');
+
+    await waitForStable(tooltip);
+    expectPanelVisibility(panel, true);
+
+    tooltip.remove();
+    parent.append(tooltip);
+    await waitForStable(tooltip);
+
+    expectPanelVisibility(panel, true);
   });
 
   it('should emit bqFocusIn and bqFocusOut events on focus/blur', async () => {
@@ -306,12 +467,12 @@ describe('bq-tooltip', () => {
 
     button.focus();
     await waitForChanges();
-    expect(panel).not.toHaveAttribute('hidden');
+    expectPanelVisibility(panel, true);
     expect(bqFocusIn).toHaveReceivedEventTimes(1);
 
     button.blur();
     await waitForChanges();
-    expect(panel).toHaveAttribute('hidden');
+    expectPanelVisibility(panel, false);
     expect(bqFocusOut).toHaveReceivedEventTimes(1);
   });
 
@@ -327,12 +488,12 @@ describe('bq-tooltip', () => {
 
     await userEvent.click(trigger);
     await waitForChanges();
-    expect(panel).not.toHaveAttribute('hidden');
+    expectPanelVisibility(panel, true);
 
     // Click outside the tooltip
     await userEvent.click(document.body);
     await waitForChanges();
-    expect(panel).toHaveAttribute('hidden');
+    expectPanelVisibility(panel, false);
   });
 
   it('should respect design style', async () => {

--- a/packages/beeq/src/components/tooltip/__tests__/bq-tooltip.e2e.tsx
+++ b/packages/beeq/src/components/tooltip/__tests__/bq-tooltip.e2e.tsx
@@ -28,6 +28,7 @@ const getArrowOffset = (arrow: HTMLElement) =>
 let unmountFn: (() => void) | undefined;
 
 afterEach(async () => {
+  window.scrollTo({ top: 0 });
   await moveOff();
   unmountFn?.();
   unmountFn = undefined;
@@ -423,6 +424,36 @@ describe('bq-tooltip', () => {
     await expect
       .poll(() => trigger.getBoundingClientRect().top - panel.getBoundingClientRect().bottom)
       .toBeCloseTo(initialOffset, 0);
+  });
+
+  it('should keep top placement inside nested overflow-hidden ancestors', async () => {
+    const { root, unmount } = await render(
+      <div style={{ minHeight: '1200px', paddingTop: '500px' }}>
+        <div style={{ height: '44px', overflow: 'hidden' }}>
+          <div style={{ height: '44px', overflow: 'hidden' }}>
+            <bq-tooltip always-visible distance={10} placement="top">
+              Yuhu! A tooltip!
+              <bq-button slot="trigger">Hover me!</bq-button>
+            </bq-tooltip>
+          </div>
+        </div>
+      </div>,
+    );
+    unmountFn = unmount;
+
+    const tooltip = root.querySelector('bq-tooltip');
+    const panel = tooltip.shadowRoot.querySelector<HTMLElement>('[part="panel"]');
+    const trigger = tooltip.shadowRoot.querySelector<HTMLElement>('[part="trigger"]');
+    const getTopOffset = () => trigger.getBoundingClientRect().top - panel.getBoundingClientRect().bottom;
+
+    await expect.poll(getTopOffset).toBeCloseTo(10, 0);
+    expect(panel.getBoundingClientRect().bottom).toBeLessThan(trigger.getBoundingClientRect().top);
+
+    window.scrollTo({ top: 200 });
+    window.dispatchEvent(new Event('scroll'));
+
+    await expect.poll(getTopOffset).toBeCloseTo(10, 0);
+    expect(panel.getBoundingClientRect().bottom).toBeLessThan(trigger.getBoundingClientRect().top);
   });
 
   it('should resume positioning after reconnection', async () => {

--- a/packages/beeq/src/components/tooltip/__tests__/bq-tooltip.e2e.tsx
+++ b/packages/beeq/src/components/tooltip/__tests__/bq-tooltip.e2e.tsx
@@ -19,12 +19,15 @@ const mkTooltip = () => (
 // userEvent.unhover() doesn't help — it targets document.body center, same coordinates.
 // Vitest exposes no API to move the cursor to arbitrary coords, so we use CDP directly.
 const moveOff = () => cdp().send('Input.dispatchMouseEvent', { type: 'mouseMoved', x: 0, y: 0 });
+
+const getArrowOffset = (arrow: HTMLElement) =>
+  [arrow.style.top, arrow.style.right, arrow.style.bottom, arrow.style.left].find((value) => value === '-4px');
+
 const expectPanelVisibility = (panel: Element, visible: boolean) => {
   expect(panel.getAttribute('aria-hidden')).toBe(String(!visible));
   expect(panel.matches(':popover-open')).toBe(visible);
 };
-const getArrowOffset = (arrow: HTMLElement) =>
-  [arrow.style.top, arrow.style.right, arrow.style.bottom, arrow.style.left].find((value) => value === '-4px');
+
 let unmountFn: (() => void) | undefined;
 
 afterEach(async () => {

--- a/packages/beeq/src/components/tooltip/__tests__/bq-tooltip.e2e.tsx
+++ b/packages/beeq/src/components/tooltip/__tests__/bq-tooltip.e2e.tsx
@@ -20,7 +20,7 @@ const mkTooltip = () => (
 // Vitest exposes no API to move the cursor to arbitrary coords, so we use CDP directly.
 const moveOff = () => cdp().send('Input.dispatchMouseEvent', { type: 'mouseMoved', x: 0, y: 0 });
 const expectPanelVisibility = (panel: Element, visible: boolean) => {
-  expect(panel).toHaveAttribute('aria-hidden', String(!visible));
+  expect(panel.getAttribute('aria-hidden')).toBe(String(!visible));
   expect(panel.matches(':popover-open')).toBe(visible);
 };
 const getArrowOffset = (arrow: HTMLElement) =>
@@ -258,7 +258,7 @@ describe('bq-tooltip', () => {
 
     const panel = root.querySelector('bq-tooltip').shadowRoot.querySelector('[part="panel"]');
     expectPanelVisibility(panel, true);
-    expect(panel).toHaveAttribute('popover', 'manual');
+    expect(panel.getAttribute('popover')).toBe('manual');
     expect(getComputedStyle(panel).position).toBe('absolute');
   });
 
@@ -285,7 +285,7 @@ describe('bq-tooltip', () => {
       await tooltip.show();
       await result.waitForChanges();
       expect(panel).not.toHaveAttribute('hidden');
-      expect(panel).toHaveAttribute('aria-hidden', 'false');
+      expect(panel.getAttribute('aria-hidden')).toBe('false');
     } finally {
       unmount?.();
       if (showPopover) Object.defineProperty(prototype, 'showPopover', showPopover);

--- a/packages/beeq/src/components/tooltip/bq-tooltip.tsx
+++ b/packages/beeq/src/components/tooltip/bq-tooltip.tsx
@@ -3,7 +3,7 @@ import { Component, Element, Event, h, Listen, Method, Prop, Watch } from '@sten
 
 import type { Placement } from '../../services/interfaces';
 import { FloatingUI } from '../../services/libraries';
-import { isEventTargetChildOfElement } from '../../shared/utils';
+import { isEventTargetChildOfElement, isPopoverSupported } from '../../shared/utils';
 
 /**
  * The Tooltip component is a small pop-up box that appears when a user hovers over or clicks on an element, providing additional information or context.
@@ -62,6 +62,16 @@ export class BqTooltip {
   private panel: HTMLElement;
   private arrow: HTMLElement;
   private floatingUI: FloatingUI;
+  /**
+   * Whether the runtime supports the HTML Popover API. When `true`, the
+   * panel is promoted to the browser top layer via `showPopover()`, which
+   * bypasses containing blocks created by ancestor `transform`, `filter`,
+   * `contain`, `will-change`, etc. When `false`, the panel remains a
+   * regular `position: fixed` element in the shadow root, which still
+   * covers the common case but is subject to those containing-block
+   * quirks.
+   */
+  private readonly supportsPopover = isPopoverSupported();
 
   // Reference to host HTML element
   // ===================================
@@ -121,7 +131,7 @@ export class BqTooltip {
       placement: this.placement,
       distance: this.distance,
       sameWidth: this.sameWidth,
-      strategy: 'fixed',
+      strategy: this.floatingStrategy,
       skidding: 0,
     });
   }
@@ -150,12 +160,23 @@ export class BqTooltip {
   // =====================================
 
   componentDidLoad() {
+    // Promote the panel to the top layer when the Popover API is available.
+    // This escapes containing blocks created by ancestor `transform`,
+    // `filter`, `contain`, `will-change`, etc., which is the root cause of
+    // scroll-related tooltip drift inside virtualised or transformed
+    // containers (e.g. tall tables, dialogs). We use `manual` mode so BEEQ
+    // keeps full control of show/hide semantics (delegated close, focus,
+    // Escape) instead of the browser's `auto` light-dismiss behaviour.
+    if (this.supportsPopover) {
+      this.panel.popover = 'manual';
+    }
+
     this.floatingUI = new FloatingUI(this.trigger, this.panel, {
       ...(!this.hideArrow && { arrow: this.arrow }),
       placement: this.placement,
       distance: this.distance,
       sameWidth: this.sameWidth,
-      strategy: 'fixed',
+      strategy: this.floatingStrategy,
       skidding: 0,
     });
   }
@@ -270,13 +291,31 @@ export class BqTooltip {
 
   private showTooltip = () => {
     if (!this.panel) return;
+    // Promote the panel into the top layer before repositioning so
+    // `getBoundingClientRect()` reads the correct box for Floating UI.
+    if (this.supportsPopover && !this.panel.matches(':popover-open')) {
+      this.panel.showPopover();
+    }
     this.floatingUI?.reposition();
   };
 
   private hideTooltip = () => {
     if (!this.panel) return;
+    if (this.supportsPopover && this.panel.matches(':popover-open')) {
+      this.panel.hidePopover();
+    }
     this.visible = false;
   };
+
+  private get floatingStrategy(): 'absolute' | 'fixed' {
+    // When the panel is in the top layer, its offset parent is the top-layer
+    // container (the initial containing block), so Floating UI must compute
+    // coordinates in `absolute` (offset-parent-relative) space and the
+    // shadow-DOM-aware `getOffsetParent` polyfill will resolve correctly.
+    // In the fallback path the panel is a regular `position: fixed` element
+    // and Floating UI must compute in viewport space.
+    return this.supportsPopover ? 'absolute' : 'fixed';
+  }
 
   private get isHidden() {
     return !this.visible && !this.alwaysVisible;
@@ -313,10 +352,18 @@ export class BqTooltip {
           <slot name="trigger" />
         </div>
         {/* PANEL */}
+        {/*
+         * When the Popover API is supported, visibility is driven imperatively
+         * via `showPopover()` / `hidePopover()`. Setting `hidden={true}` in that
+         * mode would force `display: none`, which makes `showPopover()` throw
+         * an `InvalidStateError`. In the fallback path we keep the `hidden`
+         * attribute so consumers without the Popover API keep the original
+         * visibility behaviour.
+         */}
         <div
           aria-hidden={this.isHidden}
           class="bq-tooltip--panel"
-          hidden={this.isHidden}
+          hidden={this.supportsPopover ? undefined : this.isHidden}
           part="panel"
           ref={(el: HTMLDivElement) => {
             this.panel = el;

--- a/packages/beeq/src/components/tooltip/bq-tooltip.tsx
+++ b/packages/beeq/src/components/tooltip/bq-tooltip.tsx
@@ -58,10 +58,25 @@ import { isEventTargetChildOfElement, isPopoverSupported } from '../../shared/ut
 export class BqTooltip {
   // Own Properties
   // ====================
+  private static nextId = 0;
+
   private trigger: HTMLElement;
   private panel: HTMLElement;
   private arrow: HTMLElement;
   private floatingUI: FloatingUI;
+  /**
+   * The slotted element currently acting as the tooltip trigger. Tracked so
+   * we can add/remove the tooltip's ID from its `aria-labelledby` list
+   * whenever the slot content changes, and clean it up on disconnect.
+   */
+  private assignedTrigger: HTMLElement | null = null;
+  /**
+   * Stable ID that assistive technologies use to associate the trigger with
+   * the tooltip content. When the consumer sets an `id` on `<bq-tooltip>`
+   * we honour it, otherwise we auto-generate one so `aria-labelledby`
+   * wiring always has a target.
+   */
+  private hostId!: string;
   /**
    * Whether the runtime supports the HTML Popover API. When `true`, the
    * panel is promoted to the browser top layer via `showPopover()`, which
@@ -159,6 +174,16 @@ export class BqTooltip {
   // Ordered by their natural call order
   // =====================================
 
+  componentWillLoad() {
+    // Ensure the host has an ID so slotted triggers can point to it via
+    // `aria-labelledby`. Consumers can override by setting `id` themselves.
+    if (!this.el.id) {
+      BqTooltip.nextId += 1;
+      this.el.id = `bq-tooltip-${BqTooltip.nextId}`;
+    }
+    this.hostId = this.el.id;
+  }
+
   componentDidLoad() {
     // Promote the panel to the top layer when the Popover API is available.
     // This escapes containing blocks created by ancestor `transform`,
@@ -179,10 +204,18 @@ export class BqTooltip {
       strategy: this.floatingStrategy,
       skidding: 0,
     });
+
+    // Wire ARIA on the currently slotted trigger element. Further changes
+    // are handled by the `slotchange` listener on the trigger slot.
+    this.syncTriggerAriaLabelledBy();
   }
 
   disconnectedCallback() {
     this.floatingUI?.stop();
+    if (this.assignedTrigger) {
+      this.removeFromAriaLabelledBy(this.assignedTrigger, this.hostId);
+      this.assignedTrigger = null;
+    }
   }
 
   // Listeners
@@ -321,6 +354,57 @@ export class BqTooltip {
     return !this.visible && !this.alwaysVisible;
   }
 
+  /**
+   * Re-reads the slotted trigger element and updates its `aria-labelledby`
+   * to include the tooltip's host ID. Called on initial load and whenever
+   * the `slotchange` event fires on the trigger slot.
+   */
+  private syncTriggerAriaLabelledBy = () => {
+    const slot = this.el.shadowRoot?.querySelector<HTMLSlotElement>('slot[name="trigger"]');
+    const next = (slot?.assignedElements({ flatten: true })[0] as HTMLElement | undefined) ?? null;
+    if (this.assignedTrigger === next) return;
+
+    if (this.assignedTrigger) {
+      this.removeFromAriaLabelledBy(this.assignedTrigger, this.hostId);
+    }
+    this.assignedTrigger = next;
+    if (this.assignedTrigger) {
+      this.addToAriaLabelledBy(this.assignedTrigger, this.hostId);
+    }
+  };
+
+  private handleTriggerSlotChange = () => {
+    this.syncTriggerAriaLabelledBy();
+  };
+
+  /**
+   * Adds `id` to the space-separated `aria-labelledby` token list on
+   * `element`, preserving any existing IDs and avoiding duplicates.
+   */
+  private addToAriaLabelledBy = (element: HTMLElement, id: string) => {
+    const current = element.getAttribute('aria-labelledby');
+    const tokens = current ? current.split(/\s+/).filter(Boolean) : [];
+    if (tokens.includes(id)) return;
+    tokens.push(id);
+    element.setAttribute('aria-labelledby', tokens.join(' '));
+  };
+
+  /**
+   * Removes `id` from the space-separated `aria-labelledby` token list on
+   * `element`. When no tokens remain the attribute is removed entirely so
+   * we do not leave an empty `aria-labelledby=""` behind.
+   */
+  private removeFromAriaLabelledBy = (element: HTMLElement, id: string) => {
+    const current = element.getAttribute('aria-labelledby');
+    if (!current) return;
+    const tokens = current.split(/\s+/).filter((token) => token && token !== id);
+    if (tokens.length === 0) {
+      element.removeAttribute('aria-labelledby');
+      return;
+    }
+    element.setAttribute('aria-labelledby', tokens.join(' '));
+  };
+
   // render() function
   // Always the last one in the class.
   // ===================================
@@ -349,7 +433,7 @@ export class BqTooltip {
             this.trigger = el;
           }}
         >
-          <slot name="trigger" />
+          <slot name="trigger" onSlotchange={this.handleTriggerSlotChange} />
         </div>
         {/* PANEL */}
         {/*

--- a/packages/beeq/src/components/tooltip/bq-tooltip.tsx
+++ b/packages/beeq/src/components/tooltip/bq-tooltip.tsx
@@ -208,6 +208,18 @@ export class BqTooltip {
     // Wire ARIA on the currently slotted trigger element. Further changes
     // are handled by the `slotchange` listener on the trigger slot.
     this.syncTriggerAriaLabelledBy();
+
+    // Honour the initial `visible` / `always-visible` props. Stencil's
+    // `@Watch('visible')` does not fire for the initial value, so components
+    // rendered with `visible` already true (or `always-visible`) would
+    // otherwise stay hidden — in the Popover path because `showPopover()`
+    // is only called from `show()`, and in the fallback path because the
+    // panel's `hidden` attribute reflects the state at first render but
+    // Floating UI would not have run a first positioning pass. Calling
+    // `showTooltip()` here guarantees a consistent first paint.
+    if (this.visible || this.alwaysVisible) {
+      this.showTooltip();
+    }
   }
 
   disconnectedCallback() {

--- a/packages/beeq/src/components/tooltip/bq-tooltip.tsx
+++ b/packages/beeq/src/components/tooltip/bq-tooltip.tsx
@@ -58,25 +58,10 @@ import { isEventTargetChildOfElement, isPopoverSupported } from '../../shared/ut
 export class BqTooltip {
   // Own Properties
   // ====================
-  private static nextId = 0;
-
   private trigger: HTMLElement;
   private panel: HTMLElement;
   private arrow: HTMLElement;
   private floatingUI: FloatingUI;
-  /**
-   * The slotted element currently acting as the tooltip trigger. Tracked so
-   * we can add/remove the tooltip's ID from its `aria-labelledby` list
-   * whenever the slot content changes, and clean it up on disconnect.
-   */
-  private assignedTrigger: HTMLElement | null = null;
-  /**
-   * Stable ID that assistive technologies use to associate the trigger with
-   * the tooltip content. When the consumer sets an `id` on `<bq-tooltip>`
-   * we honour it, otherwise we auto-generate one so `aria-labelledby`
-   * wiring always has a target.
-   */
-  private hostId!: string;
   /**
    * Whether the runtime supports the HTML Popover API. When `true`, the
    * panel is promoted to the browser top layer via `showPopover()`, which
@@ -174,16 +159,6 @@ export class BqTooltip {
   // Ordered by their natural call order
   // =====================================
 
-  componentWillLoad() {
-    // Ensure the host has an ID so slotted triggers can point to it via
-    // `aria-labelledby`. Consumers can override by setting `id` themselves.
-    if (!this.el.id) {
-      BqTooltip.nextId += 1;
-      this.el.id = `bq-tooltip-${BqTooltip.nextId}`;
-    }
-    this.hostId = this.el.id;
-  }
-
   componentDidLoad() {
     // Promote the panel to the top layer when the Popover API is available.
     // This escapes containing blocks created by ancestor `transform`,
@@ -205,10 +180,6 @@ export class BqTooltip {
       skidding: 0,
     });
 
-    // Wire ARIA on the currently slotted trigger element. Further changes
-    // are handled by the `slotchange` listener on the trigger slot.
-    this.syncTriggerAriaLabelledBy();
-
     // Honour the initial `visible` / `always-visible` props. Stencil's
     // `@Watch('visible')` does not fire for the initial value, so components
     // rendered with `visible` already true (or `always-visible`) would
@@ -224,10 +195,6 @@ export class BqTooltip {
 
   disconnectedCallback() {
     this.floatingUI?.stop();
-    if (this.assignedTrigger) {
-      this.removeFromAriaLabelledBy(this.assignedTrigger, this.hostId);
-      this.assignedTrigger = null;
-    }
   }
 
   // Listeners
@@ -366,57 +333,6 @@ export class BqTooltip {
     return !this.visible && !this.alwaysVisible;
   }
 
-  /**
-   * Re-reads the slotted trigger element and updates its `aria-labelledby`
-   * to include the tooltip's host ID. Called on initial load and whenever
-   * the `slotchange` event fires on the trigger slot.
-   */
-  private syncTriggerAriaLabelledBy = () => {
-    const slot = this.el.shadowRoot?.querySelector<HTMLSlotElement>('slot[name="trigger"]');
-    const next = (slot?.assignedElements({ flatten: true })[0] as HTMLElement | undefined) ?? null;
-    if (this.assignedTrigger === next) return;
-
-    if (this.assignedTrigger) {
-      this.removeFromAriaLabelledBy(this.assignedTrigger, this.hostId);
-    }
-    this.assignedTrigger = next;
-    if (this.assignedTrigger) {
-      this.addToAriaLabelledBy(this.assignedTrigger, this.hostId);
-    }
-  };
-
-  private handleTriggerSlotChange = () => {
-    this.syncTriggerAriaLabelledBy();
-  };
-
-  /**
-   * Adds `id` to the space-separated `aria-labelledby` token list on
-   * `element`, preserving any existing IDs and avoiding duplicates.
-   */
-  private addToAriaLabelledBy = (element: HTMLElement, id: string) => {
-    const current = element.getAttribute('aria-labelledby');
-    const tokens = current ? current.split(/\s+/).filter(Boolean) : [];
-    if (tokens.includes(id)) return;
-    tokens.push(id);
-    element.setAttribute('aria-labelledby', tokens.join(' '));
-  };
-
-  /**
-   * Removes `id` from the space-separated `aria-labelledby` token list on
-   * `element`. When no tokens remain the attribute is removed entirely so
-   * we do not leave an empty `aria-labelledby=""` behind.
-   */
-  private removeFromAriaLabelledBy = (element: HTMLElement, id: string) => {
-    const current = element.getAttribute('aria-labelledby');
-    if (!current) return;
-    const tokens = current.split(/\s+/).filter((token) => token && token !== id);
-    if (tokens.length === 0) {
-      element.removeAttribute('aria-labelledby');
-      return;
-    }
-    element.setAttribute('aria-labelledby', tokens.join(' '));
-  };
-
   // render() function
   // Always the last one in the class.
   // ===================================
@@ -445,7 +361,7 @@ export class BqTooltip {
             this.trigger = el;
           }}
         >
-          <slot name="trigger" onSlotchange={this.handleTriggerSlotChange} />
+          <slot name="trigger" />
         </div>
         {/* PANEL */}
         {/*

--- a/packages/beeq/src/components/tooltip/bq-tooltip.tsx
+++ b/packages/beeq/src/components/tooltip/bq-tooltip.tsx
@@ -116,7 +116,7 @@ export class BqTooltip {
   @Watch('placement')
   @Watch('sameWidth')
   handleFloatingUIOptionsChange() {
-    this.floatingUI.init({
+    this.floatingUI?.configure({
       ...(!this.hideArrow && { arrow: this.arrow }),
       placement: this.placement,
       distance: this.distance,
@@ -161,7 +161,7 @@ export class BqTooltip {
   }
 
   disconnectedCallback() {
-    this.floatingUI?.destroy();
+    this.floatingUI?.stop();
   }
 
   // Listeners
@@ -270,7 +270,7 @@ export class BqTooltip {
 
   private showTooltip = () => {
     if (!this.panel) return;
-    this.floatingUI?.update();
+    this.floatingUI?.reposition();
   };
 
   private hideTooltip = () => {

--- a/packages/beeq/src/components/tooltip/bq-tooltip.tsx
+++ b/packages/beeq/src/components/tooltip/bq-tooltip.tsx
@@ -385,7 +385,7 @@ export class BqTooltip {
          * visibility behaviour.
          */}
         <div
-           aria-hidden={String(this.isHidden)}
+          aria-hidden={String(this.isHidden)}
           class="bq-tooltip--panel"
           hidden={this.supportsPopover ? undefined : this.isHidden}
           part="panel"

--- a/packages/beeq/src/components/tooltip/bq-tooltip.tsx
+++ b/packages/beeq/src/components/tooltip/bq-tooltip.tsx
@@ -385,7 +385,7 @@ export class BqTooltip {
          * visibility behaviour.
          */}
         <div
-          aria-hidden={this.isHidden}
+           aria-hidden={String(this.isHidden)}
           class="bq-tooltip--panel"
           hidden={this.supportsPopover ? undefined : this.isHidden}
           part="panel"

--- a/packages/beeq/src/components/tooltip/bq-tooltip.tsx
+++ b/packages/beeq/src/components/tooltip/bq-tooltip.tsx
@@ -121,8 +121,16 @@ export class BqTooltip {
     await this.show();
   }
 
+  @Watch('alwaysVisible')
+  handleAlwaysVisibleChange() {
+    if (this.alwaysVisible || this.visible) {
+      this.showTooltip();
+      return;
+    }
+    this.hideTooltip();
+  }
+
   @Watch('distance')
-  @Watch('hideArrow')
   @Watch('placement')
   @Watch('sameWidth')
   handleFloatingUIOptionsChange() {
@@ -191,6 +199,17 @@ export class BqTooltip {
     if (this.visible || this.alwaysVisible) {
       this.showTooltip();
     }
+  }
+
+  componentDidRender() {
+    const arrow = this.hideArrow ? null : this.arrow;
+    if (!this.floatingUI || this.floatingUI.options.arrow === arrow) return;
+    this.floatingUI.configure({ arrow });
+  }
+
+  connectedCallback() {
+    if (!this.floatingUI || (!this.visible && !this.alwaysVisible)) return;
+    this.showTooltip();
   }
 
   disconnectedCallback() {
@@ -303,16 +322,15 @@ export class BqTooltip {
 
   private showTooltip = () => {
     if (!this.panel) return;
-    // Promote the panel into the top layer before repositioning so
-    // `getBoundingClientRect()` reads the correct box for Floating UI.
     if (this.supportsPopover && !this.panel.matches(':popover-open')) {
       this.panel.showPopover();
     }
-    this.floatingUI?.reposition();
+    this.floatingUI?.start();
   };
 
   private hideTooltip = () => {
     if (!this.panel) return;
+    this.floatingUI?.stop();
     if (this.supportsPopover && this.panel.matches(':popover-open')) {
       this.panel.hidePopover();
     }
@@ -320,12 +338,6 @@ export class BqTooltip {
   };
 
   private get floatingStrategy(): 'absolute' | 'fixed' {
-    // When the panel is in the top layer, its offset parent is the top-layer
-    // container (the initial containing block), so Floating UI must compute
-    // coordinates in `absolute` (offset-parent-relative) space and the
-    // shadow-DOM-aware `getOffsetParent` polyfill will resolve correctly.
-    // In the fallback path the panel is a regular `position: fixed` element
-    // and Floating UI must compute in viewport space.
     return this.supportsPopover ? 'absolute' : 'fixed';
   }
 

--- a/packages/beeq/src/components/tooltip/bq-tooltip.tsx
+++ b/packages/beeq/src/components/tooltip/bq-tooltip.tsx
@@ -117,10 +117,12 @@ export class BqTooltip {
   @Watch('sameWidth')
   handleFloatingUIOptionsChange() {
     this.floatingUI.init({
+      ...(!this.hideArrow && { arrow: this.arrow }),
       placement: this.placement,
       distance: this.distance,
       sameWidth: this.sameWidth,
       strategy: 'fixed',
+      skidding: 0,
     });
   }
 
@@ -153,7 +155,7 @@ export class BqTooltip {
       placement: this.placement,
       distance: this.distance,
       sameWidth: this.sameWidth,
-      strategy: 'absolute',
+      strategy: 'fixed',
       skidding: 0,
     });
   }

--- a/packages/beeq/src/components/tooltip/scss/bq-tooltip.scss
+++ b/packages/beeq/src/components/tooltip/scss/bq-tooltip.scss
@@ -11,11 +11,11 @@
   @apply text-[length:--bq-tooltip--font-size] leading-[--bq-tooltip--line-height] text-[color:--bq-tooltip--text-color];
   @apply rounded-[--bq-tooltip--border-radius] border-[length:--bq-tooltip--border-width] border-[color:--bq-tooltip--border-color];
   @apply shadow-[shadow:--bq-tooltip--box-shadow];
+
   border-style: var(--bq-tooltip--border-style);
 
   &[popover] {
-    @apply absolute m-0 overflow-visible;
-    inset: unset;
+    @apply absolute m-0 overflow-visible inset-[unset];
   }
 }
 

--- a/packages/beeq/src/components/tooltip/scss/bq-tooltip.scss
+++ b/packages/beeq/src/components/tooltip/scss/bq-tooltip.scss
@@ -11,6 +11,20 @@
   @apply text-[length:--bq-tooltip--font-size] leading-[--bq-tooltip--line-height] text-[color:--bq-tooltip--text-color];
   @apply rounded-[--bq-tooltip--border-radius] border-[length:--bq-tooltip--border-width] border-[color:--bq-tooltip--border-color];
   @apply shadow-[shadow:--bq-tooltip--box-shadow];
+
+  /* -------------------------------------------------------------------------- */
+  /*  Popover API overrides                                                     */
+  /* -------------------------------------------------------------------------- */
+  /*  The [popover] user-agent stylesheet applies `inset: 0`, `margin: auto`,   */
+  /*  and `overflow: auto` to center and clip the popover in the viewport.      */
+  /*  Floating UI positions the panel imperatively via `transform: translate`,  */
+  /*  so we neutralise those UA defaults to avoid double-positioning while      */
+  /*  keeping the browser's top-layer promotion behaviour intact.               */
+  &[popover] {
+    @apply m-0 p-b-[--bq-tooltip--paddingY] p-i-[--bq-tooltip--paddingX];
+    @apply overflow-visible;
+    inset: unset;
+  }
 }
 
 .bq-tooltip--arrow {

--- a/packages/beeq/src/components/tooltip/scss/bq-tooltip.scss
+++ b/packages/beeq/src/components/tooltip/scss/bq-tooltip.scss
@@ -11,23 +11,10 @@
   @apply text-[length:--bq-tooltip--font-size] leading-[--bq-tooltip--line-height] text-[color:--bq-tooltip--text-color];
   @apply rounded-[--bq-tooltip--border-radius] border-[length:--bq-tooltip--border-width] border-[color:--bq-tooltip--border-color];
   @apply shadow-[shadow:--bq-tooltip--box-shadow];
+  border-style: var(--bq-tooltip--border-style);
 
-  /* -------------------------------------------------------------------------- */
-  /*  Popover API overrides                                                     */
-  /* -------------------------------------------------------------------------- */
-  /*  The [popover] user-agent stylesheet applies `inset: 0`, `margin: auto`,   */
-  /*  `overflow: auto`, `border: solid`, `background-color: Canvas` and         */
-  /*  `color: CanvasText`. Floating UI positions the panel imperatively via     */
-  /*  `transform: translate`, so we neutralise those UA defaults to avoid       */
-  /*  double-positioning and, critically, we reset `border-style` — the base    */
-  /*  class only sets `border-color`/`border-width`, so an unset `border-style` */
-  /*  would fall back to the UA's `solid` value with the browser default        */
-  /*  `medium` width (~3px). That invisible border widens the panel and pulls   */
-  /*  the arrow's `bottom: -4px` anchor inside the border-box, hiding most of   */
-  /*  the arrow tip. Explicitly clearing the border restores the visual         */
-  /*  parity with the non-popover fallback path.                                */
   &[popover] {
-    @apply m-0 border-none overflow-visible;
+    @apply absolute m-0 overflow-visible;
     inset: unset;
   }
 }

--- a/packages/beeq/src/components/tooltip/scss/bq-tooltip.scss
+++ b/packages/beeq/src/components/tooltip/scss/bq-tooltip.scss
@@ -16,13 +16,18 @@
   /*  Popover API overrides                                                     */
   /* -------------------------------------------------------------------------- */
   /*  The [popover] user-agent stylesheet applies `inset: 0`, `margin: auto`,   */
-  /*  and `overflow: auto` to center and clip the popover in the viewport.      */
-  /*  Floating UI positions the panel imperatively via `transform: translate`,  */
-  /*  so we neutralise those UA defaults to avoid double-positioning while      */
-  /*  keeping the browser's top-layer promotion behaviour intact.               */
+  /*  `overflow: auto`, `border: solid`, `background-color: Canvas` and         */
+  /*  `color: CanvasText`. Floating UI positions the panel imperatively via     */
+  /*  `transform: translate`, so we neutralise those UA defaults to avoid       */
+  /*  double-positioning and, critically, we reset `border-style` — the base    */
+  /*  class only sets `border-color`/`border-width`, so an unset `border-style` */
+  /*  would fall back to the UA's `solid` value with the browser default        */
+  /*  `medium` width (~3px). That invisible border widens the panel and pulls   */
+  /*  the arrow's `bottom: -4px` anchor inside the border-box, hiding most of   */
+  /*  the arrow tip. Explicitly clearing the border restores the visual         */
+  /*  parity with the non-popover fallback path.                                */
   &[popover] {
-    @apply m-0 p-b-[--bq-tooltip--paddingY] p-i-[--bq-tooltip--paddingX];
-    @apply overflow-visible;
+    @apply m-0 border-none overflow-visible;
     inset: unset;
   }
 }

--- a/packages/beeq/src/services/interfaces/floating-ui.ts
+++ b/packages/beeq/src/services/interfaces/floating-ui.ts
@@ -3,7 +3,7 @@ import type { Placement, Strategy } from '@floating-ui/core';
 export interface FloatingUIOptions {
   distance?: number;
   placement?: Placement;
-  arrow?: HTMLElement;
+  arrow?: HTMLElement | null;
   strategy: Strategy;
   sameWidth?: boolean;
   skidding?: number;

--- a/packages/beeq/src/services/libraries/floating-ui/index.ts
+++ b/packages/beeq/src/services/libraries/floating-ui/index.ts
@@ -13,11 +13,30 @@ import {
 
 import type { FloatingUIOptions } from '../../interfaces';
 
+/**
+ * Thin wrapper around Floating UI that owns:
+ * - the middleware pipeline used by BEEQ floating components (offset, flip,
+ *   shift, size, arrow, hide),
+ * - a single `autoUpdate` subscription per instance, so scroll/resize
+ *   listeners cannot silently stack when consumers reconfigure at runtime.
+ *
+ * Lifecycle:
+ * - `start()`   opens (or reuses) the `autoUpdate` subscription and runs a
+ *                first `reposition()` pass.
+ * - `stop()`    tears the subscription down; idempotent.
+ * - `reposition()` computes the current position once; safe to call whether
+ *                or not the subscription is running.
+ * - `configure(options)` merges new options and re-runs `reposition()`,
+ *                without touching the subscription.
+ *
+ * The legacy `init` / `update` / `destroy` methods are preserved as
+ * aliases so existing consumers keep working while we migrate them.
+ */
 export class FloatingUI {
   panel: HTMLElement;
   trigger: ReferenceElement;
   options: FloatingUIOptions;
-  cleanUp: (() => void) | undefined;
+  private cleanUp: (() => void) | undefined;
 
   constructor(trigger: ReferenceElement, panel: HTMLElement, options?: FloatingUIOptions) {
     this.trigger = trigger;
@@ -29,51 +48,100 @@ export class FloatingUI {
       sameWidth: false,
       ...options,
     };
-    this.init(options);
+    this.start();
   }
 
-  init(options: FloatingUIOptions) {
+  /**
+   * Merges new options into the current configuration and repositions the
+   * panel once, without recreating the `autoUpdate` subscription. Use this
+   * when only Floating UI middleware inputs change (placement, distance,
+   * arrow, etc.).
+   */
+  configure(options: FloatingUIOptions) {
     this.options = Object.assign(this.options, options);
-    this.destroy();
-    this.update();
+    this.reposition();
   }
 
-  update() {
-    this.cleanUp = autoUpdate(this.trigger, this.panel, () => {
-      (async () => {
-        const { x, y, placement, middlewareData } = await computePosition(this.trigger, this.panel, {
-          placement: this.options.placement,
-          strategy: this.options.strategy,
-          middleware: [
-            offset({ mainAxis: this.options.distance, crossAxis: this.options.skidding }),
-            flip(),
-            shift(),
-            size(
-              this.options.sameWidth && {
-                apply({ rects, elements }) {
-                  Object.assign(elements.floating.style, {
-                    width: `${rects.reference.width}px`,
-                  });
-                },
-              },
-            ),
-            arrow({ element: this.options.arrow || null }),
-            this.positionChange(),
-            hide(),
-          ],
-        });
-
-        this.applyPanelPosition(x, y);
-        this.applyArrowPosition(placement, middlewareData);
-        this.applyVisibility(middlewareData);
-      })();
-    });
+  /**
+   * Opens the `autoUpdate` subscription so the panel keeps tracking the
+   * trigger through scroll, resize, layout and ancestor changes. No-op if
+   * the subscription is already running.
+   */
+  start() {
+    if (this.cleanUp) return;
+    this.cleanUp = autoUpdate(this.trigger, this.panel, () => this.reposition());
   }
 
-  destroy() {
+  /**
+   * Tears down the `autoUpdate` subscription. Idempotent — safe to call
+   * multiple times, and before the first `start()`.
+   */
+  stop() {
     if (!this.cleanUp) return;
     this.cleanUp();
     this.cleanUp = undefined;
+  }
+
+  /**
+   * Runs a single Floating UI `computePosition` pass and applies the
+   * resulting styles to the panel (and the arrow, if configured).
+   */
+  reposition() {
+    (async () => {
+      const { x, y, placement, middlewareData } = await computePosition(this.trigger, this.panel, {
+        placement: this.options.placement,
+        strategy: this.options.strategy,
+        middleware: [
+          offset({ mainAxis: this.options.distance, crossAxis: this.options.skidding }),
+          flip(),
+          shift(),
+          size(
+            this.options.sameWidth && {
+              apply({ rects, elements }) {
+                Object.assign(elements.floating.style, {
+                  width: `${rects.reference.width}px`,
+                });
+              },
+            },
+          ),
+          arrow({ element: this.options.arrow || null }),
+          this.positionChange(),
+          hide(),
+        ],
+      });
+
+      this.applyPanelPosition(x, y);
+      this.applyArrowPosition(placement, middlewareData);
+      this.applyVisibility(middlewareData);
+    })();
+  }
+
+  /**
+   * @deprecated Prefer `configure()` when only options change or `start()`
+   * to (re)open the subscription. Kept for backward compatibility: reruns
+   * the subscription with the merged options.
+   */
+  init(options: FloatingUIOptions) {
+    this.options = Object.assign(this.options, options);
+    this.stop();
+    this.start();
+  }
+
+  /**
+   * @deprecated Prefer `reposition()` for a one-off recompute or `start()`
+   * to open the subscription. Kept for backward compatibility: ensures the
+   * subscription is running and then repositions.
+   */
+  update() {
+    this.start();
+    this.reposition();
+  }
+
+  /**
+   * @deprecated Alias for `stop()`. Kept for backward compatibility.
+   */
+  destroy() {
+    this.stop();
   }
 
   positionChange() {

--- a/packages/beeq/src/services/libraries/floating-ui/index.ts
+++ b/packages/beeq/src/services/libraries/floating-ui/index.ts
@@ -113,7 +113,7 @@ export class FloatingUI {
       platform: {
         ...platform,
         // The default offsetParent lookup does not cross shadow roots.
-        getOffsetParent: (element: Element) => platform.getOffsetParent!(element, offsetParent),
+        getOffsetParent: (element: Element) => platform.getOffsetParent?.(element, offsetParent) ?? null,
       },
     });
 

--- a/packages/beeq/src/services/libraries/floating-ui/index.ts
+++ b/packages/beeq/src/services/libraries/floating-ui/index.ts
@@ -6,10 +6,12 @@ import {
   hide,
   type MiddlewareData,
   offset,
+  platform,
   type ReferenceElement,
   shift,
   size,
 } from '@floating-ui/dom';
+import { offsetParent } from 'composed-offset-position';
 
 import type { FloatingUIOptions } from '../../interfaces';
 
@@ -108,6 +110,19 @@ export class FloatingUI {
           this.positionChange(),
           hide(),
         ],
+        platform: {
+          ...platform,
+          // Floating UI's default `getOffsetParent` walks the ancestor tree
+          // with the current `offsetParent` spec, which does not cross shadow
+          // roots. `composed-offset-position` provides a ponyfill that walks
+          // the composed tree, giving correct results when the trigger and
+          // panel live in different shadow roots (or when either is a
+          // descendant of a shadow root).
+          //
+          // Floating UI only calls `getOffsetParent` for `strategy: 'absolute'`;
+          // it is a no-op for `strategy: 'fixed'`.
+          getOffsetParent: (element: Element) => platform.getOffsetParent!(element, offsetParent),
+        },
       });
 
       this.applyPanelPosition(x, y);

--- a/packages/beeq/src/services/libraries/floating-ui/index.ts
+++ b/packages/beeq/src/services/libraries/floating-ui/index.ts
@@ -14,23 +14,14 @@ import {
 import type { FloatingUIOptions } from '../../interfaces';
 
 /**
- * Thin wrapper around Floating UI that owns:
- * - the middleware pipeline used by BEEQ floating components (offset, flip,
- *   shift, size, arrow, hide),
- * - a single `autoUpdate` subscription per instance, so scroll/resize
- *   listeners cannot silently stack when consumers reconfigure at runtime.
+ * Thin wrapper around Floating UI that owns the shared middleware pipeline
+ * and ensures each instance has at most one `autoUpdate` subscription.
  *
  * Lifecycle:
- * - `start()`   opens (or reuses) the `autoUpdate` subscription and runs a
- *                first `reposition()` pass.
- * - `stop()`    tears the subscription down; idempotent.
- * - `reposition()` computes the current position once; safe to call whether
- *                or not the subscription is running.
- * - `configure(options)` merges new options and re-runs `reposition()`,
- *                without touching the subscription.
- *
- * The legacy `init` / `update` / `destroy` methods are preserved as
- * aliases so existing consumers keep working while we migrate them.
+ * - `start()` starts position tracking and performs an initial reposition.
+ * - `stop()` stops tracking and invalidates pending positioning results.
+ * - `reposition()` computes and applies the position once.
+ * - `configure(options)` updates options and repositions only when active.
  */
 export class FloatingUI {
   panel: HTMLElement;
@@ -115,37 +106,6 @@ export class FloatingUI {
     this.applyPanelPosition(x, y);
     this.applyArrowPosition(placement, middlewareData);
     this.applyVisibility(middlewareData);
-  }
-
-  /**
-   * @deprecated Prefer `configure()` when only options change or `start()`
-   * to (re)open the subscription. Kept for backward compatibility: reruns
-   * the subscription with the merged options.
-   */
-  init(options: FloatingUIOptions) {
-    this.options = Object.assign(this.options, options);
-    this.stop();
-    this.start();
-  }
-
-  /**
-   * @deprecated Prefer `reposition()` for a one-off recompute or `start()`
-   * to open the subscription. Kept for backward compatibility: ensures the
-   * subscription is running and then repositions.
-   */
-  update() {
-    if (!this.cleanUp) {
-      this.start();
-      return;
-    }
-    void this.reposition();
-  }
-
-  /**
-   * @deprecated Alias for `stop()`. Kept for backward compatibility.
-   */
-  destroy() {
-    this.stop();
   }
 
   positionChange() {

--- a/packages/beeq/src/services/libraries/floating-ui/index.ts
+++ b/packages/beeq/src/services/libraries/floating-ui/index.ts
@@ -6,12 +6,20 @@ import {
   hide,
   type MiddlewareData,
   offset,
+  type Placement,
   type ReferenceElement,
   shift,
   size,
 } from '@floating-ui/dom';
 
 import type { FloatingUIOptions } from '../../interfaces';
+
+const STATIC_SIDE_BY_PLACEMENT = {
+  top: 'bottom',
+  right: 'left',
+  bottom: 'top',
+  left: 'right',
+} as const;
 
 /**
  * Thin wrapper around Floating UI that owns the shared middleware pipeline
@@ -24,10 +32,10 @@ import type { FloatingUIOptions } from '../../interfaces';
  * - `configure(options)` updates options and repositions only when active.
  */
 export class FloatingUI {
-  panel: HTMLElement;
-  trigger: ReferenceElement;
-  options: FloatingUIOptions;
-  private cleanUp: (() => void) | undefined;
+  readonly panel: HTMLElement;
+  readonly trigger: ReferenceElement;
+  readonly options: FloatingUIOptions;
+  private cleanup: (() => void) | undefined;
   private repositionId = 0;
 
   constructor(trigger: ReferenceElement, panel: HTMLElement, options?: FloatingUIOptions) {
@@ -47,12 +55,15 @@ export class FloatingUI {
    * reposition without recreating their `autoUpdate` subscription; stopped
    * instances apply the options the next time they start.
    */
-  configure(options: Partial<FloatingUIOptions>) {
-    this.options = Object.assign(this.options, options);
+  configure(options: Partial<FloatingUIOptions>): void {
+    Object.assign(this.options, options);
+    this.repositionId += 1;
+
     if (options.sameWidth === false) {
       this.panel.style.width = '';
     }
-    if (!this.cleanUp) return;
+    if (!this.cleanup) return;
+
     void this.reposition();
   }
 
@@ -61,42 +72,53 @@ export class FloatingUI {
    * trigger through scroll, resize, layout and ancestor changes. No-op if
    * the subscription is already running.
    */
-  start() {
-    if (this.cleanUp) return;
-    this.cleanUp = autoUpdate(this.trigger, this.panel, () => void this.reposition());
+  start(): void {
+    if (this.cleanup) return;
+
+    this.cleanup = autoUpdate(this.trigger, this.panel, () => void this.reposition());
   }
 
   /**
    * Tears down the `autoUpdate` subscription. Idempotent — safe to call
    * multiple times, and before the first `start()`.
    */
-  stop() {
+  stop(): void {
     this.repositionId += 1;
-    if (!this.cleanUp) return;
-    this.cleanUp();
-    this.cleanUp = undefined;
+    if (!this.cleanup) return;
+
+    this.cleanup();
+    this.cleanup = undefined;
   }
 
   /**
    * Runs a single Floating UI `computePosition` pass and applies the
    * resulting styles to the panel (and the arrow, if configured).
    */
-  async reposition() {
+  async reposition(): Promise<void> {
     const repositionId = ++this.repositionId;
+    const {
+      arrow: arrowElement,
+      distance,
+      onPositionChange,
+      placement: configuredPlacement,
+      sameWidth,
+      skidding,
+      strategy,
+    } = this.options;
     const { x, y, placement, middlewareData } = await computePosition(this.trigger, this.panel, {
-      placement: this.options.placement,
-      strategy: this.options.strategy,
+      placement: configuredPlacement,
+      strategy,
       middleware: [
-        offset({ mainAxis: this.options.distance, crossAxis: this.options.skidding }),
+        offset({ mainAxis: distance, crossAxis: skidding }),
         flip(),
         shift(),
         size({
           apply: ({ rects, elements }) => {
-            elements.floating.style.width = this.options.sameWidth ? `${rects.reference.width}px` : '';
+            if (repositionId !== this.repositionId || !elements.floating.isConnected) return;
+            elements.floating.style.width = sameWidth ? `${rects.reference.width}px` : '';
           },
         }),
-        arrow({ element: this.options.arrow || null }),
-        this.positionChange(),
+        ...(arrowElement ? [arrow({ element: arrowElement })] : []),
         hide(),
       ],
     });
@@ -104,41 +126,36 @@ export class FloatingUI {
     if (repositionId !== this.repositionId || !this.panel.isConnected) return;
 
     this.applyPanelPosition(x, y);
-    this.applyArrowPosition(placement, middlewareData);
+    this.applyArrowPosition(arrowElement, placement, middlewareData);
     this.applyVisibility(middlewareData);
+
+    onPositionChange?.(placement);
   }
 
-  positionChange() {
-    return {
-      name: 'positionChange',
-      fn: ({ placement: position }) => {
-        if (typeof this.options.onPositionChange !== 'function') return {};
-        this.options.onPositionChange(position);
-        return {};
-      },
-    };
-  }
+  private applyPanelPosition(x: number, y: number): void {
+    const dpr = window.devicePixelRatio || 1;
+    const roundedX = Math.round(x * dpr) / dpr;
+    const roundedY = Math.round(y * dpr) / dpr;
 
-  private applyPanelPosition(x: number, y: number) {
     Object.assign(this.panel.style, {
       top: '0',
       left: '0',
-      transform: `translate(${this.roundByDPR(x)}px,${this.roundByDPR(y)}px)`,
+      transform: `translate(${roundedX}px, ${roundedY}px)`,
     });
   }
 
-  private applyArrowPosition(placement: string, middlewareData: MiddlewareData) {
-    if (!this.options.arrow) return;
+  private applyArrowPosition(
+    arrowElement: HTMLElement | null | undefined,
+    placement: Placement,
+    middlewareData: MiddlewareData,
+  ): void {
+    if (!arrowElement) return;
 
-    const { x: arrowX, y: arrowY } = middlewareData.arrow;
-    const staticSide = {
-      top: 'bottom',
-      right: 'left',
-      bottom: 'top',
-      left: 'right',
-    }[placement.split('-')[0]];
+    const { x: arrowX, y: arrowY } = middlewareData.arrow ?? {};
+    const basePlacement = placement.split('-')[0] as keyof typeof STATIC_SIDE_BY_PLACEMENT;
+    const staticSide = STATIC_SIDE_BY_PLACEMENT[basePlacement];
 
-    Object.assign(this.options.arrow.style, {
+    Object.assign(arrowElement.style, {
       left: arrowX != null ? `${arrowX}px` : '',
       top: arrowY != null ? `${arrowY}px` : '',
       right: '',
@@ -147,15 +164,8 @@ export class FloatingUI {
     });
   }
 
-  private applyVisibility(middlewareData: MiddlewareData) {
-    const { referenceHidden } = middlewareData.hide;
-    Object.assign(this.panel.style, {
-      visibility: referenceHidden ? 'hidden' : 'visible',
-    });
-  }
-
-  private roundByDPR(value: number) {
-    const dpr = window.devicePixelRatio || 1;
-    return Math.round(value * dpr) / dpr;
+  private applyVisibility(middlewareData: MiddlewareData): void {
+    const referenceHidden = middlewareData.hide?.referenceHidden;
+    this.panel.style.visibility = referenceHidden ? 'hidden' : 'visible';
   }
 }

--- a/packages/beeq/src/services/libraries/floating-ui/index.ts
+++ b/packages/beeq/src/services/libraries/floating-ui/index.ts
@@ -6,12 +6,10 @@ import {
   hide,
   type MiddlewareData,
   offset,
-  platform,
   type ReferenceElement,
   shift,
   size,
 } from '@floating-ui/dom';
-import { offsetParent } from 'composed-offset-position';
 
 import type { FloatingUIOptions } from '../../interfaces';
 
@@ -110,11 +108,6 @@ export class FloatingUI {
         this.positionChange(),
         hide(),
       ],
-      platform: {
-        ...platform,
-        // The default offsetParent lookup does not cross shadow roots.
-        getOffsetParent: (element: Element) => platform.getOffsetParent?.(element, offsetParent) ?? null,
-      },
     });
 
     if (repositionId !== this.repositionId || !this.panel.isConnected) return;

--- a/packages/beeq/src/services/libraries/floating-ui/index.ts
+++ b/packages/beeq/src/services/libraries/floating-ui/index.ts
@@ -39,6 +39,7 @@ export class FloatingUI {
   trigger: ReferenceElement;
   options: FloatingUIOptions;
   private cleanUp: (() => void) | undefined;
+  private repositionId = 0;
 
   constructor(trigger: ReferenceElement, panel: HTMLElement, options?: FloatingUIOptions) {
     this.trigger = trigger;
@@ -50,18 +51,20 @@ export class FloatingUI {
       sameWidth: false,
       ...options,
     };
-    this.start();
   }
 
   /**
-   * Merges new options into the current configuration and repositions the
-   * panel once, without recreating the `autoUpdate` subscription. Use this
-   * when only Floating UI middleware inputs change (placement, distance,
-   * arrow, etc.).
+   * Merges new options into the current configuration. Active instances
+   * reposition without recreating their `autoUpdate` subscription; stopped
+   * instances apply the options the next time they start.
    */
-  configure(options: FloatingUIOptions) {
+  configure(options: Partial<FloatingUIOptions>) {
     this.options = Object.assign(this.options, options);
-    this.reposition();
+    if (options.sameWidth === false) {
+      this.panel.style.width = '';
+    }
+    if (!this.cleanUp) return;
+    void this.reposition();
   }
 
   /**
@@ -71,7 +74,7 @@ export class FloatingUI {
    */
   start() {
     if (this.cleanUp) return;
-    this.cleanUp = autoUpdate(this.trigger, this.panel, () => this.reposition());
+    this.cleanUp = autoUpdate(this.trigger, this.panel, () => void this.reposition());
   }
 
   /**
@@ -79,6 +82,7 @@ export class FloatingUI {
    * multiple times, and before the first `start()`.
    */
   stop() {
+    this.repositionId += 1;
     if (!this.cleanUp) return;
     this.cleanUp();
     this.cleanUp = undefined;
@@ -88,47 +92,36 @@ export class FloatingUI {
    * Runs a single Floating UI `computePosition` pass and applies the
    * resulting styles to the panel (and the arrow, if configured).
    */
-  reposition() {
-    (async () => {
-      const { x, y, placement, middlewareData } = await computePosition(this.trigger, this.panel, {
-        placement: this.options.placement,
-        strategy: this.options.strategy,
-        middleware: [
-          offset({ mainAxis: this.options.distance, crossAxis: this.options.skidding }),
-          flip(),
-          shift(),
-          size(
-            this.options.sameWidth && {
-              apply({ rects, elements }) {
-                Object.assign(elements.floating.style, {
-                  width: `${rects.reference.width}px`,
-                });
-              },
-            },
-          ),
-          arrow({ element: this.options.arrow || null }),
-          this.positionChange(),
-          hide(),
-        ],
-        platform: {
-          ...platform,
-          // Floating UI's default `getOffsetParent` walks the ancestor tree
-          // with the current `offsetParent` spec, which does not cross shadow
-          // roots. `composed-offset-position` provides a ponyfill that walks
-          // the composed tree, giving correct results when the trigger and
-          // panel live in different shadow roots (or when either is a
-          // descendant of a shadow root).
-          //
-          // Floating UI only calls `getOffsetParent` for `strategy: 'absolute'`;
-          // it is a no-op for `strategy: 'fixed'`.
-          getOffsetParent: (element: Element) => platform.getOffsetParent!(element, offsetParent),
-        },
-      });
+  async reposition() {
+    const repositionId = ++this.repositionId;
+    const { x, y, placement, middlewareData } = await computePosition(this.trigger, this.panel, {
+      placement: this.options.placement,
+      strategy: this.options.strategy,
+      middleware: [
+        offset({ mainAxis: this.options.distance, crossAxis: this.options.skidding }),
+        flip(),
+        shift(),
+        size({
+          apply: ({ rects, elements }) => {
+            elements.floating.style.width = this.options.sameWidth ? `${rects.reference.width}px` : '';
+          },
+        }),
+        arrow({ element: this.options.arrow || null }),
+        this.positionChange(),
+        hide(),
+      ],
+      platform: {
+        ...platform,
+        // The default offsetParent lookup does not cross shadow roots.
+        getOffsetParent: (element: Element) => platform.getOffsetParent!(element, offsetParent),
+      },
+    });
 
-      this.applyPanelPosition(x, y);
-      this.applyArrowPosition(placement, middlewareData);
-      this.applyVisibility(middlewareData);
-    })();
+    if (repositionId !== this.repositionId || !this.panel.isConnected) return;
+
+    this.applyPanelPosition(x, y);
+    this.applyArrowPosition(placement, middlewareData);
+    this.applyVisibility(middlewareData);
   }
 
   /**
@@ -148,8 +141,11 @@ export class FloatingUI {
    * subscription is running and then repositions.
    */
   update() {
-    this.start();
-    this.reposition();
+    if (!this.cleanUp) {
+      this.start();
+      return;
+    }
+    void this.reposition();
   }
 
   /**

--- a/packages/beeq/src/services/libraries/floating-ui/index.ts
+++ b/packages/beeq/src/services/libraries/floating-ui/index.ts
@@ -17,7 +17,7 @@ export class FloatingUI {
   panel: HTMLElement;
   trigger: ReferenceElement;
   options: FloatingUIOptions;
-  cleanUp: () => void;
+  cleanUp: (() => void) | undefined;
 
   constructor(trigger: ReferenceElement, panel: HTMLElement, options?: FloatingUIOptions) {
     this.trigger = trigger;
@@ -34,6 +34,7 @@ export class FloatingUI {
 
   init(options: FloatingUIOptions) {
     this.options = Object.assign(this.options, options);
+    this.destroy();
     this.update();
   }
 
@@ -72,6 +73,7 @@ export class FloatingUI {
   destroy() {
     if (!this.cleanUp) return;
     this.cleanUp();
+    this.cleanUp = undefined;
   }
 
   positionChange() {

--- a/packages/beeq/src/shared/utils/index.ts
+++ b/packages/beeq/src/shared/utils/index.ts
@@ -12,6 +12,7 @@ export * from './isDefined';
 export * from './isEmpty';
 export * from './isHTMLElement';
 export * from './isNil';
+export * from './isPopoverSupported';
 export * from './isString';
 export * from './props';
 export * from './scrollLock';

--- a/packages/beeq/src/shared/utils/isPopoverSupported.ts
+++ b/packages/beeq/src/shared/utils/isPopoverSupported.ts
@@ -1,0 +1,21 @@
+/**
+ * Feature-detects the HTML Popover API (`[popover]`, `showPopover()`,
+ * `hidePopover()`).
+ *
+ * Elements promoted via `showPopover()` are painted in the browser's top
+ * layer, which sits above every stacking context and is not affected by
+ * containing blocks created by ancestor `transform`, `filter`, `contain`,
+ * `will-change`, `perspective`, `backdrop-filter`, `translate`, `rotate`
+ * or `scale`. This makes it the correct rendering path for floating UI
+ * (tooltips, popovers, menus) when the trigger lives inside a subtree
+ * that establishes such a containing block.
+ *
+ * The check is SSR-safe: it returns `false` when `HTMLElement` is not
+ * defined (e.g. Node.js server-side rendering).
+ *
+ * @returns {boolean} `true` when the current runtime supports the
+ * Popover API, otherwise `false`.
+ */
+export const isPopoverSupported = (): boolean => {
+  return typeof HTMLElement !== 'undefined' && 'popover' in HTMLElement.prototype;
+};

--- a/packages/beeq/src/shared/utils/isPopoverSupported.ts
+++ b/packages/beeq/src/shared/utils/isPopoverSupported.ts
@@ -1,21 +1,9 @@
-/**
- * Feature-detects the HTML Popover API (`[popover]`, `showPopover()`,
- * `hidePopover()`).
- *
- * Elements promoted via `showPopover()` are painted in the browser's top
- * layer, which sits above every stacking context and is not affected by
- * containing blocks created by ancestor `transform`, `filter`, `contain`,
- * `will-change`, `perspective`, `backdrop-filter`, `translate`, `rotate`
- * or `scale`. This makes it the correct rendering path for floating UI
- * (tooltips, popovers, menus) when the trigger lives inside a subtree
- * that establishes such a containing block.
- *
- * The check is SSR-safe: it returns `false` when `HTMLElement` is not
- * defined (e.g. Node.js server-side rendering).
- *
- * @returns {boolean} `true` when the current runtime supports the
- * Popover API, otherwise `false`.
- */
+/** Returns whether the current runtime provides the complete HTML Popover API. */
 export const isPopoverSupported = (): boolean => {
-  return typeof HTMLElement !== 'undefined' && 'popover' in HTMLElement.prototype;
+  return (
+    typeof HTMLElement !== 'undefined' &&
+    'popover' in HTMLElement.prototype &&
+    typeof HTMLElement.prototype.showPopover === 'function' &&
+    typeof HTMLElement.prototype.hidePopover === 'function'
+  );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,11 +306,11 @@ importers:
   packages/beeq:
     dependencies:
       '@floating-ui/core':
-        specifier: ^1.7.4
-        version: 1.7.5
+        specifier: ^1.8.0
+        version: 1.8.0
       '@floating-ui/dom':
-        specifier: ^1.7.5
-        version: 1.7.6
+        specifier: ^1.8.0
+        version: 1.8.0
       '@stencil/core':
         specifier: ^4.41.3
         version: 4.43.5
@@ -1954,14 +1954,14 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@floating-ui/core@1.7.5':
-    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
 
-  '@floating-ui/dom@1.7.6':
-    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
 
-  '@floating-ui/utils@0.2.11':
-    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
   '@gar/promise-retry@1.0.3':
     resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
@@ -12565,16 +12565,16 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@floating-ui/core@1.7.5':
+  '@floating-ui/core@1.8.0':
     dependencies:
-      '@floating-ui/utils': 0.2.11
+      '@floating-ui/utils': 0.2.12
 
-  '@floating-ui/dom@1.7.6':
+  '@floating-ui/dom@1.8.0':
     dependencies:
-      '@floating-ui/core': 1.7.5
-      '@floating-ui/utils': 0.2.11
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
 
-  '@floating-ui/utils@0.2.11': {}
+  '@floating-ui/utils@0.2.12': {}
 
   '@gar/promise-retry@1.0.3': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,6 +314,9 @@ importers:
       '@stencil/core':
         specifier: ^4.41.3
         version: 4.43.5
+      composed-offset-position:
+        specifier: 0.0.6
+        version: 0.0.6(@floating-ui/utils@0.2.11)
 
   packages/beeq-angular:
     dependencies:
@@ -5546,6 +5549,11 @@ packages:
 
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
+
+  composed-offset-position@0.0.6:
+    resolution: {integrity: sha512-Q7dLompI6lUwd7LWyIcP66r4WcS9u7AL2h8HaeipiRfCRPLMWqRx8fYsjb4OHi6UQFifO7XtNC2IlEJ1ozIFxw==}
+    peerDependencies:
+      '@floating-ui/utils': ^0.2.5
 
   compressible@2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
@@ -16647,6 +16655,10 @@ snapshots:
   common-path-prefix@3.0.0: {}
 
   commondir@1.0.1: {}
+
+  composed-offset-position@0.0.6(@floating-ui/utils@0.2.11):
+    dependencies:
+      '@floating-ui/utils': 0.2.11
 
   compressible@2.0.18:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,9 +314,6 @@ importers:
       '@stencil/core':
         specifier: ^4.41.3
         version: 4.43.5
-      composed-offset-position:
-        specifier: 0.0.6
-        version: 0.0.6(@floating-ui/utils@0.2.11)
 
   packages/beeq-angular:
     dependencies:
@@ -5549,11 +5546,6 @@ packages:
 
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
-
-  composed-offset-position@0.0.6:
-    resolution: {integrity: sha512-Q7dLompI6lUwd7LWyIcP66r4WcS9u7AL2h8HaeipiRfCRPLMWqRx8fYsjb4OHi6UQFifO7XtNC2IlEJ1ozIFxw==}
-    peerDependencies:
-      '@floating-ui/utils': ^0.2.5
 
   compressible@2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
@@ -16655,10 +16647,6 @@ snapshots:
   common-path-prefix@3.0.0: {}
 
   commondir@1.0.1: {}
-
-  composed-offset-position@0.0.6(@floating-ui/utils@0.2.11):
-    dependencies:
-      '@floating-ui/utils': 0.2.11
 
   compressible@2.0.18:
     dependencies:


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

Fixes `bq-tooltip` positioning drift when its trigger is rendered inside scrollable, transformed, contained, or `overflow: hidden` ancestors.

The tooltip panel now uses the native Popover API when available, promoting it to the browser top layer so Floating UI coordinates are not affected by ancestor containing blocks or clipping contexts. Browsers without Popover API support retain the existing fixed-position fallback.

### Changes

- Align the initial Floating UI strategy with the tooltip panel CSS.
- Promote supported tooltip panels to the browser top layer using `popover="manual"`.
- Refactor `FloatingUI` into explicit `start`, `stop`, `reposition`, and `configure` lifecycle methods.
- Run `autoUpdate` only while tooltips and panels are visible/open.
- Prevent duplicate subscriptions and stale asynchronous positioning results.
- Preserve correct positioning after component reconnection.
- Fix initial `visible` and `always-visible` behavior.
- Handle dynamic `always-visible`, `hide-arrow`, and `same-width` changes.
- Reset native Popover styles while preserving tooltip border customization.
- Serialize `aria-hidden` with valid `"true"`/`"false"` values.
- Preserve the existing fixed-position fallback for unsupported browsers.
- Update `@floating-ui/core` and `@floating-ui/dom` to 1.8.0.
- Rely on Floating UI’s native top-layer offset-parent and clipping handling without an additional positioning ponyfill.

### Shared component impact

`FloatingUI` is also used through:

- `bq-panel`
- `bq-dropdown`
- `bq-select`
- `bq-date-picker`

These components retain their existing rendering strategies. Their shared positioning lifecycle now starts only while open and stops when closed or disconnected.

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

The `bq-tooltip` panel could drift or appear detached from its trigger inside scrollable, transformed, contained, or `overflow: hidden` ancestors.

**Root cause:** Floating UI coordinates were affected by ancestor containing blocks/clipping contexts, compounded by an initial CSS strategy mismatch.

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

No public component API changes were introduced. Existing generated component documentation remains applicable.

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->

- Confirmed correct top placement and configured distance before and after shallow and deep viewport scrolling.
- Confirmed scrolling closes visible tooltips without leaving a stale panel.
- Rebuilt and tested with `@floating-ui/core` and `@floating-ui/dom` 1.8.0.
- 26 tooltip E2E tests passed.
- 139 panel, dropdown, select, and date-picker E2E tests passed.
- 165 affected E2E tests passed in total.
- Targeted TypeScript, Biome, and Stylelint checks passed.
