### PR TITLE
fix(Breadcrumb): synchronize custom separators

### DIFF
--- a/packages/beeq/src/components/breadcrumb/__tests__/bq-breadcrumb.e2e.tsx
+++ b/packages/beeq/src/components/breadcrumb/__tests__/bq-breadcrumb.e2e.tsx
@@ -4,6 +4,9 @@ import { userEvent } from 'vitest/browser';
 
 import { getTextContent } from '../../../shared/utils/slot';
 
+const generatedSeparators = (item: HTMLBqBreadcrumbItemElement) =>
+  Array.from(item.children).filter((element) => element.matches('[slot="separator"]'));
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -99,6 +102,108 @@ describe('bq-breadcrumb', () => {
     expect(separator).not.toBeNull();
     expect(firstItemSeparators).toHaveLength(1);
     expect(firstItemSeparators[0].tagName.toLowerCase()).toBe('bq-icon');
+  });
+
+  it('should synchronize delayed custom-element properties to every generated separator', async () => {
+    const { root } = await render(
+      <bq-breadcrumb>
+        <bq-icon slot="separator" />
+        <bq-breadcrumb-item>Home</bq-breadcrumb-item>
+        <bq-breadcrumb-item>Library</bq-breadcrumb-item>
+        <bq-breadcrumb-item>Current</bq-breadcrumb-item>
+      </bq-breadcrumb>,
+    );
+    const source = root.querySelector<HTMLBqIconElement>(':scope > bq-icon[slot="separator"]');
+
+    source.name = 'caret-right';
+    source.size = '16';
+    await waitForStable(root);
+
+    expect(source.name).toBe('caret-right');
+
+    const items = root.querySelectorAll('bq-breadcrumb-item');
+    const separators = [...generatedSeparators(items[0]), ...generatedSeparators(items[1])] as HTMLBqIconElement[];
+
+    expect(separators).toHaveLength(2);
+    for (const separator of separators) {
+      expect(separator.name).toBe('caret-right');
+      expect(separator.size).toBe('16');
+    }
+    await expect.poll(() => separators.every((separator) => separator.shadowRoot.querySelector('svg'))).toBe(true);
+  });
+
+  it('should refresh generated separators when the source is replaced', async () => {
+    const { root } = await render(
+      <bq-breadcrumb>
+        <bq-icon name="caret-right" size="12" slot="separator" />
+        <bq-breadcrumb-item>Home</bq-breadcrumb-item>
+        <bq-breadcrumb-item>Library</bq-breadcrumb-item>
+        <bq-breadcrumb-item>Current</bq-breadcrumb-item>
+      </bq-breadcrumb>,
+    );
+    const source = root.querySelector<HTMLBqIconElement>(':scope > bq-icon[slot="separator"]');
+    const items = root.querySelectorAll('bq-breadcrumb-item');
+
+    const replacement = document.createElement('span');
+    replacement.slot = 'separator';
+    replacement.textContent = '→';
+    source.replaceWith(replacement);
+    await waitForStable(root);
+
+    expect(generatedSeparators(items[0])[0]).toHaveTextContent('→');
+    expect(generatedSeparators(items[1])[0]).toHaveTextContent('→');
+  });
+
+  it('should reconcile generated separators and aria-current when items change', async () => {
+    const { root } = await render(
+      <bq-breadcrumb>
+        <bq-breadcrumb-item>Home</bq-breadcrumb-item>
+        <bq-breadcrumb-item>Current</bq-breadcrumb-item>
+      </bq-breadcrumb>,
+    );
+    const [home, current] = Array.from(root.querySelectorAll('bq-breadcrumb-item'));
+    const library = document.createElement('bq-breadcrumb-item');
+    library.textContent = 'Library';
+
+    root.insertBefore(library, current);
+    await waitForStable(root);
+
+    expect(generatedSeparators(home)).toHaveLength(1);
+    expect(generatedSeparators(library)).toHaveLength(1);
+    expect(generatedSeparators(current)).toHaveLength(0);
+    expect(current).toEqualAttribute('aria-current', 'page');
+
+    root.append(home);
+    await waitForStable(root);
+
+    expect(generatedSeparators(current)).toHaveLength(1);
+    expect(generatedSeparators(home)).toHaveLength(0);
+    expect(home).toEqualAttribute('aria-current', 'page');
+
+    current.remove();
+    await waitForStable(root);
+
+    expect(generatedSeparators(library)).toHaveLength(1);
+    expect(generatedSeparators(home)).toHaveLength(0);
+  });
+
+  it('should preserve consumer-provided item separators', async () => {
+    const { root } = await render(
+      <bq-breadcrumb>
+        <bq-icon name="caret-right" slot="separator" />
+        <bq-breadcrumb-item>
+          Home
+          <span slot="separator">•</span>
+        </bq-breadcrumb-item>
+        <bq-breadcrumb-item>Current</bq-breadcrumb-item>
+      </bq-breadcrumb>,
+    );
+    const [firstItem] = root.querySelectorAll('bq-breadcrumb-item');
+
+    await waitForStable(root);
+
+    expect(generatedSeparators(firstItem)).toHaveLength(1);
+    expect(generatedSeparators(firstItem)[0]).toHaveTextContent('•');
   });
 
   it('should set a default aria-label on the navigation element', async () => {

--- a/packages/beeq/src/components/breadcrumb/bq-breadcrumb.tsx
+++ b/packages/beeq/src/components/breadcrumb/bq-breadcrumb.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Host, h, Prop } from '@stencil/core';
+import { Component, Host, h, Listen, Prop } from '@stencil/core';
 
 /**
  * The Breadcrumb is used to wraps a series of breadcrumb items to indicate the current page's location within a navigational hierarchy.
@@ -32,14 +32,9 @@ import { Component, Element, Host, h, Prop } from '@stencil/core';
 export class BqBreadcrumb {
   // Own Properties
   // ====================
-
-  private navElem: HTMLElement;
-  private spanElem: HTMLElement;
-
-  // Reference to host HTML element
-  // ===================================
-
-  @Element() el!: HTMLBqBreadcrumbElement;
+  private breadcrumbSlotElem: HTMLSlotElement;
+  private readonly generatedSeparators = new WeakSet<Element>();
+  private separatorSlotElem: HTMLSlotElement;
 
   // State() variables
   // Inlined decorator, alphabetical order
@@ -63,11 +58,24 @@ export class BqBreadcrumb {
   // =====================================
 
   componentDidLoad() {
-    this.handleSlotChange();
+    this.reconcileBreadcrumbItems();
+  }
+
+  connectedCallback() {
+    if (!this.breadcrumbSlotElem || !this.separatorSlotElem) return;
+
+    this.reconcileBreadcrumbItems();
   }
 
   // Listeners
   // ==============
+
+  @Listen('svgLoaded')
+  handleSeparatorReady(event: CustomEvent<string>): void {
+    if (event.target !== this.separatorFromSlot) return;
+
+    this.reconcileBreadcrumbItems();
+  }
 
   // Public methods API
   // These methods are exposed on the host element.
@@ -82,39 +90,69 @@ export class BqBreadcrumb {
   // =======================================================
 
   private handleSlotChange = (): void => {
+    this.reconcileBreadcrumbItems();
+  };
+
+  /**
+   * Rebuilds BEEQ-generated separators after breadcrumb items or the separator
+   * source change. Consumer-provided item separators are preserved, while the
+   * last item remains separator-free and is marked as the current page.
+   */
+  private reconcileBreadcrumbItems = (): void => {
     const breadcrumbItems = this.breadcrumbItems;
-    const itemCount = breadcrumbItems.length;
-    const separatorElem = this.getSeparatorElem();
+    const lastItemIndex = breadcrumbItems.length - 1;
 
-    breadcrumbItems.forEach((item, index) => {
-      const isLastItem = index === itemCount - 1;
-      const separatorSlot = item.querySelector('[slot="separator"]');
+    for (const [index, item] of breadcrumbItems.entries()) {
+      const isLastItem = index === lastItemIndex;
+      let hasConsumerSeparator = false;
 
-      if (!separatorSlot && !isLastItem) {
-        item.append(separatorElem.cloneNode(true));
+      // Remove only separators created by a previous reconciliation pass.
+      // Any other slotted separator belongs to the consumer and must remain.
+      for (const separator of item.querySelectorAll<HTMLElement>(':scope > [slot="separator"]')) {
+        if (this.generatedSeparators.has(separator)) {
+          separator.remove();
+        } else {
+          hasConsumerSeparator = true;
+        }
       }
 
       item.setAttribute('aria-current', isLastItem ? 'page' : '');
-    });
+
+      // Last items have no separator; consumer separators replace the generated one.
+      if (isLastItem || hasConsumerSeparator) continue;
+
+      item.append(this.createSeparator());
+    }
   };
 
-  private getSeparatorElem = (): HTMLElement => {
-    const clone = this.separatorFromSlot.cloneNode(true) as HTMLElement;
-    clone.slot = 'separator';
+  private createSeparator = (): HTMLElement => {
+    const source = this.separatorFromSlot;
+    const separator = source.cloneNode(true) as HTMLElement;
 
-    return clone;
+    if (source.localName === 'bq-icon') {
+      const sourceIcon = source as HTMLBqIconElement;
+      Object.assign(separator as HTMLBqIconElement, {
+        color: sourceIcon.color,
+        label: sourceIcon.label,
+        name: sourceIcon.name,
+        size: sourceIcon.size,
+        src: sourceIcon.src,
+        weight: sourceIcon.weight,
+      });
+    }
+
+    separator.slot = 'separator';
+    this.generatedSeparators.add(separator);
+
+    return separator;
   };
 
-  private get separatorFromSlot() {
-    return this.spanElem
-      .querySelector<HTMLSlotElement>('slot[name="separator"]')
-      .assignedElements({ flatten: true })[0] as HTMLElement;
+  private get separatorFromSlot(): HTMLElement {
+    return this.separatorSlotElem.assignedElements({ flatten: true })[0] as HTMLElement;
   }
 
   private get breadcrumbItems(): HTMLBqBreadcrumbItemElement[] {
-    return this.navElem
-      .querySelector<HTMLSlotElement>('slot')
-      .assignedElements({ flatten: true }) as HTMLBqBreadcrumbItemElement[];
+    return this.breadcrumbSlotElem.assignedElements({ flatten: true }) as HTMLBqBreadcrumbItemElement[];
   }
 
   // render() function
@@ -124,25 +162,22 @@ export class BqBreadcrumb {
   render() {
     return (
       <Host>
-        <nav
-          aria-label={this.label}
-          class="flex items-center"
-          part="navigation"
-          ref={(elem) => {
-            this.navElem = elem;
-          }}
-        >
-          <slot onSlotchange={this.handleSlotChange}></slot>
+        <nav aria-label={this.label} class="flex items-center" part="navigation">
+          <slot
+            onSlotchange={this.handleSlotChange}
+            ref={(element) => {
+              this.breadcrumbSlotElem = element;
+            }}
+          />
         </nav>
-        <span
-          aria-hidden="true"
-          hidden
-          part="separator"
-          ref={(element) => {
-            this.spanElem = element;
-          }}
-        >
-          <slot name="separator">
+        <span aria-hidden="true" hidden part="separator">
+          <slot
+            name="separator"
+            onSlotchange={this.handleSlotChange}
+            ref={(element) => {
+              this.separatorSlotElem = element;
+            }}
+          >
             <span class="is-3 flex items-center justify-center">/</span>
           </slot>
         </span>

--- a/packages/beeq/src/components/breadcrumb/bq-breadcrumb.tsx
+++ b/packages/beeq/src/components/breadcrumb/bq-breadcrumb.tsx
@@ -108,7 +108,7 @@ export class BqBreadcrumb {
 
       // Remove only separators created by a previous reconciliation pass.
       // Any other slotted separator belongs to the consumer and must remain.
-      for (const separator of item.querySelectorAll<HTMLElement>(':scope > [slot="separator"]')) {
+      for (const separator of Array.from(item.querySelectorAll<HTMLElement>(':scope > [slot="separator"]'))) {
         if (this.generatedSeparators.has(separator)) {
           separator.remove();
         } else {
@@ -137,6 +137,7 @@ export class BqBreadcrumb {
         name: sourceIcon.name,
         size: sourceIcon.size,
         src: sourceIcon.src,
+        // !TO BE REMOVED: Delete this line when the `weight` property is removed from the `bq-icon` component.
         weight: sourceIcon.weight,
       });
     }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md -->

## Description
<!-- Please describe the behavior or changes that are being added by this PR. -->

Fixes custom `bq-breadcrumb` separators not rendering reliably when supplied through `@beeq/react`.

React may assign custom-element properties such as `name` and `size` after the breadcrumb initially processes its slots. Because `cloneNode()` copies attributes but not custom-element properties, generated `bq-icon` separators could lose their icon configuration.

This change:

- Copies the public `bq-icon` properties to generated separators.
- Reconciles separators when breadcrumb items or the separator slot change.
- Uses Stencil’s `@Listen` lifecycle to refresh separators after the source icon loads.
- Preserves consumer-provided per-item separators.
- Removes generated separators from the final breadcrumb item.
- Keeps `aria-current="page"` synchronized after item insertion, removal, or reordering.

## Related Issue
<!-- If this PR is related to an existing issue, please feel free to link it here. -->

N/A

## Documentation
<!-- If this PR includes changes to the documentation, please describe the changes here. -->

N/A — no public API changes.

## Screenshots (if applicable)
<!-- Please provide screenshots or images to demonstrate the changes visually. -->

## Checklist
<!-- Please take a look at the following checklist and make sure all of the items are addressed. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Endava/BEEQ/blob/main/CONTRIBUTING.md) document.
- [x] I have read the [CODE OF CONDUCT](https://github.com/Endava/BEEQ/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have reviewed my code.
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if applicable).
- [x] I have added unit tests and e2e tests (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes
<!-- Any additional information or context that reviewers should be aware of. -->

- BEEQ production build passes.
- All 14 breadcrumb E2E tests pass.
- Regression coverage includes delayed custom-element property assignment, separator replacement, item insertion/removal/reordering, and consumer-provided separators.